### PR TITLE
[packagecloud] Allow users to specify a package_glob we will search.

### DIFF
--- a/lib/dpl/provider/packagecloud.rb
+++ b/lib/dpl/provider/packagecloud.rb
@@ -86,7 +86,7 @@ module DPL
 
       def push_app
         packages = []
-        glob_args = ["**/*"]
+        glob_args = Array(options.fetch(:package_glob, '**/*'))
         Dir.chdir(options.fetch(:local_dir, Dir.pwd)) do
           Dir.glob(*glob_args) do |filename|
             unless File.directory?(filename)

--- a/spec/provider/packagecloud_spec.rb
+++ b/spec/provider/packagecloud_spec.rb
@@ -32,4 +32,25 @@ describe DPL::Provider::Packagecloud do
 
   end
 
+  describe "#push_app" do
+    it 'defaults to searching everywhere' do
+      expect(Dir).to receive(:glob).with('**/*')
+      expect { provider.push_app }.to raise_error(DPL::Error)
+    end
+
+    it 'accepts and uses a string glob' do
+      provider.options.update(:package_glob => 'foo*.gem')
+
+      expect(Dir).to receive(:glob).with('foo*.gem')
+      expect { provider.push_app }.to raise_error(DPL::Error)
+    end
+
+    it 'accepts and uses an array of globs' do
+      provider.options.update(:package_glob => ['*.rpm', '**/*.deb'])
+
+      expect(Dir).to receive(:glob).with('*.rpm', '**/*.deb')
+      expect { provider.push_app }.to raise_error(DPL::Error)
+    end
+  end
+
 end


### PR DESCRIPTION
In some cases, eligible package or package-like objects may be laying
around (particularly .gem files in .bundle/ from a bundler driven test
suite). This allows the user to specify the glob(s) for the paths we
will search rather than a recursive search of everything.

This adds the option package_glob to the provider. It takes a string
or list of strings. It defaults to "**/*" (search everthing for package
files).