### PR TITLE
Pin mime-types to 2.x for mri 1.9

### DIFF
--- a/lib/dpl/provider/gcs.rb
+++ b/lib/dpl/provider/gcs.rb
@@ -4,7 +4,7 @@ module DPL
   class Provider
     class GCS < Provider
       requires 'gstore'
-      requires 'mime-types'
+      requires 'mime-types', version: '~> 2.0'
 
       def needs_key?
         false

--- a/lib/dpl/provider/s3.rb
+++ b/lib/dpl/provider/s3.rb
@@ -4,7 +4,7 @@ module DPL
   class Provider
     class S3 < Provider
       requires 'aws-sdk', version: '>= 2.0.22'
-      requires 'mime-types'
+      requires 'mime-types', version: '~> 2.0'
 
       def api
         @api ||= ::Aws::S3::Resource.new(s3_options)


### PR DESCRIPTION
Upgrading to mri 2.x would be preferrable, but in the meantime, this should help stop the bleeding on https://github.com/travis-ci/travis-ci/issues/5145