### PR TITLE
App Engine: Update to sdk version 1.9.8, as 1.9.6 was taken down

### DIFF
--- a/lib/dpl/provider/gae.rb
+++ b/lib/dpl/provider/gae.rb
@@ -7,9 +7,9 @@ module DPL
       experimental 'Google App Engine'
 
       # https://developers.google.com/appengine/downloads
-      GAE_VERSION='1.9.6'
+      GAE_VERSION='1.9.8'
       GAE_ZIP_FILE="google_appengine_#{GAE_VERSION}.zip"
-      SHA1SUM='888a6687d868ac37f973ea2fb986931338a1c040'
+      SHA1SUM='9835547cd2566ab1eaffe15e4697724eba08831f'
       BASE_DIR=Dir.pwd
       GAE_DIR=File.join(BASE_DIR, 'google_appengine')
       APPCFG_BIN=File.join(GAE_DIR, 'appcfg.py')


### PR DESCRIPTION
This is a critical bug to everybody who is using the app engine sdk, as well as broke the specs.
