### PR TITLE
Add Provider for Azure Web Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Dpl supports the following providers:
 * [Anynines](#anynines)
 * [AppFog](#appfog)
 * [Atlas by HashiCorp](#atlas)
+* [Azure Web Apps](#azurewebapps)
 * [Biicode](#biicode)
 * [Bintray](#bintray)
 * [BitBalloon](#bitballoon)
@@ -394,6 +395,25 @@ You first need to create an [Atlas account](https://atlas.hashicorp.com/account/
     dpl --provider=atlas --token=ATLAS_TOKEN --app=ATLAS_USERNAME/APP_NAME --debug --vcs --version
     dpl --provider=atlas --token=ATLAS_TOKEN --app=ATLAS_USERNAME/APP_NAME --exclude="*.log" --include="build/*" --include="bin/*"
     dpl --provider=atlas --token=ATLAS_TOKEN --app=ATLAS_USERNAME/APP_NAME --metadata="foo=bar" --metadata="bar=baz"
+
+### Azure Web Apps:
+
+#### Options:
+
+* **site**: Web App Name (if your app lives at myapp.azurewebsites.net, the name would be myapp).
+* **username**: Web App Deployment Username.
+* **password**: Web App Deployment Password.
+* **quiet**: If passed, Azure's deployment output will not be printed.
+
+#### Environment variables:
+
+ * **AZURE_WA_SITE** Web App Name. Used if the `site` option is omitted.
+ * **AZURE_WA_USERNAME**: Web App Deployment Username. Used if the `username` option is omitted.
+ * **AZURE_WA_PASSWORD**: Web App Deployment Password. Used if the `password` option is omitted.
+
+#### Examples:
+
+    dpl --provider=AzureWebApps --username=depluser --password=deplp@ss --site=dplsite
 
 ### Divshot.io:
 

--- a/lib/dpl/provider.rb
+++ b/lib/dpl/provider.rb
@@ -9,6 +9,7 @@ module DPL
     autoload :Anynines,         'dpl/provider/anynines'
     autoload :Appfog,           'dpl/provider/appfog'
     autoload :Atlas,            'dpl/provider/atlas'
+    autoload :AzureWebApps,     'dpl/provider/azure_webapps'
     autoload :Biicode,          'dpl/provider/biicode'
     autoload :Bintray,          'dpl/provider/bintray'
     autoload :BitBalloon,       'dpl/provider/bitballoon'

--- a/lib/dpl/provider/azure_webapps.rb
+++ b/lib/dpl/provider/azure_webapps.rb
@@ -1,0 +1,40 @@
+module DPL
+  class Provider
+    class AzureWebApps < Provider
+      def config
+        {
+          "username"     => options[:username] || context.env['AZURE_WA_USERNAME'],
+          "password"     => options[:password] || context.env['AZURE_WA_PASSWORD'],
+          "site"         => options[:site] || context.env['AZURE_WA_SITE']
+        }
+      end
+
+      def git_target
+        "https://#{config['username']}:#{config['password']}@#{config['site']}.scm.azurewebsites.net:443/#{config['site']}.git"
+      end
+
+      def needs_key?
+        false
+      end
+
+      def check_app
+      end
+
+      def check_auth
+        error "missing Azure Git Deployment username" unless config['username']
+        error "missing Azure Git Deployment password" unless config['password']
+        error "missing Azure Web App name" unless config['site']
+      end
+
+      def push_app
+        log "Deploying to Azure Web App '#{config['site']}'"
+
+        if !!options[:quiet]
+          context.shell "git push --force --quiet #{git_target} master > /dev/null 2>&1"
+        else
+          context.shell "git push --force --quiet #{git_target} master"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
:wave: from your friendly Microsoft Open Source team! We (and a bunch of our customers) use Travis all the time - and while we have deployments straight from GitHub, deploying only once Travis gave :+1: would be way better. This PR adds a provider for Azure Web Apps.

- Uses Git to deploy the actual files and to print the output of Azure's deployment engine
- Mandatory parameters: `--username`, `--password`, `--site`
- Optional parameter: `--quiet` (don’t print Azure’s deployment output)

Usage
```
dpl --provider=AzureWebApps --username=dpluser --password=deplp@ss --site=dplsite
```

Typical Azure Deployment Output
```
Installing deploy dependencies
Preparing deploy
No local changes to save
Deploying application
Deploying to Azure Web App 'travisdpltest'
remote: Updating branch 'master'.
remote: Updating submodules.
remote: Preparing deployment for commit id '379d7b96bc'.
remote: Generating deployment script.
remote: Running deployment command...
remote: Handling node.js deployment.
remote: KuduSync.NET from: 'D:\home\site\repository' to: 'D:\home\site\wwwroot'
remote: Copying file: 'package.json'
remote: Using start-up script bin/www from package.json.
remote: Generated web.config.
remote: The package.json file does not specify node.js engine version constraints.
remote: The node.js application will run with the default node.js version 0.10.32.
remote: Finished successfully.
remote: Deployment successful.
```