### PR TITLE
fix(npm): don't publish with --force

### DIFF
--- a/lib/dpl/provider/npm.rb
+++ b/lib/dpl/provider/npm.rb
@@ -23,7 +23,7 @@ module DPL
       end
 
       def push_app
-        context.shell "npm publish --force"
+        context.shell "npm publish"
       end
     end
   end

--- a/spec/provider/npm.rb
+++ b/spec/provider/npm.rb
@@ -16,7 +16,7 @@ describe DPL::Provider::NPM do
 
   describe :push_app do
     example do
-      provider.context.should_receive(:shell).with("npm publish --force")
+      provider.context.should_receive(:shell).with("npm publish")
       provider.push_app
     end
   end


### PR DESCRIPTION
Force publishing is going away in the near(-ish) future, see npm/npmjs.org#148.

This is mostly just the simplest thing that could work, but I think this would be break pretty fast as the versions would overlap unless you bump the version number each commit. Not sure if we should handle this automatically or not.

We could recommend doing something like what [travis](https://github.com/travis-ci/travis) (the gem, not the project) does, by somehow adding the job number.

If people are only publishing on tags then this will mostly work (unless people force-push tags).

/cc @Aaron1011 -- I think you touched this code last and added `--force`, does this look right to you?
