### PR TITLE
Add file_glob option to GitHub Releases plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,7 @@ As a rule of thumb, you should switch to the Git strategy if you run into issues
 * **password**: GitHub Password. Not necessary if `api-key` is used.
 * **repo**: GitHub Repo. Defaults to git repo's name.
 * **file**: File to upload to GitHub Release.
+* **file_glob**: If files should be interpreted as globs (\* and \*\* wildcards). Defaults to false.
 * **release-number**: Overide automatic release detection, set a release manually.
 
 #### GitHub Two Factor Authentication

--- a/lib/dpl/provider/releases.rb
+++ b/lib/dpl/provider/releases.rb
@@ -43,6 +43,16 @@ module DPL
         @user ||= api.user
       end
 
+      def files
+        if options[:file_glob]
+          Array(options[:file]).map do |glob|
+            Dir.glob(glob)
+          end.flatten
+        else
+          Array(options[:file])
+        end
+      end
+
       def needs_key?
         false
       end
@@ -89,7 +99,7 @@ module DPL
           release_url = api.create_release(slug, get_tag).rels[:self].href
         end
 
-        Array(options[:file]).each do |file|
+        files.each do |file|
           already_exists = false
           filename = Pathname.new(file).basename.to_s
           api.release(release_url).rels[:assets].get.data.each do |existing_file|

--- a/spec/provider/releases_spec.rb
+++ b/spec/provider/releases_spec.rb
@@ -60,6 +60,32 @@ describe DPL::Provider::Releases do
     end
   end
 
+  describe "#files" do
+    example "without file globbing and a single file" do
+      expect(provider.files).to eq(['blah.txt'])
+    end
+
+    example "without file globbing and multiple files" do
+      provider.options.update(:file => ['foo.txt', 'bar.txt'])
+      expect(provider.files).to eq(['foo.txt', 'bar.txt'])
+    end
+
+    example "with file globbing and a single glob" do
+      provider.options.update(:file_glob => true)
+      provider.options.update(:file => 'bl*.txt')
+      expect(::Dir).to receive(:glob).with('bl*.txt').and_return(['blah.txt'])
+      expect(provider.files).to eq(['blah.txt'])
+    end
+
+    example "with file globbing and multiple globs" do
+      provider.options.update(:file_glob => true)
+      provider.options.update(:file => ['f*.txt', 'b*.txt'])
+      expect(::Dir).to receive(:glob).with('f*.txt').and_return(['foo.txt'])
+      expect(::Dir).to receive(:glob).with('b*.txt').and_return(['bar.txt'])
+      expect(provider.files).to eq(['foo.txt', 'bar.txt'])
+    end
+  end
+
   describe "#needs_key?" do
     example do
       expect(provider.needs_key?).to eq(false)


### PR DESCRIPTION
Allows you to set the file_glob option to true and then the file option
will be interpreted as a file glob (*, ** and ? wildcards, with \ to
escape them).

This allows deploying files without knowing their exact filenames up
front, for example packages containing the version in their filename.
