### PR TITLE
Add GitHub Enterprise support

### DIFF
--- a/lib/dpl/provider/releases.rb
+++ b/lib/dpl/provider/releases.rb
@@ -58,6 +58,11 @@ module DPL
       end
 
       def check_app
+        log "Configuring API endpoint: #{api_endpoint}"
+        Octokit.configure do |c|
+          c.api_endpoint = api_endpoint
+        end
+
         log "Deploying to repo: #{slug}"
 
         context.shell 'git fetch --tags' if travis_tag.nil?
@@ -84,7 +89,7 @@ module DPL
 
         if options[:release_number]
           tag_matched = true
-          release_url = "https://api.github.com/repos/" + slug + "/releases/" + options[:release_number]
+          release_url = "#{api_endpoint}/repos/" + slug + "/releases/" + options[:release_number]
         else
           releases.each do |release|
             if release.tag_name == get_tag
@@ -117,6 +122,16 @@ module DPL
             end
             api.upload_asset(release_url, file, {:name => filename, :content_type => content_type})
           end
+        end
+      end
+
+      def api_endpoint
+        if options[:host]
+          host = options[:host]
+          api_version = options[:api_version] || '3'
+          "https://#{host}/api/v#{api_version}"
+        else
+          "https://api.github.com"
         end
       end
     end

--- a/lib/dpl/provider/releases.rb
+++ b/lib/dpl/provider/releases.rb
@@ -3,6 +3,8 @@ module DPL
     class Releases < Provider
       require 'pathname'
 
+      DEFAULT_GITHUB_API_VERSION = '3'
+
       requires 'octokit'
       requires 'mime-types', version: '~> 2.0'
 
@@ -128,7 +130,7 @@ module DPL
       def api_endpoint
         if options[:host]
           host = options[:host]
-          api_version = options[:api_version] || '3'
+          api_version = options[:api_version] || DEFAULT_GITHUB_API_VERSION
           "https://#{host}/api/v#{api_version}"
         else
           "https://api.github.com"

--- a/spec/provider/releases_spec.rb
+++ b/spec/provider/releases_spec.rb
@@ -272,7 +272,7 @@ describe DPL::Provider::Releases do
       end
 
       it "returns 'https://example.com/api/v3'" do
-        expect(provider.api_endpoint).to eq('https://example.com/api/v3')
+        expect(provider.api_endpoint).to eq("https://example.com/api/v#{DPL::Provider::Releases::DEFAULT_GITHUB_API_VERSION}")
       end
 
       context "and api_version '4' is given" do

--- a/spec/provider/releases_spec.rb
+++ b/spec/provider/releases_spec.rb
@@ -98,7 +98,9 @@ describe DPL::Provider::Releases do
       allow(provider).to receive(:slug).and_return("foo/bar")
       allow(provider).to receive(:get_tag).and_return("foo")
 
+      expect(Octokit).to receive(:api_endpoint=).with("https://api.github.com")
       expect(provider.context).to receive(:shell).with("git fetch --tags")
+      expect(provider).to receive(:log).with("Configuring API endpoint: https://api.github.com")
       expect(provider).to receive(:log).with("Deploying to repo: foo/bar")
       expect(provider).to receive(:log).with("Current tag is: foo")
 
@@ -110,9 +112,10 @@ describe DPL::Provider::Releases do
       allow(provider).to receive(:slug).and_return("foo/bar")
 
       expect(provider.context).not_to receive(:shell).with("git fetch --tags")
+      expect(provider).to receive(:log).with("Configuring API endpoint: https://api.github.com")
       expect(provider).to receive(:log).with("Deploying to repo: foo/bar")
       expect(provider).to receive(:log).with("Current tag is: bar")
-      
+
       provider.check_app
     end
   end
@@ -247,6 +250,37 @@ describe DPL::Provider::Releases do
       expect(provider.api).to receive(:upload_asset).with("https://api.github.com/repos/foo/bar/releases/1234", "bar.txt", {:name=>"bar.txt", :content_type=>"text/plain"})
 
       provider.push_app
+    end
+  end
+
+  describe "#api_endpoint" do
+    context "when host is not given" do
+      it 'returns "https://api.github.com"' do
+        expect(provider.api_endpoint).to eq('https://api.github.com')
+      end
+
+      context "when api_version '4' is given" do
+        it "ignores api_version value" do
+          expect(provider.api_endpoint).to eq('https://api.github.com')
+        end
+      end
+    end
+
+    context "when host 'example.com' is given (for GitHub Enterprise)" do
+      before :each do
+        provider.options.update(:host => 'example.com')
+      end
+
+      it "returns 'https://example.com/api/v3'" do
+        expect(provider.api_endpoint).to eq('https://example.com/api/v3')
+      end
+
+      context "and api_version '4' is given" do
+        it "returns 'https://example.com/api/v4'" do
+          provider.options.update(:api_version => '4')
+          expect(provider.api_endpoint).to eq('https://example.com/api/v4')
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This PR adds GitHub Enterprise support. (Documentation will be added in a separate PR.)

Example usage:

```yaml
deploy:
  provider: releases
  host: example.com
```

If the API version on GitHub Enterprise falls out of sync with github.com, the additional key `api_version` can be used to specify this:

```yaml
deploy:
  provider: releases
  host: example.com
  api_version: 3 # when github.com has moved on to version 4
                 # but the Enterprise installation remains at version 3
```
