### PR TITLE
Cloud Foundry provider

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,10 @@
 source 'https://rubygems.org'
 gemspec
 
+group :cloudfoundry do
+  gem 'cf'
+end
+
 group :heroku do
   gem 'rendezvous'
   gem 'heroku-api'

--- a/README.md
+++ b/README.md
@@ -13,4 +13,5 @@ Supported providers:
 * cloudControl
 * RubyGems
 * Engine Yard
+* Cloud Foundry
 * dotCloud (experimental)

--- a/lib/dpl/provider.rb
+++ b/lib/dpl/provider.rb
@@ -12,6 +12,7 @@ module DPL
     autoload :Openshift,    'dpl/provider/openshift'
     autoload :RubyGems,     'dpl/provider/rubygems'
     autoload :CloudControl, 'dpl/provider/cloudcontrol'
+    autoload :CloudFoundry, 'dpl/provider/cloud_foundry'
 
     def self.new(context, options)
       return super if self < Provider

--- a/lib/dpl/provider/cloud_foundry.rb
+++ b/lib/dpl/provider/cloud_foundry.rb
@@ -1,0 +1,29 @@
+module DPL
+  class Provider
+    class CloudFoundry < Provider
+      requires 'cf'
+
+      def check_auth
+        context.shell "cf target #{option(:target)}"
+        context.shell "cf login --username #{option(:username)} --password #{option(:password)} --organization #{option(:organization)} --space #{option(:space)}"
+      end
+
+      def check_app
+        fail 'Application must have a manifest.yml for unattended deployment' unless File.exists? 'manifest.yml'
+      end
+
+      def needs_key?
+        false
+      end
+
+      def push_app
+        context.shell "cf push"
+        context.shell "cf logout"
+      end
+
+      def cleanup
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
This change adds a [Cloud Foundry](http://www.cloudfoundry.com) provider to the `dpl` utility.  The implementation of this provider delegates to the [`cf`](http://docs.cloudfoundry.com/docs/using/managing-apps/cf/) command line utility because the internal implementation of the gem does not lend itself to being called programmatically.

The provides requires five options to be set:
1. `target`: The API endpoint of the Cloud Foundry instance
2. `username`: The username to authenticate with
3. `password`: The password to authenticate with
4. `organization`: The Cloud Foundry organization to log into
5. `space`: The Cloud Foundry space to log into

Given this information, the provider targets the specified API endpoint and logs into the appropriate organization and space.  It then pushes the application to Cloud Foundry.  Once complete the provider logs out of Cloud Foundry, removing the authentication credentials used earlier.
