### PR TITLE
Add packagecloud.io provider

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,3 +63,8 @@ group :puppet_forge do
   gem 'puppet'
   gem 'puppet-blacksmith'
 end
+
+group :packagecloud do
+  gem 'mime'
+  gem 'packagecloud-ruby'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -65,6 +65,5 @@ group :puppet_forge do
 end
 
 group :packagecloud do
-  gem 'mime'
   gem 'packagecloud-ruby'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -65,5 +65,5 @@ group :puppet_forge do
 end
 
 group :packagecloud do
-  gem 'packagecloud-ruby'
+  gem 'packagecloud-ruby', '= 0.2.17'
 end

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Dpl supports the following providers:
 * [Google Cloud Storage](#google-cloud-storage)
 * [Elastic Beanstalk](#elastic-beanstalk)
 * [Puppet Forge](#puppet-forge)
+* [packagecloud](#packagecloud)
 
 ## Installation:
 
@@ -415,3 +416,19 @@ For accounts using two factor authentication, you have to use an oauth token as 
 #### Examples:
 
     dpl --provider=puppetforge --user=puppetlabs --password=s3cr3t
+
+### packagecloud:
+
+#### Options:
+
+ * **username**: Required. The packagecloud.io username.
+ * **token**: Required. The [packagecloud.io api token](https://packagecloud.io/docs/api#api_tokens).
+ * **repository**: Required. The repository to push to.
+ * **local_dir**: Optional. The sub-directory of the built assets for deployment. Default to current path.
+ * **dist**: Required for deb and rpm. The complete list of supported strings can be found on the [packagecloud.io docs](https://packagecloud.io/docs#os_distro_version)
+
+#### Examples:
+
+    dpl --provider=packagecloud --username=packageuser --token=t0k3n --repository=myrepo
+    dpl --provider=packagecloud --username=packageuser --token=t0k3n --repository=myrepo --dist=ubuntu/precise
+    dpl --provider=packagecloud --username=packageuser --token=t0k3n --repository=myrepo --local-dir="${TRAVIS_BUILD_DIR}/pkgs" --dist=ubuntu/precise

--- a/lib/dpl/provider.rb
+++ b/lib/dpl/provider.rb
@@ -34,6 +34,7 @@ module DPL
     autoload :Biicode,      'dpl/provider/biicode'
     autoload :ElasticBeanstalk, 'dpl/provider/elastic_beanstalk'
     autoload :PuppetForge,  'dpl/provider/puppet_forge'
+    autoload :Packagecloud, 'dpl/provider/packagecloud'
 
 
     def self.new(context, options)

--- a/lib/dpl/provider/packagecloud.rb
+++ b/lib/dpl/provider/packagecloud.rb
@@ -1,7 +1,7 @@
 module DPL
   class Provider
     class Packagecloud < Provider
-      requires 'packagecloud-ruby', :version => '~> 0.2', :load => 'packagecloud'
+      requires 'packagecloud-ruby', :version => "0.2.17", :load => 'packagecloud'
 
       def check_auth
         setup_auth

--- a/lib/dpl/provider/packagecloud.rb
+++ b/lib/dpl/provider/packagecloud.rb
@@ -1,0 +1,125 @@
+module DPL
+  class Provider
+    class Packagecloud < Provider
+      requires 'packagecloud-ruby', :version => "0.2.16", :load => 'packagecloud'
+
+      def check_auth
+        setup_auth
+        begin
+          @client = ::Packagecloud::Client.new(@creds, "travis-ci")
+        rescue ::Packagecloud::UnauthenticatedException
+          error "Could not authenticate to https://packagecloud.io, please check credentials"
+        end
+      end
+
+      def needs_key?
+        false
+      end
+
+      def setup_auth
+        @username = option(:username)
+        @token = option(:token)
+        @repo = option(:repository)
+        @dist = option(:dist) if options[:dist]
+        @creds = ::Packagecloud::Credentials.new(@username, @token)
+        log "Logging into https://packagecloud.io with #{@username}:#{@token}"
+      end
+
+      def get_distro(query)
+        distro = nil
+        begin
+          distro = @client.find_distribution_id(query)
+        rescue ArgumentError => exception
+          error "Error: #{exception.message}"
+        end
+        if distro.nil?
+          error "Could not find distribution named #{query}"
+        end
+        distro
+      end
+
+      def is_supported_package?(filename)
+        ext = File.extname(filename).gsub!('.','')
+        ::Packagecloud::SUPPORTED_EXTENSIONS.include?(ext)
+      end
+
+      def dist_required?(filename)
+        ext = File.extname(filename).gsub!('.','')
+        ["rpm", "deb", "dsc"].include?(ext)
+      end
+
+      def error_if_dist_required(filename)
+        ext = File.extname(filename).gsub!('.','')
+        if dist_required?(ext) && @dist.nil?
+          error "Distribution needed for rpm, deb, and dsc packages, example --dist='ubuntu/breezy'"
+        end
+      end
+
+      def is_source_package?(filename)
+        ext = File.extname(filename).gsub!('.','')
+        ext == 'dsc'
+      end
+
+      def get_source_files_for(orig_filename)
+        source_files = {}
+        glob_args = ["**/*"]
+        package = ::Packagecloud::Package.new(open(orig_filename))
+        result = @client.package_contents(@repo, package)
+        if result.succeeded
+          package_contents_files = result.response["files"].map { |x| x["filename"] }
+          Dir.chdir(options.fetch(:local_dir, Dir.pwd)) do
+            Dir.glob(*glob_args) do |filename|
+              unless File.directory?(filename)
+                basename = File.basename(filename)
+                if package_contents_files.include?(basename)
+                  log "Found source fragment: #{basename} for #{orig_filename}"
+                  source_files = source_files.merge({basename => open(filename)})
+                end
+              end
+            end
+          end
+        else
+          error "Error: #{result.response}"
+        end
+        source_files
+      end
+
+      def push_app
+        packages = []
+        glob_args = ["**/*"]
+        Dir.chdir(options.fetch(:local_dir, Dir.pwd)) do
+          Dir.glob(*glob_args) do |filename|
+            unless File.directory?(filename)
+              if is_supported_package?(filename)
+                error_if_dist_required(filename)
+                log "Detected supported package: #{filename}"
+                if dist_required?(filename)
+                  if is_source_package?(filename)
+                    log "Processing source package: #{filename}"
+                    source_files = get_source_files_for(filename)
+                    packages << ::Packagecloud::Package.new(open(filename), get_distro(@dist), source_files, filename)
+                  else
+                    packages << ::Packagecloud::Package.new(open(filename), get_distro(@dist), {}, filename)
+                  end
+                else
+                  packages << ::Packagecloud::Package.new(open(filename), nil, {}, filename)
+                end
+              end
+            end
+          end
+        end
+
+        packages.each do |package|
+          result = @client.put_package(@repo, package)
+          if result.succeeded
+            log "Successfully pushed #{package.filename} to #{@username}/#{@repo}"
+          else
+            error "Error #{result.response}"
+          end
+        end
+      end
+
+    end
+
+  end
+end

--- a/lib/dpl/provider/packagecloud.rb
+++ b/lib/dpl/provider/packagecloud.rb
@@ -1,7 +1,7 @@
 module DPL
   class Provider
     class Packagecloud < Provider
-      requires 'packagecloud-ruby', :version => "0.2.16", :load => 'packagecloud'
+      requires 'packagecloud-ruby', :version => '~> 0.2', :load => 'packagecloud'
 
       def check_auth
         setup_auth

--- a/spec/provider/packagecloud_spec.rb
+++ b/spec/provider/packagecloud_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+require 'rubygems'
+require 'gems'
+require 'dpl/provider/packagecloud'
+
+describe DPL::Provider::Packagecloud do
+
+  subject :provider do
+    described_class.new(DummyContext.new, :username => 'joedamato', :repository => 'test_repo', :token => 'test_token')
+  end
+
+  describe "#setup_auth" do
+    it 'should get username and token' do
+      expect(provider).to receive(:log).with("Logging into https://packagecloud.io with joedamato:test_token")
+      provider.setup_auth
+    end
+
+    it 'should require username' do
+      new_provider = described_class.new(DummyContext.new, {:token => 'test_token'})
+      expect{ new_provider.setup_auth }.to raise_error("missing username")
+    end
+
+    it 'should require token' do
+      new_provider = described_class.new(DummyContext.new, {:username => 'test_token'})
+      expect{ new_provider.setup_auth }.to raise_error("missing token")
+    end
+
+    it 'should require repository' do
+      new_provider = described_class.new(DummyContext.new, {:username => 'joedamato', :token => 'test_token'})
+      expect{ new_provider.setup_auth }.to raise_error("missing repository")
+    end
+
+  end
+
+end


### PR DESCRIPTION
This PR introduces a provider for [packagecloud.io](https://packagecloud.io)

This provider allows users to push their `deb`, `dsc`, `rpm`, or `gem` build objects to their [packagecloud.io](https://packagecloud.io) package repository.

#### Options

  -  username:  the [packagecloud.io](https://packagecloud.io) user name
  -  token: the [packagecloud.io](https://packagecloud.io) API token for the username specified
  -  repository: the name of the [packagecloud.io](https://packagecloud.io) repository
  -  local-dir: the directory where the package objects to push can be found
  -  dist: the distribution string to use. The complete list of supported strings can be found on the [packagecloud.io docs](https://packagecloud.io/docs#os_distro_version)

#### Example

```
dpl --provider=packagecloud
      --username="${PACKAGECLOUD_USERNAME}"
     --token="${PACKAGECLOUD_APITOKEN}"
     --repository="repository-name"
     --local-dir="${TRAVIS_BUILD_DIR}/pkgs"
     --dist=ubuntu/precise
```

