### PR TITLE
Github Releases: Create new release if one does not already exist. Fixes #111

### DIFF
--- a/lib/dpl/provider/releases.rb
+++ b/lib/dpl/provider/releases.rb
@@ -46,22 +46,20 @@ module DPL
 
       def push_app
         tag_matched = false
+        release_url = nil
 
         releases.each do |release|
           if release.tag_name == get_tag
-            api.upload_asset(release.rels[:self].href, option(:file), {:content_type => MIME::Types.type_for(option(:file)).first.to_s})
+            release_url = release.rels[:self].href
             tag_matched = true
           end
         end
-        unless tag_matched
-          log <<-EOS
-                 This isn't a GitHub release, so nothing has been deployed. If you haven't already, please add the following to the 'deploy' section of your .travis.yml:
 
-                 on:
-                   tags: true
-                   all_branches: true
-                EOS
+        #If for some reason GitHub hasn't already created a release for the tag, create one
+        if tag_matched == false
+          release_url = api.create_release(slug, get_tag).rels[:self].href
         end
+        api.upload_asset(release_url, option(:file), {:content_type => MIME::Types.type_for(option(:file)).first.to_s})
       end
     end
   end

--- a/spec/provider/releases_spec.rb
+++ b/spec/provider/releases_spec.rb
@@ -58,7 +58,7 @@ describe DPL::Provider::Releases do
   end
 
   describe :push_app do
-    example do
+    example "When Release Exists" do
       allow_message_expectations_on_nil
       provider.stub(:releases).and_return([""])
       provider.releases.map do |release| 
@@ -68,6 +68,21 @@ describe DPL::Provider::Releases do
       end
       provider.stub(:get_tag).and_return("v0.0.0")
       provider.api.should_receive(:upload_asset)
+      provider.push_app
+    end
+
+    example "When Release Doesn't Exist" do
+      allow_message_expectations_on_nil
+      provider.stub(:releases).and_return([""])
+      provider.releases.map do |release| 
+        release.stub(:tag_name).and_return("foo")
+        release.stub(:rels).and_return({:self => nil})
+        release.rels[:self].stub(:href)
+      end
+      provider.api.stub(:create_release)
+      provider.api.should_receive(:upload_asset)
+      provider.api.create_release.stub(:rels).and_return({:self => nil})
+      provider.api.create_release.rels[:slef].stub(:href)
       provider.push_app
     end
   end


### PR DESCRIPTION
This should create a GitHub release for a tag if the tag doesn't already have a GitHub Release. This should be merged asap please, as without this the GitHub Releases Provider is almost unusable.
