### PR TITLE
Azure Provider: Change from opt-out 'quiet' to opt-in 'verbose'

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ You first need to create an [Atlas account](https://atlas.hashicorp.com/account/
 * **site**: Web App Name (if your app lives at myapp.azurewebsites.net, the name would be myapp).
 * **username**: Web App Deployment Username.
 * **password**: Web App Deployment Password.
-* **quiet**: If passed, Azure's deployment output will not be printed.
+* **verbose**: If passed, Azure's deployment output will be printed. Warning: If you provide incorrect credentials, Git will print those in clear text. Correct authentication credentials will remain hidden.
 
 #### Environment variables:
 
@@ -448,7 +448,7 @@ You first need to create an [Atlas account](https://atlas.hashicorp.com/account/
 
 #### Examples:
 
-    dpl --provider=AzureWebApps --username=depluser --password=deplp@ss --site=dplsite
+    dpl --provider=AzureWebApps --username=depluser --password=deplp@ss --site=dplsite --verbose
 
 ### Divshot.io:
 

--- a/lib/dpl/provider/azure_webapps.rb
+++ b/lib/dpl/provider/azure_webapps.rb
@@ -29,10 +29,10 @@ module DPL
       def push_app
         log "Deploying to Azure Web App '#{config['site']}'"
 
-        if !!options[:quiet]
-          context.shell "git push --force --quiet #{git_target} master > /dev/null 2>&1"
-        else
+        if !!options[:verbose]
           context.shell "git push --force --quiet #{git_target} master"
+        else
+          context.shell "git push --force --quiet #{git_target} master > /dev/null 2>&1"
         end
       end
     end


### PR DESCRIPTION
If users provide incorrect credentials, `git push` will print the given password cleartext. This PR changes from an optional 'quiet' mode to an opt-in verbose mode, triggered by passing the 'verbose' option.