### PR TITLE
Don't auto register PyPI releases for less chance of MITM attacks.

### DIFF
--- a/lib/dpl/provider/pypi.rb
+++ b/lib/dpl/provider/pypi.rb
@@ -64,7 +64,6 @@ module DPL
       end
 
       def push_app
-        context.shell "python setup.py register -r #{options[:server] || 'pypi'}"
         context.shell "python setup.py #{options[:distributions] || 'sdist'}"
         context.shell "twine upload -r #{options[:server] || 'pypi'} dist/*"
         context.shell "rm -rf dist/*"

--- a/spec/provider/pypi_spec.rb
+++ b/spec/provider/pypi_spec.rb
@@ -30,7 +30,6 @@ describe DPL::Provider::PyPI do
 
   describe "#push_app" do
     example do
-      expect(provider.context).to receive(:shell).with("python setup.py register -r pypi")
       expect(provider.context).to receive(:shell).with("python setup.py sdist")
       expect(provider.context).to receive(:shell).with("twine upload -r pypi dist/*")
       expect(provider.context).to receive(:shell).with("rm -rf dist/*")
@@ -40,7 +39,6 @@ describe DPL::Provider::PyPI do
 
     example "with :distributions option" do
       provider.options.update(:distributions => 'sdist bdist')
-      expect(provider.context).to receive(:shell).with("python setup.py register -r pypi")
       expect(provider.context).to receive(:shell).with("python setup.py sdist bdist")
       expect(provider.context).to receive(:shell).with("twine upload -r pypi dist/*")
       expect(provider.context).to receive(:shell).with("rm -rf dist/*")
@@ -50,7 +48,6 @@ describe DPL::Provider::PyPI do
 
     example "with :server option" do
       provider.options.update(:server => 'http://blah.com')
-      expect(provider.context).to receive(:shell).with("python setup.py register -r http://blah.com")
       expect(provider.context).to receive(:shell).with("python setup.py sdist")
       expect(provider.context).to receive(:shell).with("twine upload -r http://blah.com dist/*")
       expect(provider.context).to receive(:shell).with("rm -rf dist/*")
@@ -60,7 +57,6 @@ describe DPL::Provider::PyPI do
 
     example "with :docs_dir option" do
       provider.options.update(:docs_dir => 'some/dir')
-      expect(provider.context).to receive(:shell).with("python setup.py register -r pypi")
       expect(provider.context).to receive(:shell).with("python setup.py sdist")
       expect(provider.context).to receive(:shell).with("twine upload -r pypi dist/*")
       expect(provider.context).to receive(:shell).with("rm -rf dist/*")


### PR DESCRIPTION
This is a continuation of #253 and a reaction to the comment from the twine author and PyPI admin @dstufft: https://github.com/travis-ci/dpl/pull/288#discussion_r35265268