### PR TITLE
Fixed specifying Nodejitsu config file

### DIFF
--- a/lib/dpl/provider/nodejitsu.rb
+++ b/lib/dpl/provider/nodejitsu.rb
@@ -32,7 +32,7 @@ module DPL
       end
 
       def push_app
-        context.shell "jitsu deploy -j #{CONFIG_FILE} --release=yes"
+        context.shell "jitsu deploy --localconf #{CONFIG_FILE} --release=yes"
       end
     end
   end


### PR DESCRIPTION
This commit correctly passes the Nodejitsu config file with the `--localconf` option. Before, the `jitsu` client wasn't properly using the config file, resulting in a prompt to login, even with a username and api key specified.
