### PR TITLE
Support disabling upload_docs in pypi provider

### DIFF
--- a/lib/dpl/provider/pypi.rb
+++ b/lib/dpl/provider/pypi.rb
@@ -71,12 +71,14 @@ module DPL
         context.shell "python setup.py #{options[:distributions] || 'sdist'}"
         context.shell "twine upload -r pypi dist/*"
         context.shell "rm -rf dist/*"
-        if options[:docs_dir]
-          docs_dir_option = '--upload-dir ' + options[:docs_dir]
-        else
-          docs_dir_option = ''
+        if options.fetch(:upload_docs, true)
+          if options[:docs_dir]
+            docs_dir_option = '--upload-dir ' + options[:docs_dir]
+          else
+            docs_dir_option = ''
+          end
+          context.shell "python setup.py upload_docs #{docs_dir_option} -r #{options[:server] || 'pypi'}"
         end
-        context.shell "python setup.py upload_docs #{docs_dir_option} -r #{options[:server] || 'pypi'}"
       end
     end
   end

--- a/spec/provider/pypi_spec.rb
+++ b/spec/provider/pypi_spec.rb
@@ -62,6 +62,14 @@ describe DPL::Provider::PyPI do
       expect(provider.context).to receive(:shell).with("python setup.py upload_docs --upload-dir some/dir -r pypi")
       provider.push_app
     end
+
+    example "with :upload_docs false option" do
+      provider.options.update(:upload_docs => false)
+      expect(provider.context).to receive(:shell).with("python setup.py sdist")
+      expect(provider.context).to receive(:shell).with("twine upload -r pypi dist/*")
+      expect(provider.context).to receive(:shell).with("rm -rf dist/*")
+      provider.push_app
+    end
   end
 
   describe "#write_servers" do


### PR DESCRIPTION
Handle a new configuration option called 'upload_docs' (default to true), that allows you to disable `python setup.py upload_docs`, as some pypi implementations don't support it (see pypicloud).
