### PR TITLE
Feature: Update Cloud Foundry provider for container-based infrastructure

### DIFF
--- a/lib/dpl/provider/cloud_foundry.rb
+++ b/lib/dpl/provider/cloud_foundry.rb
@@ -3,14 +3,13 @@ module DPL
     class CloudFoundry < Provider
 
       def initial_go_tools_install
-        context.shell 'wget http://go-cli.s3-website-us-east-1.amazonaws.com/releases/latest/cf-cli_amd64.deb -qO temp.deb && sudo dpkg -i temp.deb'
-        context.shell 'rm temp.deb'
+        context.shell 'wget http://go-cli.s3-website-us-east-1.amazonaws.com/releases/latest/cf-linux-amd64.tgz -qO cf-linux-amd64.tgz && tar -zxvf cf-linux-amd64.tgz && rm cf-linux-amd64.tgz'
       end
 
       def check_auth
         initial_go_tools_install
-        context.shell "cf api #{option(:api)} #{'--skip-ssl-validation' if options[:skip_ssl_validation]}"
-        context.shell "cf login --u #{option(:username)} --p #{option(:password)} --o #{option(:organization)} --s #{option(:space)}"
+        context.shell "./cf api #{option(:api)} #{'--skip-ssl-validation' if options[:skip_ssl_validation]}"
+        context.shell "./cf login --u #{option(:username)} --p #{option(:password)} --o #{option(:organization)} --s #{option(:space)}"
       end
 
       def check_app
@@ -24,8 +23,8 @@ module DPL
       end
 
       def push_app
-        context.shell "cf push#{manifest}"
-        context.shell "cf logout"
+        context.shell "./cf push#{manifest}"
+        context.shell "./cf logout"
       end
 
       def cleanup

--- a/spec/provider/cloudfoundry_spec.rb
+++ b/spec/provider/cloudfoundry_spec.rb
@@ -13,10 +13,9 @@ describe DPL::Provider::CloudFoundry do
 
   describe "#check_auth" do
     example do
-      expect(provider.context).to receive(:shell).with('wget http://go-cli.s3-website-us-east-1.amazonaws.com/releases/latest/cf-cli_amd64.deb -qO temp.deb && sudo dpkg -i temp.deb')
-      expect(provider.context).to receive(:shell).with('rm temp.deb')
-      expect(provider.context).to receive(:shell).with('cf api api.run.awesome.io --skip-ssl-validation')
-      expect(provider.context).to receive(:shell).with('cf login --u mallomar --p myreallyawesomepassword --o myorg --s outer')
+      expect(provider.context).to receive(:shell).with('wget http://go-cli.s3-website-us-east-1.amazonaws.com/releases/latest/cf-linux-amd64.tgz -qO cf-linux-amd64.tgz && tar -zxvf cf-linux-amd64.tgz && rm cf-linux-amd64.tgz')
+      expect(provider.context).to receive(:shell).with('./cf api api.run.awesome.io --skip-ssl-validation')
+      expect(provider.context).to receive(:shell).with('./cf login --u mallomar --p myreallyawesomepassword --o myorg --s outer')
       provider.check_auth
     end
   end
@@ -45,15 +44,15 @@ describe DPL::Provider::CloudFoundry do
 
   describe "#push_app" do
     example "With manifest" do
-      expect(provider.context).to receive(:shell).with('cf push -f worker-manifest.yml')
-      expect(provider.context).to receive(:shell).with('cf logout')
+      expect(provider.context).to receive(:shell).with('./cf push -f worker-manifest.yml')
+      expect(provider.context).to receive(:shell).with('./cf logout')
       provider.push_app
     end
 
     example "Without manifest" do
       provider.options.update(:manifest => nil)
-      expect(provider.context).to receive(:shell).with('cf push')
-      expect(provider.context).to receive(:shell).with('cf logout')
+      expect(provider.context).to receive(:shell).with('./cf push')
+      expect(provider.context).to receive(:shell).with('./cf logout')
       provider.push_app
     end
   end


### PR DESCRIPTION
Change the way we download, install en run the CF CLI so we can run this on the container-based infrastructure