### PR TITLE
Opsworks Provider: added custom json options

### DIFF
--- a/README.md
+++ b/README.md
@@ -329,6 +329,7 @@ It is possible to set file-specific `Cache-Control` and `Expires` headers using 
 * **app-id**: The app ID.
 * **migrate**: Migrate the database. (Default: false)
 * **wait-until-deployed**: Wait until the app is deployed and return the deployment status. (Default: false)
+* **custom_json**: Override custom_json options. If using this, default configuration will be overriden. See the code [here](https://github.com/travis-ci/dpl/blob/master/lib/dpl/provider/ops_works.rb#L34). More about `custom_json` [here](http://docs.aws.amazon.com/opsworks/latest/userguide/workingcookbook-json.html).
 
 #### Environment variables:
 

--- a/lib/dpl/provider/ops_works.rb
+++ b/lib/dpl/provider/ops_works.rb
@@ -40,16 +40,20 @@ module DPL
       end
 
       def custom_json
-        {
-          deploy: {
-            ops_works_app[:shortname] => {
-              migrate: !!options[:migrate],
-              scm: {
-                revision: current_sha
+        if options[:custom_json]
+          options[:custom_json]
+        else
+          {
+            deploy: {
+              ops_works_app[:shortname] => {
+                migrate: !!options[:migrate],
+                scm: {
+                  revision: current_sha
+                }
               }
             }
           }
-        }
+        end
       end
 
       def current_sha
@@ -69,11 +73,11 @@ module DPL
       end
 
       def push_app
-        Timeout::timeout(600) do
+        Timeout::timeout(1200) do
           create_deployment
         end
       rescue Timeout::Error
-        error 'Timeout: Could not finish deployment in 10 minutes.'
+        error 'Timeout: Could not finish deployment in 20 minutes.'
       end
 
       def create_deployment

--- a/lib/dpl/provider/ops_works.rb
+++ b/lib/dpl/provider/ops_works.rb
@@ -40,20 +40,16 @@ module DPL
       end
 
       def custom_json
-        if options[:custom_json]
-          options[:custom_json]
-        else
-          {
-            deploy: {
-              ops_works_app[:shortname] => {
-                migrate: !!options[:migrate],
-                scm: {
-                  revision: current_sha
-                }
+        options[:custom_json] || {
+          deploy: {
+            ops_works_app[:shortname] => {
+              migrate: !!options[:migrate],
+              scm: {
+                revision: current_sha
               }
             }
           }
-        end
+        }
       end
 
       def current_sha

--- a/lib/dpl/provider/ops_works.rb
+++ b/lib/dpl/provider/ops_works.rb
@@ -73,11 +73,11 @@ module DPL
       end
 
       def push_app
-        Timeout::timeout(1200) do
+        Timeout::timeout(600) do
           create_deployment
         end
       rescue Timeout::Error
-        error 'Timeout: Could not finish deployment in 20 minutes.'
+        error 'Timeout: Could not finish deployment in 10 minutes.'
       end
 
       def create_deployment


### PR DESCRIPTION
Added custom_json options. If not set, will fallback to default configuration.
User have responsibility to set the custom_json value by himself. I assumed anyone who wanted to use custom_json already understand how to uses it.

closes #271 