### PR TITLE
Remove ruby Cloud Foundry dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,6 @@
 source 'https://rubygems.org'
 gemspec
 
-group :cloudfoundry do
-  gem 'cf'
-  gem 'activesupport', '~> 3.2'
-end
-
 group :heroku do
   gem 'rendezvous'
   gem 'heroku-api'

--- a/lib/dpl/provider/cloud_foundry.rb
+++ b/lib/dpl/provider/cloud_foundry.rb
@@ -1,10 +1,9 @@
 module DPL
   class Provider
     class CloudFoundry < Provider
-      requires 'activesupport', :version => '~> 3.2', :load => 'active_support'
-      requires 'cf'
 
       def check_auth
+        context.shell "gem install cf"
         context.shell "cf target #{option(:target)}"
         context.shell "cf login --username #{option(:username)} --password #{option(:password)} --organization #{option(:organization)} --space #{option(:space)}"
       end


### PR DESCRIPTION
This change removes the ruby-level dependency on the `cf` gem.  This was done because there's a conflict between the versions of `activesupport` used by `cf` and by `dpl`.  Instead, the dependency is handled by running gem install as a shell command which separates the dependencies by separating the runtimes.

An alternative fix to #29.
