### PR TITLE
gae: Adapt to gcloud-0.9.80

### DIFF
--- a/README.md
+++ b/README.md
@@ -782,9 +782,10 @@ it's [`gcloud` tool](https://cloud.google.com/sdk/gcloud/) using a [Service Acco
 * **keyfile**: Path to the JSON file containing your [Service Account](https://developers.google.com/console/help/new/#serviceaccounts) credentials in [JSON Web Token](https://tools.ietf.org/html/rfc7519) format. To be obtained via the [Google Developers Console](https://console.developers.google.com/project/_/apiui/credential). Defaults to `"service-account.json"`. Note that this file should be handled with care as it contains authorization keys.
 * **config**: Path to your module configuration file. Defaults to `"app.yaml"`. This file is runtime dependent ([Go](https://cloud.google.com/appengine/docs/go/config/appconfig), [Java](https://cloud.google.com/appengine/docs/java/configyaml/appconfig_yaml), [PHP](https://developers.google.com/console/help/new/#projectnumber), [Python](https://cloud.google.com/appengine/docs/python/config/appconfig))
 * **version**: The version of the app that will be created or replaced by this deployment. If you do not specify a version, one will be generated for you. See [`gcloud preview app deploy`](https://cloud.google.com/sdk/gcloud/reference/preview/app/deploy)
-* **default**: Flag to set the deployed version to be the default serving version. See [`gcloud preview app deploy`](https://cloud.google.com/sdk/gcloud/reference/preview/app/deploy)
+* **no_promote**: Flag to not promote the deployed version. See [`gcloud preview app deploy`](https://cloud.google.com/sdk/gcloud/reference/preview/app/deploy)
 * **verbosity**: Let's you adjust the verbosity when invoking `"gcloud"`. Defaults to `"warning"`. See [`gcloud`](https://cloud.google.com/sdk/gcloud/reference/).
 * **docker_build**: If deploying a Managed VM, specifies where to build your image. Typical values are `"remote"` to build on Google Cloud Engine and `"local"` which requires Docker to be set up properly (to utilize this on Travis CI, read [Using Docker on Travis CI](http://blog.travis-ci.com/2015-08-19-using-docker-on-travis-ci/)). Defaults to `"remote"`.
+* **no_stop_previous_version**: Flag to prevent your deployment from stopping the previously promoted version. This is from the future, so might not work (yet). See [`gcloud preview app deploy`](https://cloud.google.com/sdk/gcloud/reference/preview/app/deploy)
 
 #### Environment variables:
 

--- a/lib/dpl/provider/gae.rb
+++ b/lib/dpl/provider/gae.rb
@@ -54,8 +54,8 @@ module DPL
         options[:config] || 'app.yaml'
       end
 
-      def default
-        options[:default]
+      def no_promote
+        options[:no_promote]
       end
 
       def verbosity
@@ -66,6 +66,10 @@ module DPL
         options[:docker_build] || 'remote'
       end
 
+      def no_stop_previous_version
+          options[:no_stop_previous_version]
+      end
+
       def push_app
         command = GCLOUD
         command << ' --quiet'
@@ -74,7 +78,8 @@ module DPL
         command << " preview app deploy \"#{config}\""
         command << " --version \"#{version}\""
         command << " --docker-build \"#{docker_build}\""
-        command << (default ? ' --set-default' : '')
+        command << " --#{no_promote ? 'no-' : ''}promote"
+        command << (no_stop_previous_version ? '--no-stop-previous-version' : '')
         unless context.shell(command)
           error 'Deployment failed.'
         end

--- a/spec/provider/gae_spec.rb
+++ b/spec/provider/gae_spec.rb
@@ -8,7 +8,7 @@ describe DPL::Provider::GAE do
 
   describe '#push_app' do
     example 'with defaults' do
-      expect(provider.context).to receive(:shell).with("#{DPL::Provider::GAE::GCLOUD} --quiet --verbosity \"warning\" --project \"test\" preview app deploy \"app.yaml\" --version \"\" --docker-build \"remote\"").and_return(true)
+      expect(provider.context).to receive(:shell).with("#{DPL::Provider::GAE::GCLOUD} --quiet --verbosity \"warning\" --project \"test\" preview app deploy \"app.yaml\" --version \"\" --docker-build \"remote\" --promote").and_return(true)
       provider.push_app
     end
   end


### PR DESCRIPTION
The new gcloud version deprecates --set-default and introduces --promote (and --no-promote for transition, apparently). This is reflected in the options to the provider. There is no smooth transition from 'default' to 'no_promote' as the provider is experimental.

Also, the release notes hint that --no-stop-previous-version will become available as soon as --promote kicks in. This is also exposed as an option.

See https://dl.google.com/dl/cloudsdk/release/RELEASE_NOTES