### PR TITLE
Make bucket_path option truly optional for elastic beanstalk provider

### DIFF
--- a/lib/dpl/provider/elastic_beanstalk.rb
+++ b/lib/dpl/provider/elastic_beanstalk.rb
@@ -95,11 +95,14 @@ module DPL
 
       def upload(key, file)
         obj = s3.buckets[bucket_name]
+
         if option(:bucket_path)
           option(:bucket_path).gsub!(/\/*$/,'/')
+          obj = obj.objects["#{option(:bucket_path)}#{key}"]
+        else
+          obj = obj.objects[key]
         end
 
-        obj = obj.objects["#{option(:bucket_path)}#{key}"]
         obj.write(Pathname.new(file))
         obj
       end

--- a/lib/dpl/provider/elastic_beanstalk.rb
+++ b/lib/dpl/provider/elastic_beanstalk.rb
@@ -60,6 +60,10 @@ module DPL
         option(:bucket_name)
       end
 
+      def bucket_path
+        @bucket_path ||= option(:bucket_path) ? option(:bucket_path).gsub(/\/*$/,'/') : nil
+      end
+
       def s3
         @s3 ||= AWS::S3.new
       end
@@ -95,14 +99,7 @@ module DPL
 
       def upload(key, file)
         obj = s3.buckets[bucket_name]
-
-        if option(:bucket_path)
-          option(:bucket_path).gsub!(/\/*$/,'/')
-          obj = obj.objects["#{option(:bucket_path)}#{key}"]
-        else
-          obj = obj.objects[key]
-        end
-
+        obj = bucket_path ? obj.objects["#{bucket_path}#{key}"] : obj.objects[key]
         obj.write(Pathname.new(file))
         obj
       end

--- a/lib/dpl/provider/elastic_beanstalk.rb
+++ b/lib/dpl/provider/elastic_beanstalk.rb
@@ -61,7 +61,7 @@ module DPL
       end
 
       def bucket_path
-        @bucket_path ||= option(:bucket_path) ? option(:bucket_path).gsub(/\/*$/,'/') : nil
+        @bucket_path ||= options[:bucket_path] ? option(:bucket_path).gsub(/\/*$/,'/') : nil
       end
 
       def s3

--- a/spec/provider/elastic_beanstalk_spec.rb
+++ b/spec/provider/elastic_beanstalk_spec.rb
@@ -22,6 +22,7 @@ describe DPL::Provider::ElasticBeanstalk do
     allow(dbl).to receive(:objects).and_return(double("Hash", :[] => dbl))
     dbl
   end
+
   let(:s3_mock) do
     hash_dbl = double("Hash", :[] => bucket_mock, :map => [])
     double("AWS::S3", buckets: hash_dbl)
@@ -31,6 +32,13 @@ describe DPL::Provider::ElasticBeanstalk do
     described_class.new(
       DummyContext.new, :access_key_id => access_key_id, :secret_access_key => secret_access_key,
       :region => region, :app => app, :env => env, :bucket_name => bucket_name, :bucket_path => bucket_path
+    )
+  end
+
+  subject :provider_without_bucket_path do
+    described_class.new(
+      DummyContext.new, :access_key_id => access_key_id, :secret_access_key => secret_access_key,
+      :region => region, :app => app, :env => env, :bucket_name => bucket_name
     )
   end
 
@@ -73,6 +81,25 @@ describe DPL::Provider::ElasticBeanstalk do
       expect(provider).to receive(:update_app).with(app_version)
 
       provider.push_app
+    end
+
+    context 'When the bucket_path option is not set' do
+      example 'Does not prepend bucket_path to the s3 bucket' do
+        allow(s3_mock.buckets).to receive(:map).and_return([bucket_name])
+
+        expect(provider_without_bucket_path).to receive(:s3).and_return(s3_mock).twice
+        expect(provider_without_bucket_path).not_to receive(:create_bucket)
+        expect(provider_without_bucket_path).to receive(:create_zip).and_return('/path/to/file.zip')
+        expect(provider_without_bucket_path).to receive(:archive_name).and_return('file.zip')
+        expect(provider_without_bucket_path).to receive(:bucket_path).and_return(nil)
+        expect(bucket_mock.objects).to receive(:[]).with("file.zip").and_return(bucket_mock)
+        expect(provider_without_bucket_path).to receive(:upload).with('file.zip', '/path/to/file.zip').and_call_original
+        expect(provider_without_bucket_path).to receive(:sleep).with(5)
+        expect(provider_without_bucket_path).to receive(:create_app_version).with(bucket_mock).and_return(app_version)
+        expect(provider_without_bucket_path).to receive(:update_app).with(app_version)
+
+        provider_without_bucket_path.push_app
+      end
     end
   end
 end


### PR DESCRIPTION
PR #230 relied on the `#option` method in order to access the value of the `bucket_path` option. Because of this if :bucket_path was left empty or nil the elastic beanstalk provider would error with `Missing bucket_path`. 

Instead add an accessor method for `bucket_path` which allows for :bucket_path to be nil this way if `bucket_path` is not specified deploys still work.