### PR TITLE
Add Chef Supermarket provider

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,3 +59,7 @@ group :puppet_forge do
   gem 'puppet'
   gem 'puppet-blacksmith'
 end
+
+group :chef_supermarket do
+  gem 'chef'
+end

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Dpl supports the following providers:
 * [Google Cloud Storage](#google-cloud-storage)
 * [Elastic Beanstalk](#elastic-beanstalk)
 * [Puppet Forge](#puppet-forge)
+* [Chef Supermarket](#chef-supermarket)
 
 ## Installation:
 
@@ -415,3 +416,15 @@ For accounts using two factor authentication, you have to use an oauth token as 
 #### Examples:
 
     dpl --provider=puppetforge --user=puppetlabs --password=s3cr3t
+
+### Chef Supermarket:
+
+#### Options:
+
+ * **user_id**: Required. The user name at Chef Supermarket.
+ * **client_key**: Required. The client API key file name.
+ * **cookbook_category**: Required. The cookbook category in Supermarket (see: https://docs.getchef.com/knife_cookbook_site.html#id12 )
+
+#### Examples:
+
+    dpl --provider=chef-supermarket --user-id=chef --client-key=.travis/client.pem --cookbook-category=Others

--- a/lib/dpl/provider.rb
+++ b/lib/dpl/provider.rb
@@ -34,6 +34,7 @@ module DPL
     autoload :Biicode,      'dpl/provider/biicode'
     autoload :ElasticBeanstalk, 'dpl/provider/elastic_beanstalk'
     autoload :PuppetForge,  'dpl/provider/puppet_forge'
+    autoload :ChefSupermarket,  'dpl/provider/chef_supermarket'
 
 
     def self.new(context, options)

--- a/lib/dpl/provider/chef_supermarket.rb
+++ b/lib/dpl/provider/chef_supermarket.rb
@@ -1,0 +1,81 @@
+module DPL
+  class Provider
+    class ChefSupermarket < Provider
+
+      # Most of the code is inspired by:
+      # https://github.com/opscode/chef/blob/11.16.4/lib/chef/knife/cookbook_site_share.rb
+
+      requires 'chef', load: 'chef/config'
+      requires 'chef', load: 'chef/cookbook_loader'
+      requires 'chef', load: 'chef/cookbook_uploader'
+      requires 'chef', load: 'chef/cookbook_site_streaming_uploader'
+
+      attr_reader :cookbook_name, :cookbook_category
+      attr_reader :cookbook
+
+      def needs_key?
+        false
+      end
+
+      def check_auth
+        error "Missing user_id option" unless options[:user_id]
+        error "Missing client_key option" unless options[:client_key]
+        ::Chef::Config[:client_key] = options[:client_key]
+        error "#{options[:client_key]} does not exist" unless ::File.exist?(options[:client_key])
+      end
+
+      def check_app
+        @cookbook_name = options[:cookbook_name] || options[:app]
+        @cookbook_category = options[:cookbook_category]
+        unless cookbook_category
+          error "Missing cookbook_category option\n" +
+            "see https://docs.getchef.com/knife_cookbook_site.html#id12"
+        end
+
+        log "Validating cookbook #{cookbook_name}"
+        # Check that cookbook exist and is valid
+        # So we assume cookbook path is '..'
+        cl = ::Chef::CookbookLoader.new '..'
+        @cookbook = cl[cookbook_name]
+        ::Chef::CookbookUploader.new(cookbook, '..').validate_cookbooks
+      end
+
+      def push_app
+        log "Creating cookbook build directory"
+        tmp_cookbook_dir = Chef::CookbookSiteStreamingUploader.create_build_dir(cookbook)
+        log "Making tarball in #{tmp_cookbook_dir}"
+        system("tar -czf #{cookbook_name}.tgz #{cookbook_name}", :chdir => tmp_cookbook_dir)
+
+        uri = "http://cookbooks.opscode.com/api/v1/cookbooks"
+
+        log "Uploading to #{uri}"
+        category_string = { 'category'=>cookbook_category }.to_json
+        http_resp = ::Chef::CookbookSiteStreamingUploader.post(
+          uri,
+          options[:user_id],
+          options[:client_key],
+          {
+            :tarball => File.open("#{tmp_cookbook_dir}/#{cookbook_name}.tgz"),
+            :cookbook => category_string
+          }
+        )
+        res = ::Chef::JSONCompat.from_json(http_resp.body)
+        if http_resp.code.to_i != 201
+          if res['error_messages']
+            if res['error_messages'][0] =~ /Version already exists/
+              error "The same version of this cookbook already exists on the Opscode Cookbook Site."
+            else
+              error "#{res['error_messages'][0]}"
+            end
+          else
+            error "Unknown error while sharing cookbook\n" +
+              "Server response: #{http_resp.body}"
+          end
+        end
+
+        log "Upload complete."
+        ::FileUtils.rm_rf tmp_cookbook_dir
+      end
+    end
+  end
+end

--- a/spec/provider/chef_supermarket_spec.rb
+++ b/spec/provider/chef_supermarket_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+require 'chef/cookbook_loader'
+require 'chef/cookbook_uploader'
+require 'dpl/provider/chef_supermarket'
+
+describe DPL::Provider::ChefSupermarket do
+  subject :provider do
+    described_class.new(
+      DummyContext.new,
+      app: 'example',
+      cookbook_category: 'Others',
+      user_id: 'user',
+      client_key: '/tmp/example.pem'
+    )
+  end
+
+  let(:cookbook_uploader) do
+    double('cookbook_uploader', validate_cookbooks: true)
+  end
+
+  let(:http_resp) do
+    double('http_resp', body: '{}', code: '201')
+  end
+
+  describe "#check_auth" do
+    example do
+      ::File.stub(:exist?).and_return(true)
+      expect(File).to receive(:exist?)
+      provider.check_auth
+    end
+  end
+
+  describe "#check_app" do
+    example do
+      ::Chef::CookbookLoader.any_instance.stub(:[]).and_return nil
+      expect(::Chef::CookbookUploader).to receive(:new).and_return(cookbook_uploader)
+      provider.check_app
+    end
+  end
+
+  describe "#push_app" do
+    example do
+      expect(::Chef::CookbookSiteStreamingUploader).to receive(:create_build_dir).and_return('/tmp/build_dir')
+      expect(provider).to receive(:system).and_return(true)
+      expect(::File).to receive(:open)
+      expect(::Chef::CookbookSiteStreamingUploader).to receive(:post).and_return(http_resp)
+      expect(::FileUtils).to receive(:rm_rf).with('/tmp/build_dir')
+      provider.push_app
+    end
+  end
+end


### PR DESCRIPTION
Upload Chef cookbooks to https://supermarket.getchef.com/

#### Options:

 * **user_id**: Required. The user name at Chef Supermarket.
 * **client_key**: Required. The client API key file name.
 * **cookbook_category**: Required. The cookbook category in Supermarket (see: https://docs.getchef.com/knife_cookbook_site.html#id12 )

#### Examples:

    dpl --provider=chef-supermarket --user-id=chef --client-key=.travis/client.pem --cookbook-category=Others