### PR TITLE
PyPI: upload_docs to the right server

### DIFF
--- a/lib/dpl/provider/pypi.rb
+++ b/lib/dpl/provider/pypi.rb
@@ -70,7 +70,7 @@ module DPL
         else
           docs_dir_option = ''
         end
-        context.shell "python setup.py upload_docs #{docs_dir_option}"
+        context.shell "python setup.py upload_docs #{docs_dir_option} -r #{options[:server] || 'pypi'}"
       end
     end
   end

--- a/spec/provider/pypi_spec.rb
+++ b/spec/provider/pypi_spec.rb
@@ -31,7 +31,7 @@ describe DPL::Provider::PyPI do
     example do
       expect(provider.context).to receive(:shell).with("python setup.py register -r pypi")
       expect(provider.context).to receive(:shell).with("python setup.py sdist upload -r pypi")
-      expect(provider.context).to receive(:shell).with("python setup.py upload_docs ")
+      expect(provider.context).to receive(:shell).with("python setup.py upload_docs  -r pypi")
       provider.push_app
     end
 
@@ -39,7 +39,7 @@ describe DPL::Provider::PyPI do
       provider.options.update(:distributions => 'sdist bdist')
       expect(provider.context).to receive(:shell).with("python setup.py register -r pypi")
       expect(provider.context).to receive(:shell).with("python setup.py sdist bdist upload -r pypi")
-      expect(provider.context).to receive(:shell).with("python setup.py upload_docs ")
+      expect(provider.context).to receive(:shell).with("python setup.py upload_docs  -r pypi")
       provider.push_app
     end
 
@@ -47,7 +47,7 @@ describe DPL::Provider::PyPI do
       provider.options.update(:server => 'http://blah.com')
       expect(provider.context).to receive(:shell).with("python setup.py register -r http://blah.com")
       expect(provider.context).to receive(:shell).with("python setup.py sdist upload -r http://blah.com")
-      expect(provider.context).to receive(:shell).with("python setup.py upload_docs ")
+      expect(provider.context).to receive(:shell).with("python setup.py upload_docs  -r http://blah.com")
       provider.push_app
     end
 
@@ -55,7 +55,7 @@ describe DPL::Provider::PyPI do
       provider.options.update(:docs_dir => 'some/dir')
       expect(provider.context).to receive(:shell).with("python setup.py register -r pypi")
       expect(provider.context).to receive(:shell).with("python setup.py sdist upload -r pypi")
-      expect(provider.context).to receive(:shell).with("python setup.py upload_docs --upload-dir some/dir")
+      expect(provider.context).to receive(:shell).with("python setup.py upload_docs --upload-dir some/dir -r pypi")
       provider.push_app
     end
   end


### PR DESCRIPTION
Hi there,

Using the pypi deployer. The first commands `setup.py register` and `setup.py sdist upload` work but the third one `setup.py upload_docs` fails with an authentication error. See the last lines of [this Travis job](https://travis-ci.org/jacquev6/LowVoltage/jobs/59508356) and [my .travis.yml file](https://github.com/jacquev6/LowVoltage/blob/master/.travis.yml).

This PR adds the `-r` option to the `upload_docs` command.

Thanks!