### PR TITLE
Ensuring the elastic beanstalk "bucket_name" option is optional

### DIFF
--- a/lib/dpl/provider/elastic_beanstalk.rb
+++ b/lib/dpl/provider/elastic_beanstalk.rb
@@ -51,7 +51,7 @@ module DPL
       end
 
       def bucket_name
-        option(:bucket_name) || "travis-elasticbeanstalk-builds-#{region}"
+        options[:bucket_name] || "travis-elasticbeanstalk-builds-#{region}"
       end
 
       def s3

--- a/spec/provider/elastic_beanstalk_spec.rb
+++ b/spec/provider/elastic_beanstalk_spec.rb
@@ -67,4 +67,12 @@ describe DPL::Provider::ElasticBeanstalk do
       provider.push_app
     end
   end
+
+  context 'when bucket name is not provided' do
+    before { allow(provider).to receive(:options).and_return({region: 'us-bork-2'}) }
+
+    it 'uses the default bucket name' do
+      expect(provider.send(:bucket_name)).to eq('travis-elasticbeanstalk-builds-us-bork-2')
+    end
+  end
 end


### PR DESCRIPTION
Related to #173
- [ ] only merge if `bucket_name` really should be optional
