### PR TITLE
Use environment variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,11 @@ As a rule of thumb, you should switch to the Git strategy if you run into issues
 
 It is possible to set file-specific `Cache-Control` and `Expires` headers using `value: file[, file]` format.
 
+#### Environment variables:
+
+ * **AWS_ACCESS_KEY_ID**: AWS Access Key ID. Used if the `access-key-id` option is omitted.
+ * **AWS_SECRET_ACCESS_KEY**: AWS Secret Key. Used if the `secret-access-key` option is omitted.
+
 ##### Example:
 
     --cache_control="no-cache: index.html"
@@ -233,6 +238,12 @@ It is possible to set file-specific `Cache-Control` and `Expires` headers using 
 * **app-id**: The app ID.
 * **migrate**: Migrate the database. (Default: false)
 * **wait-until-deployed**: Wait until the app is deployed and return the deployment status. (Default: false)
+
+#### Environment variables:
+
+ * **AWS_ACCESS_KEY_ID**: AWS Access Key ID. Used if the `access-key-id` option is omitted.
+ * **AWS_SECRET_ACCESS_KEY**: AWS Secret Key. Used if the `secret-access-key` option is omitted.
+
 #### Examples:
 
     dpl --provider=opsworks --access-key-id=<access-key-id> --secret-access-key=<secret-access-key> --app-id=<app-id> --migrate --wait-until-deployed
@@ -405,6 +416,11 @@ For accounts using two factor authentication, you have to use an oauth token as 
  * **bucket_name**: Bucket name to upload app to.
  * **bucket_path**: Location within Bucket to upload app to.
 
+#### Environment variables:
+
+ * **AWS_ACCESS_KEY_ID**: AWS Access Key ID. Used if the `access-key-id` option is omitted.
+ * **AWS_SECRET_ACCESS_KEY**: AWS Secret Key. Used if the `secret-access-key` option is omitted.
+
 #### Examples:
 
     dpl --provider=elasticbeanstalk --access-key-id=<access-key-id> --secret-access-key="<secret-access-key>" --app="example-app-name" --env="example-app-environment" --region="us-west-2"
@@ -552,6 +568,11 @@ and your testers can start testing your app.
 * **repository**: Repository Name in case of GitHub.
 * **region**: AWS Availability Zone.
 * **wait-until-deployed**: Wait until the app is deployed and return the deployment status (Optional, Default false).
+
+#### Environment variables:
+
+ * **AWS_ACCESS_KEY_ID**: AWS Access Key ID. Used if the `access-key-id` option is omitted.
+ * **AWS_SECRET_ACCESS_KEY**: AWS Secret Key. Used if the `secret-access-key` option is omitted.
 
 #### Examples:
 

--- a/lib/dpl/provider/code_deploy.rb
+++ b/lib/dpl/provider/code_deploy.rb
@@ -12,10 +12,18 @@ module DPL
       def code_deploy_options
         code_deploy_options = {
           region:      options[:region] || 'us-east-1',
-          credentials: Aws::Credentials.new(option(:access_key_id), option(:secret_access_key))
+          credentials: Aws::Credentials.new(access_key_id, secret_access_key)
         }
         code_deploy_options[:endpoint] = options[:endpoint] if options[:endpoint]
         code_deploy_options
+      end
+
+      def access_key_id
+        options[:access_key_id] || context.env['AWS_ACCESS_KEY_ID'] || raise(Error, "missing access_key_id")
+      end
+
+      def secret_access_key
+        options[:secret_access_key] || context.env['AWS_SECRET_ACCESS_KEY'] || raise(Error, "missing secret_access_key")
       end
 
       def needs_key?

--- a/lib/dpl/provider/elastic_beanstalk.rb
+++ b/lib/dpl/provider/elastic_beanstalk.rb
@@ -12,8 +12,16 @@ module DPL
         false
       end
 
+      def access_key_id
+        options[:access_key_id] || context.env['AWS_ACCESS_KEY_ID'] || raise(Error, "missing access_key_id")
+      end
+
+      def secret_access_key
+        options[:secret_access_key] || context.env['AWS_SECRET_ACCESS_KEY'] || raise(Error, "missing secret_access_key")
+      end
+
       def check_auth
-        AWS.config(access_key_id: option(:access_key_id), secret_access_key: option(:secret_access_key), region: region)
+        AWS.config(access_key_id: access_key_id, secret_access_key: secret_access_key, region: region)
       end
 
       def check_app

--- a/lib/dpl/provider/ops_works.rb
+++ b/lib/dpl/provider/ops_works.rb
@@ -22,8 +22,16 @@ module DPL
 
       end
 
+      def access_key_id
+        options[:access_key_id] || context.env['AWS_ACCESS_KEY_ID'] || raise(Error, "missing access_key_id")
+      end
+
+      def secret_access_key
+        options[:secret_access_key] || context.env['AWS_SECRET_ACCESS_KEY'] || raise(Error, "missing secret_access_key")
+      end
+
       def setup_auth
-        AWS.config(access_key_id: option(:access_key_id), secret_access_key: option(:secret_access_key))
+        AWS.config(access_key_id: access_key_id, secret_access_key: secret_access_key)
       end
 
       def check_auth

--- a/lib/dpl/provider/s3.rb
+++ b/lib/dpl/provider/s3.rb
@@ -18,6 +18,14 @@ module DPL
 
       end
 
+      def access_key_id
+        options[:access_key_id] || context.env['AWS_ACCESS_KEY_ID'] || raise(Error, "missing access_key_id")
+      end
+
+      def secret_access_key
+        options[:secret_access_key] || context.env['AWS_SECRET_ACCESS_KEY'] || raise(Error, "missing secret_access_key")
+      end
+
       def setup_auth
         AWS.config(:access_key_id => option(:access_key_id), :secret_access_key => option(:secret_access_key), :region => options[:region]||'us-east-1')
       end


### PR DESCRIPTION
Try the env variables for AWS authentication if these options aren't set in the configuration.
For CodeDeploy, S3, OpsWorks and ElasticBeanstalk.

These environment variables are also [used by the aws cli app](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#config-settings-and-precedence).

This allows you to define the credentials once in the configuration, while deploying to multiple AWS services and/or using the AWS CLI.