### PR TITLE
Implement slot support for azure web apps deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,12 +444,13 @@ You first need to create an [Atlas account](https://atlas.hashicorp.com/account/
 #### Environment variables:
 
  * **AZURE_WA_SITE** Web App Name. Used if the `site` option is omitted.
+ * **AZURE_WA_SLOT** Optional. Slot name if your app uses staging deployment. Used if the `slot` option is omitted.
  * **AZURE_WA_USERNAME**: Web App Deployment Username. Used if the `username` option is omitted.
  * **AZURE_WA_PASSWORD**: Web App Deployment Password. Used if the `password` option is omitted.
 
 #### Examples:
 
-    dpl --provider=AzureWebApps --username=depluser --password=deplp@ss --site=dplsite --verbose
+    dpl --provider=AzureWebApps --username=depluser --password=deplp@ss --site=dplsite --slot=dplsite-test --verbose
 
 ### Divshot.io:
 

--- a/README.md
+++ b/README.md
@@ -436,6 +436,7 @@ You first need to create an [Atlas account](https://atlas.hashicorp.com/account/
 #### Options:
 
 * **site**: Web App Name (if your app lives at myapp.azurewebsites.net, the name would be myapp).
+* **slot**: Optional. Slot name if your app uses staging deployment. (e.g. if your slot lives at myapp-test.azurewebsites.net, the slot would be myapp-test).
 * **username**: Web App Deployment Username.
 * **password**: Web App Deployment Password.
 * **verbose**: If passed, Azure's deployment output will be printed. Warning: If you provide incorrect credentials, Git will print those in clear text. Correct authentication credentials will remain hidden.

--- a/lib/dpl/provider/azure_webapps.rb
+++ b/lib/dpl/provider/azure_webapps.rb
@@ -28,7 +28,7 @@ module DPL
       end
 
       def push_app
-        log "Deploying to Azure Web App '#{config['site']}'"
+        log "Deploying to Azure Web App '#{config[slot] || config['site']}'"
 
         if !!options[:verbose]
           context.shell "git push --force --quiet #{git_target} master"

--- a/lib/dpl/provider/azure_webapps.rb
+++ b/lib/dpl/provider/azure_webapps.rb
@@ -5,12 +5,13 @@ module DPL
         {
           "username"     => options[:username] || context.env['AZURE_WA_USERNAME'],
           "password"     => options[:password] || context.env['AZURE_WA_PASSWORD'],
-          "site"         => options[:site] || context.env['AZURE_WA_SITE']
+          "site"         => options[:site] || context.env['AZURE_WA_SITE'],
+          "slot"         => options[:slot] || context.env['AZURE_WA_SLOT']
         }
       end
 
       def git_target
-        "https://#{config['username']}:#{config['password']}@#{config['site']}.scm.azurewebsites.net:443/#{config['site']}.git"
+        "https://#{config['username']}:#{config['password']}@#{config['slot'] || config['site']}.scm.azurewebsites.net:443/#{config['site']}.git"
       end
 
       def needs_key?

--- a/lib/dpl/provider/azure_webapps.rb
+++ b/lib/dpl/provider/azure_webapps.rb
@@ -28,7 +28,7 @@ module DPL
       end
 
       def push_app
-        log "Deploying to Azure Web App '#{config[slot] || config['site']}'"
+        log "Deploying to Azure Web App '#{config['slot'] || config['site']}'"
 
         if !!options[:verbose]
           context.shell "git push --force --quiet #{git_target} master"


### PR DESCRIPTION
Azure uses different git url format for slot deployment (implemented in this PR):
```
https://{SLOT}.scm.azurewebsites.net:443/{SITE}.git
```

If **slot** config is not passed then the git url stays the same as it was previously:
```
https://{SITE}.scm.azurewebsites.net:443/{SITE}.git
```

This is not a breaking-change!

More about staging development in azure [read here](https://azure.microsoft.com/en-us/documentation/articles/web-sites-staged-publishing/).
Sorry but I don't have any build links to show since I'm using this provider only in private project...