### PR TITLE
Fix Elastic Beanstalk description length

### DIFF
--- a/lib/dpl/provider/elastic_beanstalk.rb
+++ b/lib/dpl/provider/elastic_beanstalk.rb
@@ -94,10 +94,12 @@ module DPL
       end
 
       def create_app_version(s3_object)
+        # Elastic Beanstalk doesn't support descriptions longer than 200 characters
+        description = commit_msg[0, 200]
         options = {
           :application_name  => app_name,
           :version_label     => version_label,
-          :description       => commit_msg,
+          :description       => description,
           :source_bundle     => {
             :s3_bucket => bucket_name,
             :s3_key    => s3_object.key


### PR DESCRIPTION
I've been playing with the Elastic Beanstalk provider and it worked quite well so far. The only issue I've hit is long commit messages. dpl fails with the following error:

```
/home/travis/.rvm/gems/ruby-1.9.3-p551/gems/aws-sdk-v1-1.60.2/lib/aws/core/client.rb:375:in `return_or_raise': 1 validation error detected: Value 'New shiny verison (AWS::ElasticBeanstalk::Errors::ValidationError)
Long description ....
goes here' at 'description' failed to satisfy constraint: Member must have length less than or equal to 200
```

This should fix the issue.
