### PR TITLE
Autoload Openshift in provider.rb

### DIFF
--- a/lib/dpl/provider.rb
+++ b/lib/dpl/provider.rb
@@ -9,6 +9,7 @@ module DPL
     autoload :EngineYard, 'dpl/provider/engine_yard'
     autoload :DotCloud,   'dpl/provider/dot_cloud'
     autoload :Nodejitsu,  'dpl/provider/nodejitsu'
+    autoload :Openshift,  'dpl/provider/openshift'
 
     def self.new(context, options)
       return super if self < Provider


### PR DESCRIPTION
In my earlier pull request which added Openshift support, I had forgotten to add an `autoload` statement to `provider.rb` to load Openshift.
