### PR TITLE
Requires: Don't install documentation

### DIFF
--- a/lib/dpl/provider.rb
+++ b/lib/dpl/provider.rb
@@ -49,7 +49,7 @@ module DPL
       load    = options[:load]    || name
       gem(name, version)
     rescue LoadError
-      context.shell("gem install %s -v %p" % [name, version], retry: true)
+      context.shell("gem install %s -v %p --no-ri --no-rdoc" % [name, version], retry: true)
       Gem.clear_paths
     ensure
       require load

--- a/spec/provider_spec.rb
+++ b/spec/provider_spec.rb
@@ -26,7 +26,7 @@ describe DPL::Provider do
 
     example "missing" do
       expect(example_provider).to receive(:gem).with("foo", "~> 1.4").and_raise(LoadError)
-      expect(example_provider.context).to receive(:shell).with('gem install foo -v "~> 1.4"', retry: true)
+      expect(example_provider.context).to receive(:shell).with('gem install foo -v "~> 1.4" --no-ri --no-rdoc', retry: true)
       example_provider.requires("foo", :version => "~> 1.4")
     end
   end


### PR DESCRIPTION
This should help with travis-ci/travis-ci#2612's request to cut down on gem install time.
