### PR TITLE
Fix incorrect documentation of ELASTIC_BEANSTALK_LABEL

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,7 +540,7 @@ For accounts using two factor authentication, you have to use an oauth token as 
 #### Environment variables:
 
  * **ELASTIC_BEANSTALK_ENV**: Elastic Beanstalk environment name which will be updated. Is only used if `env` option is omitted.
- * **ELASTIC_BEANSTALK_VERSION**: Label name of the new version.
+ * **ELASTIC_BEANSTALK_LABEL**: Label name of the new version.
  * **ELASTIC_BEANSTALK_DESCRIPTION**: Description of the new version. Defaults to the last commit message.
 
 #### Examples:


### PR DESCRIPTION
This was incorrectly documented as ELASTIC_BEANSTALK_VERSION

Can see the correct variable used in code [here](https://github.com/travis-ci/dpl/blob/master/lib/dpl/provider/elastic_beanstalk.rb#L56)