### PR TITLE
Support for migrations and deploy tested sha

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,12 +170,12 @@ As a rule of thumb, you should switch to the Git strategy if you run into issues
 
 * **access-key-id**: AWS Access Key ID. Can be obtained from [here](https://console.aws.amazon.com/iam/home?#security_credential).
 * **secret-access-key**: AWS Secret Key. Can be obtained from [here](https://console.aws.amazon.com/iam/home?#security_credential).
-* **stack-id**: The stack ID.
 * **app-id**: The app ID.
+* **migrate**: Migrate the database. (Default: false)
 
 #### Examples:
 
-    dpl --provider=opsworks --access-key-id=<access-key-id> --secret-access-key=<secret-access-key> --stack-id=<stack-id> --app-id=<app-id>
+    dpl --provider=opsworks --access-key-id=<access-key-id> --secret-access-key=<secret-access-key> --app-id=<app-id> --migrate
 
 
 ### Appfog:


### PR DESCRIPTION
This adds support for running migrations and deploying the currently tested sha (before the latest commit from the branch was deployed). I removed the stack-id from the configuration as the app-id unique in AWS and the shortname of the app has to be fetched to deploy the correct commit.

@rkh I'm not really sure how an example project should look like. I use the edge feature already here: https://magnum.travis-ci.com/sixdoorsHQ/bridge-shopify, but OpsWorks is a paid AWS service (I'm only a customer loving continuous deployment:smile:) and requires some travis unrelated setup before the deployment.

Here is an example .travis.yml

``` yaml
language: ruby
bundler_args: --without development
deploy:
  edge: true
  provider: opsworks
  migrate: true
  app_id: <app-id>
  access_key_id:
    secure: XYZ
  secret_access_key:
    secure: XYZ
```
