### PR TITLE
Added additional logging to s3 provider

### DIFF
--- a/lib/dpl/provider/s3.rb
+++ b/lib/dpl/provider/s3.rb
@@ -32,8 +32,10 @@ module DPL
       end
 
       def push_app
+        log "Uploading to #{option(:bucket)}"
         Dir.chdir(options.fetch(:local_dir, Dir.pwd)) do
           Dir.glob("**/*") do |filename|
+            log "\t#{upload_path(filename)}"
             content_type = MIME::Types.type_for(filename).first.to_s
             api.buckets[option(:bucket)].objects.create(upload_path(filename), File.read(filename), :content_type => content_type) unless File.directory?(filename)
           end

--- a/lib/dpl/provider/s3.rb
+++ b/lib/dpl/provider/s3.rb
@@ -32,7 +32,7 @@ module DPL
       end
 
       def push_app
-        log "Uploading to #{option(:bucket)}"
+        log "Uploading to #{option(:bucket)}..." if options[:verbose]
         glob_args = ["**/*"]
         glob_args << File::FNM_DOTMATCH if options[:dot_match]
         Dir.chdir(options.fetch(:local_dir, Dir.pwd)) do
@@ -43,7 +43,7 @@ module DPL
             opts[:acl]           = options[:acl] if options[:acl]
             opts[:expires]       = options[:expires] if options[:expires]
             unless File.directory?(filename)
-              log "\t#{upload_path(filename)}"
+              log "\t#{upload_path(filename)}" if options[:verbose]
               api.buckets[option(:bucket)].objects.create(upload_path(filename), File.read(filename), opts)
             end
           end

--- a/spec/provider/s3_spec.rb
+++ b/spec/provider/s3_spec.rb
@@ -110,9 +110,9 @@ describe DPL::Provider::S3 do
       provider.push_app
     end
 
-    example "With quiet" do
-      provider.options.update(:quiet => true)
-      provider.should_not_receive(:log)
+    example "With verbose" do
+      provider.options.update(:verbose => true)
+      expect(provider).to receive(:log)
       provider.push_app
     end
   end

--- a/spec/provider/s3_spec.rb
+++ b/spec/provider/s3_spec.rb
@@ -73,6 +73,12 @@ describe :needs_key? do
       AWS::S3::ObjectCollection.any_instance.should_receive(:create).with(anything(), anything(), hash_including(:content_type => 'application/x-ruby'))
       provider.push_app
     end
+
+    example "With quiet" do
+      provider.options.update(:quiet => true)
+      provider.should_not_receive(:log)
+      provider.push_app
+    end
   end
 
   describe :api do

--- a/spec/provider/s3_spec.rb
+++ b/spec/provider/s3_spec.rb
@@ -3,11 +3,12 @@ require 'aws-sdk'
 require 'dpl/provider/s3'
 
 describe DPL::Provider::S3 do
-  
+
   before (:each) do
     AWS.stub!
+    allow_any_instance_of(DPL::Provider).to receive(:log)
   end
-  
+
   subject :provider do
     described_class.new(DummyContext.new, :access_key_id => 'qwertyuiopasdfghjklz', :secret_access_key => 'qwertyuiopasdfghjklzqwertyuiopasdfghjklz', :bucket => 'my-bucket')
   end
@@ -47,7 +48,7 @@ describe DPL::Provider::S3 do
       provider.setup_auth
     end
   end
-  
+
 describe :needs_key? do
     example do
       provider.needs_key?.should == false
@@ -62,7 +63,7 @@ describe :needs_key? do
 
     example "With local_dir" do
       provider.options.update(:local_dir => 'BUILD')
-      
+
       Dir.should_receive(:chdir).with('BUILD')
       provider.push_app
     end
@@ -74,7 +75,7 @@ describe :needs_key? do
     end
   end
 
-  describe :api do   
+  describe :api do
     example "Without Endpoint" do
       AWS::S3.should_receive(:new).with(:endpoint => 's3.amazonaws.com')
       provider.api

--- a/spec/provider/s3_spec.rb
+++ b/spec/provider/s3_spec.rb
@@ -112,7 +112,14 @@ describe DPL::Provider::S3 do
 
     example "With verbose" do
       provider.options.update(:verbose => true)
-      expect(provider).to receive(:log)
+      expect(provider).to receive(:log).exactly(1).times.with("Uploading to #{provider.options[:bucket]}...")
+      expect(provider).to receive(:log).at_least(1).times.with(/\A\t.+\Z/)
+      provider.push_app
+    end
+
+    example "Without verbose" do
+      provider.options.update(:verbose => false)
+      expect(provider).to_not receive(:log)
       provider.push_app
     end
   end

--- a/spec/provider/s3_spec.rb
+++ b/spec/provider/s3_spec.rb
@@ -111,13 +111,15 @@ describe DPL::Provider::S3 do
     end
 
     example "With verbose" do
+      expect(Dir).to receive(:glob).and_yield(__FILE__)
       provider.options.update(:verbose => true)
       expect(provider).to receive(:log).exactly(1).times.with("Uploading to #{provider.options[:bucket]}...")
-      expect(provider).to receive(:log).at_least(1).times.with(/\A\t.+\Z/)
+      expect(provider).to receive(:log).exactly(1).times.with(/\A\t#{__FILE__}\Z/)
       provider.push_app
     end
 
     example "Without verbose" do
+      expect(Dir).to receive(:glob).and_yield(__FILE__)
       provider.options.update(:verbose => false)
       expect(provider).to_not receive(:log)
       provider.push_app


### PR DESCRIPTION
This is a reasonably trivial commit, but I thought it might help to have a bit of logging output for S3 deploys. We've also had some issues on our (really) long S3 deploys hitting the 10 minute timeout, and though the extra logs might help here?