### PR TITLE
[pypi] set index server or upload_docs will fail. Fix for travis/travis#2909

### DIFF
--- a/lib/dpl/provider/pypi.rb
+++ b/lib/dpl/provider/pypi.rb
@@ -19,7 +19,7 @@ module DPL
       def config
         {
           :header => '[distutils]',
-          :servers_line => 'index-servers =',
+          :servers_line => 'index-servers = pypi',
           :servers => {
             'pypi' => [
                          "repository: #{options[:server] || DEFAULT_SERVER}",


### PR DESCRIPTION
implements suggestion from pypi staff http://sourceforge.net/p/pypi/support-requests/429/
