### PR TITLE
Add More Logging to GitHub Provider

### DIFF
--- a/lib/dpl/provider/releases.rb
+++ b/lib/dpl/provider/releases.rb
@@ -33,6 +33,8 @@ module DPL
       end
 
       def check_app
+        log "Deploying to repo: #{slug}"
+        log "Current tag is: #{get_tag}"
       end
 
       def setup_auth


### PR DESCRIPTION
This pull request is to add some additional logging to the GitHub releases provider, useful to see what is going on the in the deployment process ( and when it's not working as well, as I found out :smile: )
