### PR TITLE
Fixes #207 Modulus deploys failing without error

### DIFF
--- a/lib/dpl/provider/modulus.rb
+++ b/lib/dpl/provider/modulus.rb
@@ -16,7 +16,7 @@ module DPL
       end
 
       def push_app
-        context.shell "MODULUS_TOKEN=#{option(:api_key)} modulus deploy -p #{option(:project_name)}"
+        context.shell "env MODULUS_TOKEN=#{option(:api_key)} modulus deploy -p #{option(:project_name)}"
       end
     end
   end

--- a/spec/provider/modulus_spec.rb
+++ b/spec/provider/modulus_spec.rb
@@ -22,7 +22,7 @@ describe DPL::Provider::Modulus do
 
   describe "#push_app" do
     it 'should include the api key and project name specified' do
-      expect(provider.context).to receive(:shell).with("MODULUS_TOKEN=test-token modulus deploy -p test-project")
+      expect(provider.context).to receive(:shell).with("env MODULUS_TOKEN=test-token modulus deploy -p test-project")
       provider.push_app
     end
   end


### PR DESCRIPTION
The command was not setting the ENV variable for MODULUS_TOKEN and was
failing with an exit status of 127.