### PR TITLE
PyPI Provider: delete setuptools zip file

### DIFF
--- a/lib/dpl/provider/pypi.rb
+++ b/lib/dpl/provider/pypi.rb
@@ -6,7 +6,7 @@ module DPL
 
       def self.install_setuptools
         shell 'wget https://bitbucket.org/pypa/setuptools/raw/bootstrap/ez_setup.py -O - | sudo python'
-        shell 'rm -f setuptools-*.tar.gz'
+        shell 'rm -f setuptools-*.zip'
       end
 
       def initialize(*args)


### PR DESCRIPTION
ez_setup downloads "setuptools-$VER.zip", *not* "setuptools-$VER.tar.gz", so the file didn't get properly deleted.  This can lead to issues if we're deploying to multiple places (for example, if we deploy to PyPI, and then make a tarball and deploy elsewhere).