### PR TITLE
Added upload directory option to s3

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,10 +155,12 @@ As a rule of thumb, you should switch to the Git strategy if you run into issues
 * **access-key-id**: AWS Access Key ID. Can be obtained from [here](https://console.aws.amazon.com/iam/home?#security_credential).
 * **secret-access-key**: AWS Secret Key. Can be obtained from [here](https://console.aws.amazon.com/iam/home?#security_credential).
 * **bucket**: S3 Bucket.
+* **upload-dir**: S3 directory to upload to. Defaults to root directory.
 
 #### Examples:
 
     dpl --provider=s3 --access-key-id=<access-key-id> --secret-access-key=<secret-access-key> --bucket=<bucket>
+    dpl --provider=s3 --access-key-id=<access-key-id> --secret-access-key=<secret-access-key> --bucket=<bucket> --upload-dir=BUILDS
 
 ### Appfog:
 

--- a/lib/dpl/provider/s3.rb
+++ b/lib/dpl/provider/s3.rb
@@ -24,9 +24,13 @@ module DPL
         log "Logging in with Access Key: #{option(:access_key_id)[-4..-1].rjust(20, '*')}"
       end
 
+      def upload_path(filename)
+        [options[:upload_dir], filename].compact.join("/")
+      end
+
       def push_app
-        Dir.glob("**/*") do |fileName|
-          api.buckets[option(:bucket)].objects.create(fileName, File.read(fileName)) unless File.directory?(fileName)
+        Dir.glob("**/*") do |filename|
+          api.buckets[option(:bucket)].objects.create(upload_path(filename), File.read(filename)) unless File.directory?(filename)
         end
       end
 

--- a/spec/provider/s3_spec.rb
+++ b/spec/provider/s3_spec.rb
@@ -20,6 +20,21 @@ describe DPL::Provider::S3 do
     end
   end
 
+  describe :upload_path do
+    example "Without :upload_dir"do
+      filename = "testfile.file"
+
+      provider.upload_path(filename).should == "testfile.file"
+    end
+
+    example "With :upload_dir" do
+      provider.options.update(:upload_dir => 'BUILD3')
+      filename = "testfile.file"
+
+      provider.upload_path(filename).should == "BUILD3/testfile.file"
+    end
+  end
+
   describe :setup_auth do
     example do
       AWS.should_receive(:config).with(:access_key_id => 'qwertyuiopasdfghjklz', :secret_access_key => 'qwertyuiopasdfghjklzqwertyuiopasdfghjklz').once.and_call_original


### PR DESCRIPTION
Hello!

I was just adding another feature to s3 uploading. Currently, s3 uploading uploads to the root directory to s3 and overwrites any files with the same name. This allows people to upload to a specific directory. I'm intending this to mostly be used with the TRAVIS_BUILD_NUMBER environmental variable or something like that.

This allows people to a upload to a specific folder in s3. Defaults to root directory.
