### PR TITLE
Ensuring docs reflect elastic beanstalk provider requires bucket_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ For accounts using two factor authentication, you have to use an oauth token as 
  * **region**: AWS Region the Elastic Beanstalk app is running in. Defaults to 'us-east-1'. Please be aware that this must match the region of the elastic beanstalk app.
  * **app**: Elastic Beanstalk application name.
  * **env**: Elastic Beanstalk environment name which will be updated.
- * **bucket_name**: Bucket name to upload app to. Optional, and defaults to `travis-elasticbeanstalk-builds-REGION` (where `REGION` is the `region` value set above).
+ * **bucket_name**: Bucket name to upload app to.
 
 #### Examples:
 

--- a/lib/dpl/provider/elastic_beanstalk.rb
+++ b/lib/dpl/provider/elastic_beanstalk.rb
@@ -51,7 +51,7 @@ module DPL
       end
 
       def bucket_name
-        option(:bucket_name) || "travis-elasticbeanstalk-builds-#{region}"
+        option(:bucket_name)
       end
 
       def s3

--- a/spec/provider/elastic_beanstalk_spec.rb
+++ b/spec/provider/elastic_beanstalk_spec.rb
@@ -14,7 +14,7 @@ describe DPL::Provider::ElasticBeanstalk do
   let(:region) { 'us-west-2' }
   let(:app) { 'example-app' }
   let(:env) { 'live' }
-  let(:bucket_name) { "travis-elasticbeanstalk-builds-#{region}" }
+  let(:bucket_name) { "travis-elasticbeanstalk-test-builds-#{region}" }
 
   subject :provider do
     described_class.new(
@@ -32,7 +32,7 @@ describe DPL::Provider::ElasticBeanstalk do
 
   describe "#push_app" do
 
-    let(:bucket_name) { "travis-elasticbeanstalk-builds-#{region}" }
+    let(:bucket_name) { "travis-elasticbeanstalk-test-builds-#{region}" }
     let(:s3_object) { Object.new }
     let(:app_version) { Object.new }
 


### PR DESCRIPTION
and adjusting impl to remove (non-working) default value.
