### PR TITLE
pass options hash to octokit create_release 

### DIFF
--- a/lib/dpl/provider/releases.rb
+++ b/lib/dpl/provider/releases.rb
@@ -96,7 +96,7 @@ module DPL
 
         #If for some reason GitHub hasn't already created a release for the tag, create one
         if tag_matched == false
-          release_url = api.create_release(slug, get_tag, options[:release_body], options[:release_draft], options[:release_prerelease]).rels[:self].href
+          release_url = api.create_release(slug, get_tag, options).rels[:self].href
         end
 
         files.each do |file|


### PR DESCRIPTION
- this is helpful when using travis to generate build artifacts and store them in a github release container but not marking it as a "final release".
- further optimizes the creation of the github release by setting some additional flags in `.travis.yml`:
- possible values ([method reference](http://octokit.github.io/octokit.rb/Octokit/Client/Releases.html#create_release-instance_method)):
  - target_commitish (String) — Specifies the commitish value that determines where the Git tag is created from.
  - name (String) — Name for the release
  - body (String) — Content for release notes
  - draft (String) — Mark this release as a draft
  - prerelease (String) — Mark this release as a pre-release
- full example:

```
deploy:
  provider: releases
  api-key: "GITHUB OAUTH TOKEN"

  target_commitish: "xxx"
  name: "custom-release"
  body: "custom release message"
  draft: false
  prerelease: true
```
