### PR TITLE
Environment variables for Elastic Beanstalk

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,6 +405,12 @@ For accounts using two factor authentication, you have to use an oauth token as 
  * **bucket_name**: Bucket name to upload app to.
  * **bucket_path**: Location within Bucket to upload app to.
 
+#### Environment variables:
+
+ * **ELASTIC_BEANSTALK_ENV**: Elastic Beanstalk environment name which will be updated. Is only used if `env` option is omitted.
+ * **ELASTIC_BEANSTALK_VERSION**: Label name of the new version.
+ * **ELASTIC_BEANSTALK_DESCRIPTION**: Description of the new version. Defaults to the last commit message.
+
 #### Examples:
 
     dpl --provider=elasticbeanstalk --access-key-id=<access-key-id> --secret-access-key="<secret-access-key>" --app="example-app-name" --env="example-app-environment" --region="us-west-2"

--- a/lib/dpl/provider/elastic_beanstalk.rb
+++ b/lib/dpl/provider/elastic_beanstalk.rb
@@ -48,6 +48,10 @@ module DPL
         context.env['ELASTIC_BEANSTALK_LABEL'] || "travis-#{sha}-#{Time.now.to_i}"
       end
 
+      def version_description
+        context.env['ELASTIC_BEANSTALK_DESCRIPTION'] || commit_msg
+      end
+
       def archive_name
         "#{version_label}.zip"
       end
@@ -106,7 +110,7 @@ module DPL
 
       def create_app_version(s3_object)
         # Elastic Beanstalk doesn't support descriptions longer than 200 characters
-        description = commit_msg[0, 200]
+        description = version_description[0, 200]
         options = {
           :application_name  => app_name,
           :version_label     => version_label,

--- a/lib/dpl/provider/elastic_beanstalk.rb
+++ b/lib/dpl/provider/elastic_beanstalk.rb
@@ -41,11 +41,11 @@ module DPL
       end
 
       def env_name
-        option(:env)
+        options[:env] || context.env['ELASTIC_BEANSTALK_ENV']
       end
 
       def version_label
-        "travis-#{sha}-#{Time.now.to_i}"
+        context.env['ELASTIC_BEANSTALK_LABEL'] || "travis-#{sha}-#{Time.now.to_i}"
       end
 
       def archive_name

--- a/lib/dpl/provider/elastic_beanstalk.rb
+++ b/lib/dpl/provider/elastic_beanstalk.rb
@@ -41,7 +41,7 @@ module DPL
       end
 
       def env_name
-        options[:env] || context.env['ELASTIC_BEANSTALK_ENV']
+        options[:env] || context.env['ELASTIC_BEANSTALK_ENV'] || raise(Error, "missing env")
       end
 
       def version_label


### PR DESCRIPTION
* Allow setting the environment name using environment variable `ELASTIC_BEANSTALK_ENV`. Use case: set the env name based on the current branch.
* Allow setting the version label for elastic beanstalk through environment variable `ELASTIC_BEANSTALK_LABEL`. Falls back to travis sha.