### PR TITLE
npm provider strips custom registry protocol

### DIFF
--- a/lib/dpl/provider/npm.rb
+++ b/lib/dpl/provider/npm.rb
@@ -1,4 +1,5 @@
 require 'json'
+require 'uri'
 
 module DPL
   class Provider
@@ -36,7 +37,7 @@ module DPL
         if File.exists?('package.json')
           data = JSON.parse(File.read('package.json'))
           if data['publishConfig'] && data['publishConfig']['registry']
-            return data['publishConfig']['registry']
+            return URI(data['publishConfig']['registry']).host
           end
         end
 
@@ -48,7 +49,7 @@ module DPL
         if npm_version =~ /^1/
           "_auth = ${NPM_API_KEY}\nemail = #{option(:email)}"
         else
-          "//#{package_registry.gsub(/\/+$/,'')}/:_authToken=${NPM_API_KEY}"
+          "//#{package_registry}/:_authToken=${NPM_API_KEY}"
         end
       end
 

--- a/spec/provider/npm_spec.rb
+++ b/spec/provider/npm_spec.rb
@@ -46,7 +46,8 @@ describe DPL::Provider::NPM do
   end
 
   context 'when package.json exists' do
-    let(:custom_rpm_registry) { 'npm.example.com' }
+    let(:host) { 'npm.example.com' }
+    let(:custom_rpm_registry) { 'https://' + host }
     before :each do
       expect(File).to receive(:exists?).with('package.json').and_return(true)
     end
@@ -56,14 +57,14 @@ describe DPL::Provider::NPM do
 
       describe '#setup_auth' do
         example do
-          test_setup_auth(custom_rpm_registry)
+          test_setup_auth(host)
         end
       end
     end
 
     context 'and it defines custom RPM registry with trailing slash' do
-      let(:host) { 'npm.example.com'}
-      let(:custom_rpm_registry) { host + '/' }
+      let(:host) { 'npm.example.com' }
+      let(:custom_rpm_registry) { 'https://' + host + '/' }
       before { expect(File).to receive(:read).with('package.json').and_return("{\"publishConfig\":{\"registry\":\"#{custom_rpm_registry}\"}}") }
 
       describe '#setup_auth' do


### PR DESCRIPTION
@BanzaiMan sorry I dropped off the radar on helping with npm2 support (this is related to #309).

The npm provider still seems broken when using npm 2.  `publishConfig.registry` (and npm in general) expects you to include a protocol on your registry address, but that protocol should be stripped in the `.npmrc`.  This PR addresses that.
