### PR TITLE
Fix for Divshot tokens starting with a dash

### DIFF
--- a/lib/dpl/provider/divshot.rb
+++ b/lib/dpl/provider/divshot.rb
@@ -16,7 +16,7 @@ module DPL
       end
 
       def push_app
-        context.shell "divshot push #{options[:environment] || "production"} --token #{option(:api_key)}"
+        context.shell "divshot push #{options[:environment] || "production"} --token=#{option(:api_key)}"
       end
     end
   end

--- a/spec/provider/divshot_spec.rb
+++ b/spec/provider/divshot_spec.rb
@@ -16,12 +16,12 @@ describe DPL::Provider::Divshot do
   describe "#push_app" do
     it 'should include the environment specified' do
       provider.options.update(:environment => 'development')
-      expect(provider.context).to receive(:shell).with("divshot push development --token abc123")
+      expect(provider.context).to receive(:shell).with("divshot push development --token=abc123")
       provider.push_app
     end
 
     it 'should default to production' do
-      expect(provider.context).to receive(:shell).with("divshot push production --token abc123")
+      expect(provider.context).to receive(:shell).with("divshot push production --token=abc123")
       provider.push_app
     end
   end


### PR DESCRIPTION
If a Divshot token begins with a dash it currently gets parsed as extra
options being passed into the CLI and fails with:

  `TypeError: Object true has no method 'split'`
