### PR TITLE
Update deis provider to allow for custom scheme

### DIFF
--- a/lib/dpl/provider/deis.rb
+++ b/lib/dpl/provider/deis.rb
@@ -101,7 +101,11 @@ module DPL
       end
 
       def controller_url
-        "http://#{option(:controller)}"
+        if URI.parse(option(:controller)).scheme
+          "#{option(:controller)}"
+        else
+          "http://#{option(:controller)}"
+        end
       end
     end
   end


### PR DESCRIPTION
Deis client won't follow redirects. This is a problem if you have set up deis to force an https scheme. This allows you to optionally provide a controller scheme. Really trivial change, made the edit live on GitHub so, no tests ran.