### PR TITLE
Added support for deployment to Ninefold

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,3 +31,7 @@ end
 group :cloud_files do
   gem 'fog'
 end
+
+group :ninefold do
+  gem 'ninefold'
+end

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Dpl supports the following providers:
 * [Rackspace Cloud Files](#rackspace-cloud-files)
 * [AWS OpsWorks](#opsworks)
 * [Modulus](#modulus)
+* [Ninefold](#ninefold)
 
 ## Installation:
 
@@ -258,3 +259,14 @@ As a rule of thumb, you should switch to the Git strategy if you run into issues
 #### Examples:
 
     dpl --provider=cloudfiles --username=<username> --api-key=<api-key> --region=<region> --container=<container>
+
+### Ninefold
+
+#### Options:
+
+* **auth_token**: Ninefold deploy auth token
+* **app_id**: Ninefold deploy app ID
+
+#### Examples:
+
+    dpl --provider=ninefold --auth_token=<auth_token> --app_id=<app_id>

--- a/lib/dpl/provider.rb
+++ b/lib/dpl/provider.rb
@@ -21,6 +21,7 @@ module DPL
     autoload :CloudFiles,   'dpl/provider/cloud_files'
     autoload :OpsWorks,     'dpl/provider/ops_works'
     autoload :Modulus,      'dpl/provider/modulus'
+    autoload :Ninefold,     'dpl/provider/ninefold'
 
     def self.new(context, options)
       return super if self < Provider

--- a/lib/dpl/provider/ninefold.rb
+++ b/lib/dpl/provider/ninefold.rb
@@ -1,0 +1,23 @@
+module DPL
+  class Provider
+    class Ninefold < Provider
+      requires 'ninefold'
+
+      def check_auth
+        raise Error, "must supply an auth token" unless option(:auth_token)
+      end
+
+      def check_app
+        raise Error, "must supply an app ID" unless option(:app_id)
+      end
+
+      def needs_key?
+        false
+      end
+
+      def push_app
+        context.shell "AUTH_TOKEN=#{option(:auth_token)} APP_ID=#{option(:app_id)} ninefold app redeploy --sure"
+      end
+    end
+  end
+end

--- a/spec/provider/ninefold_spec.rb
+++ b/spec/provider/ninefold_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+require 'dpl/provider/ninefold'
+
+describe DPL::Provider::Ninefold do
+  subject :provider do
+    described_class.new(DummyContext.new, :auth_token => "123456789", :app_id => "1234")
+  end
+
+  describe :check_auth do
+    it 'requires an auth token' do
+      provider.options.update(:auth_token => nil)
+      expect{ provider.check_auth }.to raise_error "must supply an auth token"
+    end
+  end
+
+  describe :check_app do
+    it 'requires an app ID' do
+      provider.options.update(:app_id => nil)
+      expect{ provider.check_app }.to raise_error "must supply an app ID"
+    end
+  end
+
+  describe :needs_key? do
+    it 'returns false' do
+      expect(provider.needs_key?).to be_false
+    end
+  end
+
+  describe :push_app do
+    it 'includes the auth token and app ID specified' do
+      expect(provider.context).to receive(:shell).with("AUTH_TOKEN=123456789 APP_ID=1234 ninefold app redeploy --sure")
+      provider.push_app
+    end
+  end
+end


### PR DESCRIPTION
This adds a [Ninefold](http://www.ninefold.com) provider to use their CLI to trigger deployments. Specs are in there too, and an updated readme. Not sure if this is the right approach - but I based it off similar other providers in the repo.
