### PR TITLE
Boxfuse provider: Fixed image/version paramater swap

### DIFF
--- a/lib/dpl/provider/boxfuse.rb
+++ b/lib/dpl/provider/boxfuse.rb
@@ -8,7 +8,7 @@ module DPL
         @configfile = options[:configfile]
         @payload = options[:payload]
         @app = options[:app]
-        @version = options[:version]
+        @image = options[:image]
         @env = options[:env]
 
         @param_user = ''
@@ -36,12 +36,12 @@ module DPL
           @param_app = " -app=" + @app
         end
 
-        @param_version = ''
-        if @version.to_s != ''
-          @param_version = " -version=" + @version
+        @param_image = ''
+        if @image.to_s != ''
+          @param_image = " -image=" + @image
         end
 
-        @param_env = ''
+        @param_env = 'test'
         if @env.to_s != ''
           @param_env = " -env=" + @env
         end

--- a/lib/dpl/provider/boxfuse.rb
+++ b/lib/dpl/provider/boxfuse.rb
@@ -41,14 +41,14 @@ module DPL
           @param_image = " -image=" + @image
         end
 
-        @param_env = 'test'
+        @param_env = ' test'
         if @env.to_s != ''
           @param_env = " -env=" + @env
         end
 
         context.shell "curl -L https://files.boxfuse.com/com/boxfuse/client/boxfuse-commandline/latest/boxfuse-commandline-latest-linux-x64.tar.gz | tar xz"
 
-        @command = "boxfuse/boxfuse run" + @param_user + @param_secret + @param_configfile + @param_payload + @param_app + @param_version + @param_env
+        @command = "boxfuse/boxfuse run" + @param_user + @param_secret + @param_configfile + @param_payload + @param_app + @param_image + @param_env
         context.fold("Deploying application") { context.shell @command }
       end
 

--- a/spec/provider/boxfuse_spec.rb
+++ b/spec/provider/boxfuse_spec.rb
@@ -9,7 +9,7 @@ describe DPL::Provider::Boxfuse do
   describe "#deploy" do
     example do
       expect(provider.context).to receive(:shell).with('curl -L https://files.boxfuse.com/com/boxfuse/client/boxfuse-commandline/latest/boxfuse-commandline-latest-linux-x64.tar.gz | tar xz')
-      expect(provider.context).to receive(:shell).with('boxfuse/boxfuse run -user=dummyuser -image=abc:123')
+      expect(provider.context).to receive(:shell).with('boxfuse/boxfuse run -user=dummyuser -image=abc:123 test')
       provider.deploy
     end
   end

--- a/spec/provider/boxfuse_spec.rb
+++ b/spec/provider/boxfuse_spec.rb
@@ -3,13 +3,13 @@ require 'dpl/provider/boxfuse'
 
 describe DPL::Provider::Boxfuse do
   subject :provider do
-    described_class.new(DummyContext.new, :user => 'dummyuser')
+    described_class.new(DummyContext.new, :user => 'dummyuser', :image => 'abc:123')
   end
 
   describe "#deploy" do
     example do
       expect(provider.context).to receive(:shell).with('curl -L https://files.boxfuse.com/com/boxfuse/client/boxfuse-commandline/latest/boxfuse-commandline-latest-linux-x64.tar.gz | tar xz')
-      expect(provider.context).to receive(:shell).with('boxfuse/boxfuse run -user=dummyuser')
+      expect(provider.context).to receive(:shell).with('boxfuse/boxfuse run -user=dummyuser -image=abc:123')
       provider.deploy
     end
   end


### PR DESCRIPTION
This fixes a bug in the previous PR.