### PR TITLE
Change nodejitsu config command line flag

### DIFF
--- a/lib/dpl/provider/nodejitsu.rb
+++ b/lib/dpl/provider/nodejitsu.rb
@@ -32,7 +32,7 @@ module DPL
       end
 
       def push_app
-        context.shell "jitsu deploy --jitsuconf #{CONFIG_FILE} --release=yes"
+        context.shell "jitsu deploy --jitsuconf #{File.expand_path(CONFIG_FILE)} --release=yes"
       end
     end
   end


### PR DESCRIPTION
According to `jitsu --help`:

```
help:      --localconf      search for .jitsuconf file in ./ and then parent directories
help:      --jitsuconf, -j  specify file to load configuration from
```
