### PR TITLE
Fix travis-lint warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ rvm:
   - 1.9.2
   - 1.9.3
   - 2.0.0
-  - jruby
-  - rbx
+  - jruby-18mode
+  - rbx-18mode


### PR DESCRIPTION
I've fixed a couple warning that `travis-lint` generated for `.travis.yml`.
