### PR TITLE
Use specific version of aws-sdk for the Lambda provider.

### DIFF
--- a/lib/dpl/provider/lambda.rb
+++ b/lib/dpl/provider/lambda.rb
@@ -5,7 +5,7 @@ require 'fileutils'
 module DPL
   class Provider
     class Lambda < Provider
-      requires 'aws-sdk', pre: true
+      requires 'aws-sdk', version: '2.0.37'
       requires 'rubyzip', load: 'zip'
 
       def lambda
@@ -99,7 +99,7 @@ module DPL
       def check_auth
         log "Using Access Key: #{option(:access_key_id)[-4..-1].rjust(20, '*')}"
       end
- 
+
       def output_file_path
         @output_file_path ||= '/tmp/' + random_chars(8) + '-lambda.zip'
       end

--- a/lib/dpl/version.rb
+++ b/lib/dpl/version.rb
@@ -1,3 +1,3 @@
 module DPL
-  VERSION = '1.7.13'
+  VERSION = '1.7.14'
 end


### PR DESCRIPTION
This commit makes the lambda provider temporarily depend
on 2.0.37. This is because of the fact that when the
provider was implemented Lambda was in preview (version
2014-11-11). Now the Lambda API is at version 2015-03-31.

The new API is different than the old one, which breaks
the provider for this project.

This is a fix so that the existing provider works, but
the provider needs to be updated to conform to the newest
API.
