### PR TITLE
gae: Adapt to gcloud-0.9.88

### DIFF
--- a/lib/dpl/provider/gae.rb
+++ b/lib/dpl/provider/gae.rb
@@ -23,7 +23,7 @@ module DPL
 
         $stderr.puts 'Bootstrapping Google Cloud SDK ...'
 
-        unless context.shell("#{BOOTSTRAP} --usage-reporting=false --command-completion=false --path-update=false --additional-components=app")
+        unless context.shell("#{BOOTSTRAP} --usage-reporting=false --command-completion=false --path-update=false")
           error 'Could not bootstrap Google Cloud SDK.'
         end
       end


### PR DESCRIPTION
The "app" component was removed, and all "app" subcommands are now installed by default, as clarified in https://groups.google.com/forum/#!topic/google-cloud-sdk/NGIit4pTFQE