### PR TITLE
Deis: prevents Deis client to be cleaned

### DIFF
--- a/lib/dpl/provider/deis.rb
+++ b/lib/dpl/provider/deis.rb
@@ -63,6 +63,13 @@ module DPL
           error 'Running command failed.'
         end
       end
+
+      def cleanup
+        return if options[:skip_cleanup]
+        context.shell "mv deis ~/deis"
+        super
+        context.shell "mv ~/deis deis"
+      end
     end
   end
 end

--- a/spec/provider/deis_spec.rb
+++ b/spec/provider/deis_spec.rb
@@ -97,4 +97,15 @@ describe DPL::Provider::Deis do
       provider.run('shell command')
     end
   end
+
+  describe "#cleanup" do
+    example do
+      expect(provider.context).to receive(:shell).with('mv deis ~/deis')
+      expect(provider.context).to receive(:shell).with('mv .dpl ~/dpl')
+      expect(provider.context).to receive(:shell).with('git stash --all')
+      expect(provider.context).to receive(:shell).with('mv ~/dpl .dpl')
+      expect(provider.context).to receive(:shell).with('mv ~/deis deis')
+      provider.cleanup
+    end
+  end
 end


### PR DESCRIPTION
Deis provider installs `./deis` client and use it for add/remove SSH keys. In `deploy` task, provider [cleanup](https://github.com/travis-ci/dpl/blob/master/lib/dpl/provider.rb#L140) the working directory and so remove the deis client.
Later [`remove_key`](https://github.com/travis-ci/dpl/blob/master/lib/dpl/provider.rb#L154) silently fails due to missing executable.
This PR overwrite default `cleanup` for backup deis client before `git stash --all` executed by default [cleanup](https://github.com/travis-ci/dpl/blob/master/lib/dpl/provider.rb#L170).
I didn't write tests because I have no idea how to test that.