### PR TITLE
Fix: SSL validation issue when deploying to Cloud Foundry

### DIFF
--- a/lib/dpl/provider/cloud_foundry.rb
+++ b/lib/dpl/provider/cloud_foundry.rb
@@ -9,8 +9,8 @@ module DPL
 
       def check_auth
         initial_go_tools_install
-        context.shell "cf api #{option(:api)}"
-        context.shell "cf login --u #{option(:username)} --p #{option(:password)} --o #{option(:organization)} --s #{option(:space)} #{'--skip-ssl-validation' if options[:skip_ssl_validation]}"
+        context.shell "cf api #{option(:api)} #{'--skip-ssl-validation' if options[:skip_ssl_validation]}"
+        context.shell "cf login --u #{option(:username)} --p #{option(:password)} --o #{option(:organization)} --s #{option(:space)}"
       end
 
       def check_app

--- a/spec/provider/cloudfoundry_spec.rb
+++ b/spec/provider/cloudfoundry_spec.rb
@@ -15,8 +15,8 @@ describe DPL::Provider::CloudFoundry do
     example do
       expect(provider.context).to receive(:shell).with('wget http://go-cli.s3-website-us-east-1.amazonaws.com/releases/latest/cf-cli_amd64.deb -qO temp.deb && sudo dpkg -i temp.deb')
       expect(provider.context).to receive(:shell).with('rm temp.deb')
-      expect(provider.context).to receive(:shell).with('cf api api.run.awesome.io')
-      expect(provider.context).to receive(:shell).with('cf login --u mallomar --p myreallyawesomepassword --o myorg --s outer --skip-ssl-validation')
+      expect(provider.context).to receive(:shell).with('cf api api.run.awesome.io --skip-ssl-validation')
+      expect(provider.context).to receive(:shell).with('cf login --u mallomar --p myreallyawesomepassword --o myorg --s outer')
       provider.check_auth
     end
   end


### PR DESCRIPTION
We need to pass --skip-ssl-validation when we set the API endpoint, not to the login command