### PR TITLE
Add Puppet Forge plugin using Puppet Blacksmith

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,3 +54,8 @@ end
 group :bitballoon do
   gem 'bitballoon'
 end
+
+group :puppet_forge do
+  gem 'puppet'
+  gem 'puppet-blacksmith'
+end

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Dpl supports the following providers:
 * [Deis](#deis)
 * [Google Cloud Storage](#google-cloud-storage)
 * [Elastic Beanstalk](#elastic-beanstalk)
+* [Puppet Forge](#puppet-forge)
 
 ## Installation:
 
@@ -390,3 +391,14 @@ For accounts using two factor authentication, you have to use an oauth token as 
     dpl --access-token=<access-token> --site-id=3f932c1e-708b-4573-938a-a07d9728c22e
     dpl --access-token=<access-token> --site-id=3f932c1e-708b-4573-938a-a07d9728c22e --local-dir=build
 
+### Puppet Forge:
+
+#### Options:
+
+ * **user**: Required. The user name at Puppet forge.
+ * **password**: Required. The Puppet forge password.
+ * **url**: Optional. The forge URL to deploy to. Defaults to https://forgeapi.puppetlabs.com/
+
+#### Examples:
+
+    dpl --provider=puppetforge --user=puppetlabs --password=s3cr3t

--- a/lib/dpl/provider.rb
+++ b/lib/dpl/provider.rb
@@ -30,6 +30,7 @@ module DPL
     autoload :GAE,          'dpl/provider/gae'
     autoload :BitBalloon,   'dpl/provider/bitballoon'
     autoload :ElasticBeanstalk, 'dpl/provider/elastic_beanstalk'
+    autoload :PuppetForge,  'dpl/provider/puppet_forge'
 
     def self.new(context, options)
       return super if self < Provider

--- a/lib/dpl/provider/puppet_forge.rb
+++ b/lib/dpl/provider/puppet_forge.rb
@@ -1,0 +1,42 @@
+module DPL
+  class Provider
+    class PuppetForge < Provider
+      require 'pathname'
+
+      requires 'puppet', :load => 'puppet/face'
+      requires 'puppet-blacksmith', :load => 'puppet_blacksmith'
+
+      def modulefile
+        @modulefile ||= Blacksmith::Modulefile.new
+      end
+
+      def forge
+        @forge ||= Blacksmith::Forge.new(options[:user], options[:password], options[:url])
+      end
+
+      def build
+        pmod = Puppet::Face['module', :current]
+        pmod.build('./')
+      end
+
+      def needs_key?
+        false
+      end
+
+      def check_app
+        modulefile.metadata
+      end
+
+      def check_auth
+        raise Error, "must supply a user" unless option(:user)
+        raise Error, "must supply a password" unless option(:password)
+      end
+
+      def push_app
+        build
+        log "Uploading to Puppet Forge #{forge.username}/#{modulefile.name}"
+        forge.push!(modulefile.name)
+      end
+    end
+  end
+end

--- a/spec/provider/puppet_forge_spec.rb
+++ b/spec/provider/puppet_forge_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+require 'dpl/provider/puppet_forge'
+require 'puppet/face'
+require 'puppet_blacksmith'
+
+describe DPL::Provider::PuppetForge do
+  subject :provider do
+    described_class.new(DummyContext.new, :user => 'puppetlabs', :password => 's3cr3t')
+  end
+
+  describe "forge" do
+    it 'should include the user and password specified' do
+      expect(provider.forge.username).to eq(provider.options[:user])
+      expect(provider.forge.password).to eq(provider.options[:password])
+    end
+  end
+
+  describe "build" do
+    it 'should use Puppet module tool to build the module' do
+      pmt = double('pmt')
+      expect(::Puppet::Face).to receive(:[]).and_return(pmt)
+      expect(pmt).to receive(:build).with('./')
+      provider.build
+    end
+  end
+
+  describe "#check_auth" do
+    it 'should require a user' do
+      provider.options.update(:user => nil)
+      expect{ provider.check_auth }.to raise_error("must supply a user")
+    end
+
+    it 'should require a password' do
+      provider.options.update(:password => nil)
+      expect{ provider.check_auth }.to raise_error("must supply a password")
+    end
+  end
+
+  describe "#check_app" do
+    it 'should load module metadata using Blacksmith' do
+      modulefile = double('modulefile')
+      expect(::Blacksmith::Modulefile).to receive(:new).and_return(modulefile)
+      expect(modulefile).to receive(:metadata) { true }
+      provider.check_app
+    end
+  end
+
+  describe "#push_app" do
+    it 'should use Blacksmith to push to the Forge' do
+      forge = double('forge')
+      expect(provider).to receive(:build).and_return(true)
+      expect(provider).to receive(:modulefile).at_least(:once).and_return(double('modulefile', :name => 'test'))
+      expect(provider).to receive(:log).and_return(true)
+      expect(::Blacksmith::Forge).to receive(:new).and_return(forge)
+      expect(forge).to receive(:push!) { true }
+      expect(forge).to receive(:username) { provider.options[:user] }
+      provider.push_app
+    end
+  end
+end


### PR DESCRIPTION
Allows deploying to forge.puppetlabs.com using Puppet Blacksmith, https://github.com/maestrodev/puppet-blacksmith
