### PR TITLE
Added region option to S3. Fixes #90

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,13 +171,14 @@ As a rule of thumb, you should switch to the Git strategy if you run into issues
 * **access-key-id**: AWS Access Key ID. Can be obtained from [here](https://console.aws.amazon.com/iam/home?#security_credential).
 * **secret-access-key**: AWS Secret Key. Can be obtained from [here](https://console.aws.amazon.com/iam/home?#security_credential).
 * **bucket**: S3 Bucket.
+* **region**: S3 Region. Defaults to us-east-1.
 * **upload-dir**: S3 directory to upload to. Defaults to root directory.
 * **local-dir**: Local directory to upload from. Can be set from a global perspective (~/travis/build) or relative perspective (build) Defaults to project root.
 
 #### Examples:
 
     dpl --provider=s3 --access-key-id=<access-key-id> --secret-access-key=<secret-access-key> --bucket=<bucket>
-    dpl --provider=s3 --access-key-id=<access-key-id> --secret-access-key=<secret-access-key> --bucket=<bucket> --local-dir= BUILD --upload-dir=BUILDS
+    dpl --provider=s3 --access-key-id=<access-key-id> --secret-access-key=<secret-access-key> --bucket=<bucket> --region:us-west-2 --local-dir= BUILD --upload-dir=BUILDS 
 
 ### OpsWorks:
 

--- a/lib/dpl/provider/s3.rb
+++ b/lib/dpl/provider/s3.rb
@@ -19,7 +19,7 @@ module DPL
       end
 
       def setup_auth
-        AWS.config(:access_key_id => option(:access_key_id), :secret_access_key => option(:secret_access_key))
+        AWS.config(:access_key_id => option(:access_key_id), :secret_access_key => option(:secret_access_key), :region => options[:region]||'us-east-1')
       end
 
       def check_auth

--- a/spec/provider/s3_spec.rb
+++ b/spec/provider/s3_spec.rb
@@ -36,8 +36,14 @@ describe DPL::Provider::S3 do
   end
 
   describe :setup_auth do
-    example do
-      AWS.should_receive(:config).with(:access_key_id => 'qwertyuiopasdfghjklz', :secret_access_key => 'qwertyuiopasdfghjklzqwertyuiopasdfghjklz').once.and_call_original
+    example "Without :region" do
+      AWS.should_receive(:config).with(:access_key_id => 'qwertyuiopasdfghjklz', :secret_access_key => 'qwertyuiopasdfghjklzqwertyuiopasdfghjklz', :region => 'us-east-1').once.and_call_original
+      provider.setup_auth
+    end
+    example "With :region" do
+      provider.options.update(:region => 'us-west-2')
+
+      AWS.should_receive(:config).with(:access_key_id => 'qwertyuiopasdfghjklz', :secret_access_key => 'qwertyuiopasdfghjklzqwertyuiopasdfghjklz', :region => 'us-west-2').once
       provider.setup_auth
     end
   end


### PR DESCRIPTION
Please don't merge this until we sort out the bundler funkiness, as this needs some prerelease testing to make sure this works as expected. According to [this](http://ruby.awsblog.com/post/TxVOTODBPHAEP9/Working-with-Regions) blogpost by amazon `us-east-1` is the default region for the ruby sdk. However, I have been able to push to buckets in different regions before and want to confirm that this doesn't break anything.
