### PR TITLE
Added support for Jruby and Rubinius again

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: ruby
 rvm:
 - 1.9.3
 - 2.0.0
+- jruby-19mode
+- rbx-19mode
 deploy:
   provider: rubygems
   api_key:


### PR DESCRIPTION
Recently, support for versions of Ruby before 1.9.3 was dropped. I've re-added the 19mode versions of Jruby and Rubinius, as they support 1.9.3.
