### PR TITLE
Adds better support for CF deploy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,10 +1,6 @@
 source 'https://rubygems.org'
 gemspec
 
-group :cloudfoundry do
-  gem 'cf', '~> 5.4.5'
-end
-
 group :heroku do
   gem 'rendezvous', '~> 0.0.2'
   gem 'heroku-api', '= 0.3.16'

--- a/README.md
+++ b/README.md
@@ -228,12 +228,12 @@ As a rule of thumb, you should switch to the Git strategy if you run into issues
 * **username**: Cloud Foundry username.
 * **password**: Cloud Foundry password.
 * **organization**: Cloud Foundry target organization.
-* **target**: Cloud Foundry target cloud/URL
+* **api**: Cloud Foundry api URL
 * **space**: Cloud Foundry target space
 
 #### Examples:
 
-    dpl --provider=cloudfoundry --username=<username> --password=<password> --organization=<organization> --target=<target> --space=<space>
+    dpl --provider=cloudfoundry --username=<username> --password=<password> --organization=<organization> --api=<api> --space=<space>
 
 ### dotCloud:
 

--- a/lib/dpl/provider/cloud_foundry.rb
+++ b/lib/dpl/provider/cloud_foundry.rb
@@ -1,11 +1,16 @@
 module DPL
   class Provider
     class CloudFoundry < Provider
-      requires 'cf'
+
+      def initial_go_tools_install
+        context.shell 'wget http://go-cli.s3-website-us-east-1.amazonaws.com/releases/latest/cf-cli_amd64.deb -qO temp.deb && sudo dpkg -i temp.deb'
+        context.shell 'rm temp.deb'
+      end
 
       def check_auth
-        context.shell "cf target #{option(:target)}"
-        context.shell "cf login --username #{option(:username)} --password #{option(:password)} --organization #{option(:organization)} --space #{option(:space)}"
+        initial_go_tools_install
+        context.shell "cf api #{option(:api)}"
+        context.shell "cf login --u #{option(:username)} --p #{option(:password)} --o #{option(:organization)} --s #{option(:space)}"
       end
 
       def check_app

--- a/spec/provider/cloudfoundry_spec.rb
+++ b/spec/provider/cloudfoundry_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+require 'dpl/provider/cloud_foundry'
+
+describe DPL::Provider::CloudFoundry do
+  subject :provider do
+    described_class.new(DummyContext.new, api: 'api.run.awesome.io', username: 'mallomar',
+                        password: 'myreallyawesomepassword',
+                        organization: 'myorg',
+                        space: 'outer')
+  end
+
+  describe :check_auth do
+    example do
+      expect(provider.context).to receive(:shell).with('wget http://go-cli.s3-website-us-east-1.amazonaws.com/releases/latest/cf-cli_amd64.deb -qO temp.deb && sudo dpkg -i temp.deb')
+      expect(provider.context).to receive(:shell).with('rm temp.deb')
+      expect(provider.context).to receive(:shell).with('cf api api.run.awesome.io')
+      expect(provider.context).to receive(:shell).with('cf login --u mallomar --p myreallyawesomepassword --o myorg --s outer')
+      provider.check_auth
+    end
+  end
+
+  describe :check_app do
+    example do
+      expect{provider.check_app}.to raise_error('Application must have a manifest.yml for unattended deployment')
+    end
+  end
+
+  describe :needs_key? do
+    example do
+      expect(provider.needs_key?).to eq(false)
+    end
+  end
+
+  describe :push_app do
+    example do
+      expect(provider.context).to receive(:shell).with('cf push')
+      expect(provider.context).to receive(:shell).with('cf logout')
+      provider.push_app
+
+    end
+  end
+end


### PR DESCRIPTION
- Removed the CF ruby gem that is deprecated and now using the go package
  installer
- Added tests to actually make sure all of the wonderful code is working
- Adds a setup step for the go package (don't really like the way this
  is being done)
- Updates README to reflect changes
- Switched out CF commands as they have become incorrect
- Changes target to api to be more symantically correct
