### PR TITLE
Unstash stashed changes before exiting

### DIFF
--- a/lib/dpl/provider.rb
+++ b/lib/dpl/provider.rb
@@ -116,6 +116,7 @@ module DPL
       if needs_key?
         remove_key rescue nil
       end
+      uncleanup
     end
 
     def sha


### PR DESCRIPTION
Changes introduced to the app are cleaned up during deployment,
making them unavailable to after_deploy block.
Since such changes include the bundled gems, after_deploy block
could not use "bundle exec" to interact with the application in
an expected manner.
