### PR TITLE
simplify preversion numbering

### DIFF
--- a/dpl.gemspec
+++ b/dpl.gemspec
@@ -24,8 +24,6 @@ Gem::Specification.new do |s|
 
   # prereleases from Travis CI
   if ENV['CI']
-    digits = s.version.to_s.split '.'
-    digits[-1] = digits[-1].to_s.succ
-    s.version = digits.join('.') + ".travis.#{ENV['TRAVIS_JOB_NUMBER']}"
+    s.version = "#{s.versio.succ}.travis.#{ENV['TRAVIS_JOB_NUMBER']}"
   end
 end


### PR DESCRIPTION
`s.version` is a already a String and `succ` works on strings like that: `"1.2.3".succ == "1.2.4"`