### PR TITLE
Skip installing a gem if it's already installed

### DIFF
--- a/lib/dpl/provider.rb
+++ b/lib/dpl/provider.rb
@@ -59,7 +59,7 @@ module DPL
       load    = options[:load]    || name
       gem(name, version)
     rescue LoadError
-      context.shell("gem install %s -v %p --no-ri --no-rdoc #{'--pre' if options[:pre]}" % [name, version], retry: true)
+      context.shell("(gem list %s | grep -q -w %s) || gem install %s -v %p --no-ri --no-rdoc #{'--pre' if options[:pre]}" % [name, name, name, version], retry: true)
       Gem.clear_paths
     ensure
       require load

--- a/spec/provider_spec.rb
+++ b/spec/provider_spec.rb
@@ -31,7 +31,7 @@ describe DPL::Provider do
 
     example "missing" do
       expect(example_provider).to receive(:gem).with("foo", "~> 1.4").and_raise(LoadError)
-      expect(example_provider.context).to receive(:shell).with('gem install foo -v "~> 1.4" --no-ri --no-rdoc ', retry: true)
+      expect(example_provider.context).to receive(:shell).with('(gem list foo | grep -q -w foo) || gem install foo -v "~> 1.4" --no-ri --no-rdoc ', retry: true)
       example_provider.requires("foo", :version => "~> 1.4")
     end
   end


### PR DESCRIPTION
In particular, we should skip 'gem install nokogiri' if
it's already available.