### PR TITLE
Add deployment on specific instances support for opsworks

### DIFF
--- a/lib/dpl/provider/ops_works.rb
+++ b/lib/dpl/provider/ops_works.rb
@@ -69,13 +69,17 @@ module DPL
       end
 
       def create_deployment
-        data = client.create_deployment(
+        deployment_config = {
           stack_id: ops_works_app[:stack_id],
           app_id: option(:app_id),
           command: {name: 'deploy'},
           comment: travis_deploy_comment,
           custom_json: custom_json.to_json
-        )
+        }
+        if !options[:instance_ids].nil?
+          deployment_config[:instance_ids] = option(:instance_ids)
+        end
+        data = client.create_deployment(deployment_config)
         log "Deployment created: #{data[:deployment_id]}"
         return unless options[:wait_until_deployed]
         print "Deploying "

--- a/spec/provider/ops_works_spec.rb
+++ b/spec/provider/ops_works_spec.rb
@@ -71,6 +71,15 @@ describe DPL::Provider::OpsWorks do
       expect(client).to receive(:describe_deployments).with({deployment_ids: ['deployment_id']}).and_return({deployments: [status: 'running']}, {deployments: [status: 'successful']})
       provider.push_app
     end
+
+    example 'with :instance-ids' do
+      provider.options.update(app_id: 'app-id', instance_ids: ['instance-id'])
+      expect(client).to receive(:describe_apps).with(app_ids: ['app-id']).and_return({apps: [ops_works_app]})
+      expect(client).to receive(:create_deployment).with(
+        stack_id: 'stack-id', app_id: 'app-id', instance_ids:['instance-id'], command: {name: 'deploy'}, comment: 'Deploy build 123 via Travis CI', custom_json: custom_json
+      ).and_return({})
+      provider.push_app
+    end
   end
 
   describe "#api" do


### PR DESCRIPTION
Related to #191 

Example :

```
deploy:
  provider: opsworks
  access_key_id: <ACCESS KEY>
  secret_access_key:
    secure: <SECURE SECRET KEY>
  app-id: <APP ID>
  on:
    repo: <REPO>
    branch: master
    instance-ids: 
    - <INSTANCE ID>
```
