### PR TITLE
Adding support for custom S3 Object options

### DIFF
--- a/lib/dpl/cli.rb
+++ b/lib/dpl/cli.rb
@@ -1,4 +1,5 @@
 require 'json'
+require 'uri'
 require 'dpl/error'
 require 'dpl/provider'
 
@@ -23,9 +24,9 @@ module DPL
           options[key] = match[2] || true
         end
 
-        if "#{options[key]}" =~ /^{.*}$/
+        if "#{options[key]}" =~ /^({|%7B).*(}|%7D)$/
           begin
-            options[key] = JSON.parse(options[key], symbolize_names: true)
+            options[key] = JSON.parse(URI.unescape(options[key]), symbolize_names: true)
           rescue
             $stderr.puts "Failed to load JSON-y value #{options[key].inspect}"
           end

--- a/lib/dpl/cli.rb
+++ b/lib/dpl/cli.rb
@@ -1,5 +1,3 @@
-require 'json'
-require 'uri'
 require 'dpl/error'
 require 'dpl/provider'
 
@@ -26,6 +24,8 @@ module DPL
 
         if "#{options[key]}" =~ /^({|%7B).*(}|%7D)$/
           begin
+            require 'json'
+            require 'uri'
             options[key] = JSON.parse(URI.unescape(options[key]), symbolize_names: true)
           rescue
             $stderr.puts "Failed to load JSON-y value #{options[key].inspect}"

--- a/lib/dpl/cli.rb
+++ b/lib/dpl/cli.rb
@@ -1,3 +1,4 @@
+require 'json'
 require 'dpl/error'
 require 'dpl/provider'
 
@@ -20,6 +21,14 @@ module DPL
           options[key] = Array(options[key]) << match[2]
         else
           options[key] = match[2] || true
+        end
+
+        if "#{options[key]}" =~ /^{.*}$/
+          begin
+            options[key] = JSON.parse(options[key], symbolize_names: true)
+          rescue
+            $stderr.puts "Failed to load JSON-y value #{options[key].inspect}"
+          end
         end
       end
 

--- a/lib/dpl/provider/s3.rb
+++ b/lib/dpl/provider/s3.rb
@@ -35,7 +35,7 @@ module DPL
         Dir.chdir(options.fetch(:local_dir, Dir.pwd)) do
           Dir.glob("**/*") do |filename|
             content_type = MIME::Types.type_for(filename).first.to_s
-            api.buckets[option(:bucket)].objects.create(upload_path(filename), File.read(filename), :content_type => content_type) unless File.directory?(filename)
+            api.buckets[option(:bucket)].objects.create(upload_path(filename), File.read(filename), option(:s3_options, {:acl => :private}).merge(:content_type => content_type)) unless File.directory?(filename)
           end
         end
       end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -9,6 +9,7 @@ describe DPL::CLI do
     example { described_class.new("--app")                  .options[:app].should be == true                   }
     example { described_class.new("--app=foo", "--app=bar") .options[:app].should be == ['foo', 'bar']         }
     example { described_class.new('--app={"a":true,"b":{"c":1}}').options[:app].should be == {:a => true, :b => {:c => 1}} }
+    example { described_class.new('--app=%7B%22a%22:true,%22b%22:%7B%22c%22:1%7D%7D').options[:app].should be == {:a => true, :b => {:c => 1}} }
 
     example "error handling" do
       $stderr.should_receive(:puts).with('invalid option "app"')

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -8,10 +8,16 @@ describe DPL::CLI do
     example { described_class.new("--app=foo")              .options[:app].should be == 'foo'                  }
     example { described_class.new("--app")                  .options[:app].should be == true                   }
     example { described_class.new("--app=foo", "--app=bar") .options[:app].should be == ['foo', 'bar']         }
+    example { described_class.new('--app={"a":true,"b":{"c":1}}').options[:app].should be == {:a => true, :b => {:c => 1}} }
 
     example "error handling" do
       $stderr.should_receive(:puts).with('invalid option "app"')
       expect { described_class.new("app") }.to raise_error(SystemExit)
+    end
+
+    example "malformed JSON handling" do
+      $stderr.should_receive(:puts).with('Failed to load JSON-y value "{zzz}"')
+      described_class.new('--a={zzz}').options[:a].should be == '{zzz}'
     end
   end
 


### PR DESCRIPTION
mostly so that I can pass a canned acl of ":public_read", but it felt silly to limit to only one of the [many options available](http://docs.aws.amazon.com/AWSRubySDK/latest/AWS/S3/S3Object.html#write-instance_method).