### PR TITLE
lock down to 2.6.2 to keep rvm 1.9 compatible

### DIFF
--- a/lib/dpl/provider/s3.rb
+++ b/lib/dpl/provider/s3.rb
@@ -4,7 +4,7 @@ module DPL
   class Provider
     class S3 < Provider
       requires 'aws-sdk', version: '>= 2.0.22'
-      requires 'mime-types'
+      requires 'mime-types', version: '= 2.6.2'
 
       def api
         @api ||= ::Aws::S3::Resource.new(s3_options)


### PR DESCRIPTION
mime-types upgrade to 3.0.0 on Nov 21st, which cause the deploy to s3 failed because 3.0.0 is not compatible with rvm 1.9. So we lock down to an earlier version.