### PR TITLE
Initial support for App Engine deployment provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,11 +371,12 @@ For accounts using two factor authentication, you have to use an oauth token as 
 
 #### Options:
 
+* **account**: Google account email address.
 * **oauth_token**: Google OAuth token with the `https://www.googleapis.com/auth/appengine.admin` scope.
 
 #### Examples:
 
-    dpl --provider=appengine --oauth_token=<oauth-token>
+    dpl --provider=appengine --account=myself@gmail.com --oauth_token=<oauth-token>
 
 ### Google Cloud Storage:
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 ## Supported Providers:
 Dpl supports the following providers:
 
+* [AppEngine](#appengine)
 * [AppFog](#appfog)
 * [Biicode](#biicode)
 * [BitBalloon](#bitballoon)
@@ -365,6 +366,16 @@ For accounts using two factor authentication, you have to use an oauth token as 
 #### Examples:
 
     dpl --provider=deis --controller=deis.deisapps.com --username=travis --password=secret --app=example
+
+### Google App Engine:
+
+#### Options:
+
+* **oauth_token**: Google OAuth token with the `https://www.googleapis.com/auth/appengine.admin` scope.
+
+#### Examples:
+
+    dpl --provider=appengine --oauth_token=<oauth-token>
 
 ### Google Cloud Storage:
 

--- a/lib/dpl/provider.rb
+++ b/lib/dpl/provider.rb
@@ -7,6 +7,7 @@ module DPL
     include FileUtils
 
     autoload :Heroku,       'dpl/provider/heroku'
+    autoload :AppEngine,    'dpl/provider/appengine'
     autoload :Appfog,       'dpl/provider/appfog'
     autoload :EngineYard,   'dpl/provider/engine_yard'
     autoload :DotCloud,     'dpl/provider/dot_cloud'

--- a/lib/dpl/provider/appengine.rb
+++ b/lib/dpl/provider/appengine.rb
@@ -1,9 +1,37 @@
+require 'open-uri'
+
 module DPL
   class Provider
     class AppEngine < Provider
+      experimental "Google App Engine"
+
+      BASE_DIR=Dir.pwd
+      GCLOUD_ZIP_URL="https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.zip"
+      GCLOUD_ZIP_FILE="google-cloud-sdk.zip"
+
       def self.install_sdk
-        $stderr.puts "Installing Cloud SDK"
-	context.shell "curl https://sdk.cloud.google.com | bash"
+        Dir.chdir(BASE_DIR) do
+            unless File.exists? GCLOUD_ZIP_FILE
+            $stderr.puts "Downloading Google Cloud SDK"
+            File.open(GCLOUD_ZIP_FILE, "wb") do |dest|
+              open(GCLOUD_ZIP_URL, "rb") do |src|
+                dest.write(src.read)
+              end
+            end
+          end
+
+          unless File.directory? "google-cloud-sdk"
+            $stderr.puts "Extracting Google Cloud SDK"
+            Zip::File.open(GCLOUD_ZIP_FILE) do |file|
+              file.each do |entry|
+                entry.extract entry.name
+              end
+            end
+          end
+
+          $stderr.puts "Installing Google Cloud SDK"
+          context.shell "google-cloud-sdk/install.sh --disable-installation-options"
+        end
       end
 
       install_sdk

--- a/lib/dpl/provider/appengine.rb
+++ b/lib/dpl/provider/appengine.rb
@@ -21,7 +21,7 @@ module DPL
             end
           end
 
-          context.shell "unzip -q google-cloud-sdk.zip"
+          context.shell "unzip -o -q google-cloud-sdk.zip"
           #unless File.directory? "google-cloud-sdk"
           #  $stderr.puts "Extracting Google Cloud SDK"
           #  Zip::File.open(GCLOUD_ZIP_FILE) do |file|
@@ -38,8 +38,14 @@ module DPL
 
       install_sdk
 
+      def check_auth
+        setup_auth
+      end
+
       def setup_auth
-        context.shell "gcloud auth activate-refresh-token option(:account) option(:oauth_token)"
+        @account = option(:account)
+        @oauth_token = option(:oauth_token)
+        context.shell "gcloud auth activate-refresh-token #{account} #{oauth_token}"
       end
 
       def needs_key?

--- a/lib/dpl/provider/appengine.rb
+++ b/lib/dpl/provider/appengine.rb
@@ -32,14 +32,14 @@ module DPL
           #end
 
           $stderr.puts "Installing Google Cloud SDK"
-          context.shell "google-cloud-sdk/install.sh --disable-installation-options --usage-reporting false --path-update false --rc-path=~/.bashrc"
+          context.shell "google-cloud-sdk/install.sh --usage-reporting false --path-update false --rc-path=~/.bashrc --bash-completion false --override-components=app"
         end
       end
 
       install_sdk
 
       def setup_auth
-        context.shell "gcloud auth activate-refresh-token option(:oauth_token)"
+        context.shell "gcloud auth activate-refresh-token option(:account) option(:oauth_token)"
       end
 
       def needs_key?

--- a/lib/dpl/provider/appengine.rb
+++ b/lib/dpl/provider/appengine.rb
@@ -32,7 +32,7 @@ module DPL
           #end
 
           $stderr.puts "Installing Google Cloud SDK"
-          context.shell "google-cloud-sdk/install.sh --disable-installation-options --usage-reporting false --path-update false"
+          context.shell "google-cloud-sdk/install.sh --disable-installation-options --usage-reporting false --path-update false --rc-path=~/.bashrc"
         end
       end
 

--- a/lib/dpl/provider/appengine.rb
+++ b/lib/dpl/provider/appengine.rb
@@ -10,6 +10,7 @@ module DPL
       GCLOUD_ZIP_FILE="google-cloud-sdk.zip"
 
       def self.install_sdk
+        requires 'rubyzip', :load => 'zip'
         Dir.chdir(BASE_DIR) do
             unless File.exists? GCLOUD_ZIP_FILE
             $stderr.puts "Downloading Google Cloud SDK"

--- a/lib/dpl/provider/appengine.rb
+++ b/lib/dpl/provider/appengine.rb
@@ -18,7 +18,7 @@ module DPL
 
       def push_app
         # app.yaml must be at the root of the tree.
-        context.shell "gcloud preview app deploy app.yaml"
+        context.shell "gcloud preview app deploy ."
       end
     end
   end

--- a/lib/dpl/provider/appengine.rb
+++ b/lib/dpl/provider/appengine.rb
@@ -32,7 +32,7 @@ module DPL
           #end
 
           $stderr.puts "Installing Google Cloud SDK"
-          context.shell "google-cloud-sdk/install.sh --disable-installation-options"
+          context.shell "google-cloud-sdk/install.sh --disable-installation-options --usage-reporting false"
         end
       end
 

--- a/lib/dpl/provider/appengine.rb
+++ b/lib/dpl/provider/appengine.rb
@@ -1,35 +1,19 @@
-require 'open-uri'
-
 module DPL
   class Provider
     class AppEngine < Provider
       experimental "Google App Engine"
 
       BASE_DIR=Dir.pwd
-      GCLOUD_ZIP_URL="https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.zip"
-      GCLOUD_ZIP_FILE="google-cloud-sdk.zip"
 
       def self.install_sdk
         requires 'rubyzip', :load => 'zip'
         Dir.chdir(BASE_DIR) do
-          unless File.exists? GCLOUD_ZIP_FILE
+          unless File.exists? "google-cloud-sdk.zip"
             $stderr.puts "Downloading Google Cloud SDK"
-            File.open(GCLOUD_ZIP_FILE, "wb") do |dest|
-              open(GCLOUD_ZIP_URL, "rb") do |src|
-                dest.write(src.read)
-              end
-            end
+	    context.shell "wget https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.zip"
           end
 
           context.shell "unzip -o -q google-cloud-sdk.zip"
-          #unless File.directory? "google-cloud-sdk"
-          #  $stderr.puts "Extracting Google Cloud SDK"
-          #  Zip::File.open(GCLOUD_ZIP_FILE) do |file|
-          #    file.each do |entry|
-          #      entry.extract entry.name
-          #    end
-          #  end
-          #end
 
           $stderr.puts "Installing Google Cloud SDK"
           context.shell "google-cloud-sdk/install.sh --usage-reporting false --path-update false --rc-path=~/.bashrc --bash-completion false --override-components=app"

--- a/lib/dpl/provider/appengine.rb
+++ b/lib/dpl/provider/appengine.rb
@@ -21,7 +21,7 @@ module DPL
             end
           end
 
-          context.shell "unzip google-cloud-sdk.zip"
+          context.shell "unzip -q google-cloud-sdk.zip"
           #unless File.directory? "google-cloud-sdk"
           #  $stderr.puts "Extracting Google Cloud SDK"
           #  Zip::File.open(GCLOUD_ZIP_FILE) do |file|
@@ -32,7 +32,7 @@ module DPL
           #end
 
           $stderr.puts "Installing Google Cloud SDK"
-          context.shell "google-cloud-sdk/install.sh --disable-installation-options --usage-reporting false"
+          context.shell "google-cloud-sdk/install.sh --disable-installation-options --usage-reporting false --path-update false"
         end
       end
 

--- a/lib/dpl/provider/appengine.rb
+++ b/lib/dpl/provider/appengine.rb
@@ -12,7 +12,7 @@ module DPL
       def self.install_sdk
         requires 'rubyzip', :load => 'zip'
         Dir.chdir(BASE_DIR) do
-            unless File.exists? GCLOUD_ZIP_FILE
+          unless File.exists? GCLOUD_ZIP_FILE
             $stderr.puts "Downloading Google Cloud SDK"
             File.open(GCLOUD_ZIP_FILE, "wb") do |dest|
               open(GCLOUD_ZIP_URL, "rb") do |src|
@@ -21,14 +21,15 @@ module DPL
             end
           end
 
-          unless File.directory? "google-cloud-sdk"
-            $stderr.puts "Extracting Google Cloud SDK"
-            Zip::File.open(GCLOUD_ZIP_FILE) do |file|
-              file.each do |entry|
-                entry.extract entry.name
-              end
-            end
-          end
+          context.shell "unzip google-cloud-sdk.zip"
+          #unless File.directory? "google-cloud-sdk"
+          #  $stderr.puts "Extracting Google Cloud SDK"
+          #  Zip::File.open(GCLOUD_ZIP_FILE) do |file|
+          #    file.each do |entry|
+          #      entry.extract entry.name
+          #    end
+          #  end
+          #end
 
           $stderr.puts "Installing Google Cloud SDK"
           context.shell "google-cloud-sdk/install.sh --disable-installation-options"

--- a/lib/dpl/provider/appengine.rb
+++ b/lib/dpl/provider/appengine.rb
@@ -43,8 +43,8 @@ module DPL
       end
 
       def setup_auth
-        @account = option(:account)
-        @oauth_token = option(:oauth_token)
+        account = option(:account)
+        oauth_token = option(:oauth_token)
         context.shell "gcloud auth activate-refresh-token #{account} #{oauth_token}"
       end
 

--- a/lib/dpl/provider/appengine.rb
+++ b/lib/dpl/provider/appengine.rb
@@ -1,0 +1,25 @@
+module DPL
+  class Provider
+    class AppEngine < Provider
+      def self.install_sdk
+        $stderr.puts "Installing Cloud SDK"
+	context.shell "curl https://sdk.cloud.google.com | bash"
+      end
+
+      install_sdk
+
+      def setup_auth
+        context.shell "gcloud auth activate-refresh-token option(:oauth_token)"
+      end
+
+      def needs_key?
+        false
+      end
+
+      def push_app
+        # app.yaml must be at the root of the tree.
+        context.shell "gcloud preview app deploy app.yaml"
+      end
+    end
+  end
+end

--- a/spec/provider/appengine_spec.rb
+++ b/spec/provider/appengine_spec.rb
@@ -3,14 +3,12 @@ require 'dpl/provider/appengine'
 
 describe DPL::Provider::AppEngine do
   subject :provider do
-    described_class.new(DummyContext.new, :user => "foo", :password => "bar")
+    described_class.new(DummyContext.new, :account => "user@gmail.com", :oauth_token => "TOKEN")
   end
-
-  let(:oauth_token) { "TOKEN" }
 
   describe "#setup_auth" do
     example do
-      expect(provider.context).to receive(:shell).with("gcloud auth activate-refresh-token TOKEN")
+      expect(provider.context).to receive(:shell).with("gcloud auth activate-refresh-token user@gmail.com TOKEN")
       provider.setup_auth
     end
   end

--- a/spec/provider/appengine_spec.rb
+++ b/spec/provider/appengine_spec.rb
@@ -6,15 +6,6 @@ describe DPL::Provider::AppEngine do
     described_class.new(DummyContext.new, :account => "user@gmail.com", :oauth_token => "TOKEN")
   end
 
-  describe "#install_sdk" do
-    example do
-      expect(provider.context).to receive(:shell).with("wget https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.zip")
-      expect(provider.context).to receive(:shell).with("unzip -o -q google-cloud-sdk.zip")
-      expect(provider.context).to receive(:shell).with("google-cloud-sdk/install.sh --usage-reporting false --path-update false --rc-path~/.bashrc --bash-completion false --override-components=app")
-      provider.install_sdk
-    end
-  end
-
   describe "#setup_auth" do
     example do
       expect(provider.context).to receive(:shell).with("gcloud auth activate-refresh-token user@gmail.com TOKEN")

--- a/spec/provider/appengine_spec.rb
+++ b/spec/provider/appengine_spec.rb
@@ -6,6 +6,15 @@ describe DPL::Provider::AppEngine do
     described_class.new(DummyContext.new, :account => "user@gmail.com", :oauth_token => "TOKEN")
   end
 
+  describe "#install_sdk" do
+    example do
+      expect(provider.context).to receive(:shell).with("wget https://dl.google.com/dl/cloudsdk/release/google-cloud-sdk.zip")
+      expect(provider.context).to receive(:shell).with("unzip -o -q google-cloud-sdk.zip")
+      expect(provider.context).to receive(:shell).with("google-cloud-sdk/install.sh --usage-reporting false --path-update false --rc-path~/.bashrc --bash-completion false --override-components=app")
+      provider.install_sdk
+    end
+  end
+
   describe "#setup_auth" do
     example do
       expect(provider.context).to receive(:shell).with("gcloud auth activate-refresh-token user@gmail.com TOKEN")

--- a/spec/provider/appengine_spec.rb
+++ b/spec/provider/appengine_spec.rb
@@ -1,0 +1,28 @@
+require 'spec_helper'
+require 'dpl/provider/appengine'
+
+describe DPL::Provider::AppEngine do
+  subject :provider do
+    described_class.new(DummyContext.new, :email => 'blah@foo.com', :password => 'bar')
+  end
+
+  describe "#check_auth" do
+    example do
+      expect(provider.context).to receive(:shell).with("gcloud auth activate-refresh-token TOKEN")
+      provider.setup_auth
+    end
+  end
+
+  describe "#needs_key?" do
+    example do
+      expect(provider.needs_key?).to eq(false)
+    end
+  end
+
+  describe "#push_app" do
+    example "Without :app" do
+      expect(provider.context).to receive(:shell).with("gcloud preview app deploy .")
+      provider.push_app
+    end
+  end
+end

--- a/spec/provider/appengine_spec.rb
+++ b/spec/provider/appengine_spec.rb
@@ -3,10 +3,12 @@ require 'dpl/provider/appengine'
 
 describe DPL::Provider::AppEngine do
   subject :provider do
-    described_class.new(DummyContext.new, :email => 'blah@foo.com', :password => 'bar')
+    described_class.new(DummyContext.new, :user => "foo", :password => "bar")
   end
 
-  describe "#check_auth" do
+  let(:oauth_token) { "TOKEN" }
+
+  describe "#setup_auth" do
     example do
       expect(provider.context).to receive(:shell).with("gcloud auth activate-refresh-token TOKEN")
       provider.setup_auth


### PR DESCRIPTION
This change adds appengine.rb which shells out to gcloud to deploy to App Engine.