### PR TITLE
Releases: Add release-number option

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,7 @@ As a rule of thumb, you should switch to the Git strategy if you run into issues
 * **password**: GitHub Password. Not necessary if `api-key` is used.
 * **repo**: GitHub Repo. Defaults to git repo's name.
 * **file**: File to upload to GitHub Release.
+* **release-number**: Overide automatic release detection, set a release manually.
 
 #### GitHub Two Factor Authentication
 

--- a/lib/dpl/provider/releases.rb
+++ b/lib/dpl/provider/releases.rb
@@ -56,11 +56,16 @@ module DPL
       def push_app
         tag_matched = false
         release_url = nil
-
-        releases.each do |release|
-          if release.tag_name == get_tag
-            release_url = release.rels[:self].href
-            tag_matched = true
+        
+        if options[:release_number]
+          tag_matched = true
+          release_url = "https://api.github.com/repos/" + slug + "/releases/" + options[:release_number]
+        else 
+          releases.each do |release|
+            if release.tag_name == get_tag
+              release_url = release.rels[:self].href
+              tag_matched = true
+            end
           end
         end
 

--- a/spec/provider/releases_spec.rb
+++ b/spec/provider/releases_spec.rb
@@ -144,5 +144,23 @@ describe DPL::Provider::Releases do
 
       provider.push_app
     end
+
+    example "With Release Number" do
+      allow_message_expectations_on_nil
+
+      provider.options.update(:file => ["bar.foo"])
+      provider.options.update(:release_number => "1234")
+
+      provider.stub(:slug).and_return("foo/bar")
+
+      provider.api.stub(:release)
+      provider.api.release.stub(:rels).and_return({:assets => nil})
+      provider.api.release.rels[:assets].stub(:get).and_return({:data => nil})
+      provider.api.release.rels[:assets].get.stub(:data).and_return([])
+
+      provider.api.should_receive(:upload_asset).with("https://api.github.com/repos/foo/bar/releases/1234", "bar.foo", {:name=>"bar.foo", :content_type=>""})
+
+      provider.push_app
+    end
   end
 end


### PR DESCRIPTION
This allows you to override release detection, which allows you to run dpl releases out of a git repository.
