### PR TITLE
Allow the protocol of the deis controller to be specified for the deis provider.

### DIFF
--- a/lib/dpl/provider/deis.rb
+++ b/lib/dpl/provider/deis.rb
@@ -101,7 +101,11 @@ module DPL
       end
 
       def controller_url
-        "http://#{option(:controller)}"
+        if option(:controller) =~ /\Ahttp/
+          option(:controller)
+        else
+          "http://#{option(:controller)}"
+        end
       end
     end
   end

--- a/spec/provider/deis_spec.rb
+++ b/spec/provider/deis_spec.rb
@@ -29,6 +29,17 @@ describe DPL::Provider::Deis do
     end
   end
 
+  describe '#controller_url' do
+    example 'no protocol specified' do
+      expect(provider.send(:controller_url)).to eq 'http://deis.deisapps.com'
+    end
+
+    example 'protocol specified' do
+      options[:controller] = 'https://deis.deisapps.com'
+      expect(provider.send(:controller_url)).to eq 'https://deis.deisapps.com'
+    end
+  end
+
   describe "#needs_key?" do
     example do
       expect(provider.needs_key?).to eq(true)


### PR DESCRIPTION
Deis added https support for the control plane several versions ago, and the current provider does not support an https controller. This adds that support while maintaining backwards compatibility.