### PR TITLE
Only use --upload-dir for pypi docs if docs_dir is set. Fixes travis-ci/...

### DIFF
--- a/lib/dpl/provider/pypi.rb
+++ b/lib/dpl/provider/pypi.rb
@@ -65,7 +65,12 @@ module DPL
       def push_app
         context.shell "python setup.py register -r #{options[:server] || 'pypi'}"
         context.shell "python setup.py #{options[:distributions] || 'sdist'} upload -r #{options[:server] || 'pypi'}"
-        context.shell "python setup.py upload_docs --upload-dir #{options[:docs_dir] || 'build/docs'}"
+        if options[:docs_dir]
+          docs_dir_option = '--upload-dir ' + options[:docs_dir]
+        else
+          docs_dir_option = ''
+        end
+        context.shell "python setup.py upload_docs #{docs_dir_option}"
       end
     end
   end

--- a/spec/provider/pypi_spec.rb
+++ b/spec/provider/pypi_spec.rb
@@ -31,7 +31,7 @@ describe DPL::Provider::PyPI do
     example do
       expect(provider.context).to receive(:shell).with("python setup.py register -r pypi")
       expect(provider.context).to receive(:shell).with("python setup.py sdist upload -r pypi")
-      expect(provider.context).to receive(:shell).with("python setup.py upload_docs --upload-dir build/docs")
+      expect(provider.context).to receive(:shell).with("python setup.py upload_docs ")
       provider.push_app
     end
 
@@ -39,7 +39,7 @@ describe DPL::Provider::PyPI do
       provider.options.update(:distributions => 'sdist bdist')
       expect(provider.context).to receive(:shell).with("python setup.py register -r pypi")
       expect(provider.context).to receive(:shell).with("python setup.py sdist bdist upload -r pypi")
-      expect(provider.context).to receive(:shell).with("python setup.py upload_docs --upload-dir build/docs")
+      expect(provider.context).to receive(:shell).with("python setup.py upload_docs ")
       provider.push_app
     end
 
@@ -47,7 +47,7 @@ describe DPL::Provider::PyPI do
       provider.options.update(:server => 'http://blah.com')
       expect(provider.context).to receive(:shell).with("python setup.py register -r http://blah.com")
       expect(provider.context).to receive(:shell).with("python setup.py sdist upload -r http://blah.com")
-      expect(provider.context).to receive(:shell).with("python setup.py upload_docs --upload-dir build/docs")
+      expect(provider.context).to receive(:shell).with("python setup.py upload_docs ")
       provider.push_app
     end
 


### PR DESCRIPTION
travis-ci/travis-ci#2011.

This allows Travis to honor the upload-dir directive in setup.cfg.
This means that standard sphinx docs and pre-generated docs using setup.cfg
will just work out of the box, without special configuration being needed
for Travis.