### PR TITLE
Upgrade to latest RSpec

### DIFF
--- a/dpl.gemspec
+++ b/dpl.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.require_path          = 'lib'
   s.required_ruby_version = '>= 1.8.7'
 
-  s.add_development_dependency 'rspec', '~> 2.13.0'
+  s.add_development_dependency 'rspec'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'simplecov'
 end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -17,7 +17,7 @@ describe DPL::CLI do
 
   describe :run do
     example "triggers deploy" do
-      provider = stub('provider')
+      provider = double('provider')
       DPL::Provider.should_receive(:new).and_return(provider)
       provider.should_receive(:deploy)
 

--- a/spec/provider/heroku_spec.rb
+++ b/spec/provider/heroku_spec.rb
@@ -9,13 +9,13 @@ describe DPL::Provider::Heroku do
 
   describe :api do
     it 'accepts an api key' do
-      api = stub(:api)
+      api = double(:api)
       ::Heroku::API.should_receive(:new).with(:api_key => "foo").and_return(api)
       provider.api.should be == api
     end
 
     it 'accepts a user and a password' do
-      api = stub(:api)
+      api = double(:api)
       provider.options.update(:user => "foo", :password => "bar")
       ::Heroku::API.should_receive(:new).with(:user => "foo", :password => "bar").and_return(api)
       provider.api.should be == api
@@ -24,9 +24,9 @@ describe DPL::Provider::Heroku do
 
   context "with fake api" do
     let :api do
-      stub "api",
-        :get_user => stub("get_user", :body => { "email" => "foo@bar.com" }),
-        :get_app  => stub("get_app",  :body => { "name"  => "example", "git_url" => "GIT URL" })
+      double "api",
+        :get_user => double("get_user", :body => { "email" => "foo@bar.com" }),
+        :get_app  => double("get_app",  :body => { "name"  => "example", "git_url" => "GIT URL" })
     end
 
     before do
@@ -76,7 +76,7 @@ describe DPL::Provider::Heroku do
 
     describe :run do
       example do
-        data = stub("data", :body => { "rendezvous_url" => "rendezvous url" })
+        data = double("data", :body => { "rendezvous_url" => "rendezvous url" })
         api.should_receive(:post_ps).with("example", "that command", :attach => true).and_return(data)
         Rendezvous.should_receive(:start).with(:url => "rendezvous url")
         provider.run("that command")

--- a/spec/provider/openshift_spec.rb
+++ b/spec/provider/openshift_spec.rb
@@ -9,7 +9,7 @@ describe DPL::Provider::Openshift do
 
   describe :api do
     it 'accepts a user and a password' do
-      api = stub(:api)
+      api = double(:api)
       provider.options.update(:user => "foo", :password => "bar")
       ::RHC::Rest::Client.should_receive(:new).with(:user => "foo", :password => "bar", :server => "openshift.redhat.com").and_return(api)
       provider.api.should be == api
@@ -18,14 +18,14 @@ describe DPL::Provider::Openshift do
 
   context "with api" do
     let :api do
-      stub "api",
-        :user => stub(:login => "foo@bar.com"),
-        :find_application => stub(:name => "example", :git_url => "git://something"),
-        :add_key => stub
+      double "api",
+        :user => double(:login => "foo@bar.com"),
+        :find_application => double(:name => "example", :git_url => "git://something"),
+        :add_key => double
     end
     let :app do
-      stub "app",
-        :restart => stub
+      double "app",
+        :restart => double
     end
 
     before do

--- a/spec/provider_spec.rb
+++ b/spec/provider_spec.rb
@@ -5,8 +5,7 @@ describe DPL::Provider do
   let(:example_provider) { Class.new(described_class)}
   subject(:provider) { example_provider.new(DummyContext.new, :app => 'example', :key_name => 'foo', :run => ["foo", "bar"]) }
 
-  before { described_class.const_set(:Example, example_provider) }
-  after { described_class.send(:remove_const, :Example) }
+  before { stub_const "DPL::Provider::Example", example_provider }
 
   describe :new do
     example { described_class.new(DummyContext.new, :provider => "example") .should be_an(example_provider) }
@@ -64,7 +63,7 @@ describe DPL::Provider do
     end
 
     example "does not need key" do
-      provider.stub(:needs_key?, false)
+      provider.stub(:needs_key? => false)
       provider.deploy
     end
   end


### PR DESCRIPTION
Hi I noticed that you had some issues with the latest RSpec, this PR fixes the only spec that was broken for me on the latest version of rspec, so removes the explicit dependency and also removes some deprecation warning(s).

From what I can see the spec would pass coincidentally on RSpec 2.13, as the return value of the stubbed method would have been `nil`, not `false` as intended.

Of course if you had another issue I'd be happy to help investigate what it is :)
