### PR TITLE
use all git-tracked files to create archive

### DIFF
--- a/lib/dpl/provider/elastic_beanstalk.rb
+++ b/lib/dpl/provider/elastic_beanstalk.rb
@@ -70,7 +70,7 @@ module DPL
         s3.buckets.create(bucket_name)
       end
 
-      def files
+      def files_to_pack
         `git ls-files -z`.split("\x0")
       end
 
@@ -79,7 +79,7 @@ module DPL
         zipfile_name = File.join(directory, archive_name)
 
         Zip::File.open(zipfile_name, Zip::File::CREATE) do |zipfile|
-          files.each do |file|
+          files_to_pack.each do |file|
             relative_archive_path = File.join(directory, '/')
             zipfile.add(file.sub(relative_archive_path, ''), file)
           end


### PR DESCRIPTION
ElasticBeanstalk uses .ebextensions for managing the environment. And by defaults all `dot-files` would be excluded. So we should pack all files tracked by git :dancers:

cheers, 
