### PR TITLE
Adds option to skip the cleanup

### DIFF
--- a/lib/dpl/provider.rb
+++ b/lib/dpl/provider.rb
@@ -99,6 +99,7 @@ module DPL
     end
 
     def cleanup
+      return if options[:skip_cleanup]
       context.shell "git reset --hard #{sha}"
       context.shell "git clean -dffqx -e .dpl"
     end

--- a/spec/provider_spec.rb
+++ b/spec/provider_spec.rb
@@ -68,6 +68,21 @@ describe DPL::Provider do
     end
   end
 
+  describe :cleanup do
+    example do
+      provider.should_receive(:sha).and_return("sha")
+      provider.context.should_receive(:shell).with('git reset --hard sha')
+      provider.context.should_receive(:shell).with('git clean -dffqx -e .dpl')
+      provider.cleanup
+    end
+
+    example "skip cleanup" do
+      provider.options.should_receive(:[]).with(:skip_cleanup).and_return("true")
+      provider.context.should_not_receive(:shell)
+      provider.cleanup
+    end
+  end
+
   describe :create_key do
     example do
       provider.context.should_receive(:shell).with('ssh-keygen -t rsa -N "" -C foo -f thekey')


### PR DESCRIPTION
We are generating the assets for our Rails app on Travis and committing them into git before deploying to Heroku.

Is there anything else, I can help you with to bring this option into travis.yml?
