### PR TITLE
Allow Github release provider to overwrite files

### DIFF
--- a/README.md
+++ b/README.md
@@ -526,6 +526,7 @@ You first need to create an [Atlas account](https://atlas.hashicorp.com/account/
 * **repo**: GitHub Repo. Defaults to git repo's name.
 * **file**: File to upload to GitHub Release.
 * **file_glob**: If files should be interpreted as globs (\* and \*\* wildcards). Defaults to false.
+* **overwrite**: If files with the same name should be overwritten. Defaults to false.
 * **release-number**: Overide automatic release detection, set a release manually.
 
 Additionally, options can be passed to [Octokit](https://github.com/octokit/octokit.rb) client.

--- a/lib/dpl/provider/releases.rb
+++ b/lib/dpl/provider/releases.rb
@@ -108,7 +108,6 @@ module DPL
             end
           end
           if !existing_url
-            log "#{filename} doesn't exist, uploading."
             upload_file(file, filename, release_url)
           elsif existing_url && options[:overwrite]
             log "#{filename} already exists, overwriting."

--- a/spec/provider/releases_spec.rb
+++ b/spec/provider/releases_spec.rb
@@ -200,7 +200,6 @@ describe DPL::Provider::Releases do
 
       expect(provider.api).to receive(:upload_asset).with(anything, "bar.txt", {:name=>"bar.txt", :content_type=>"text/plain"})
       expect(provider).to receive(:log).with("foo.bar already exists, skipping.")
-      expect(provider).to receive(:log).with("bar.txt doesn't exist, uploading.")
       expect(provider.api).to receive(:update_release).with(anything, hash_including(:draft => false))
 
       provider.push_app

--- a/spec/provider/releases_spec.rb
+++ b/spec/provider/releases_spec.rb
@@ -200,6 +200,7 @@ describe DPL::Provider::Releases do
 
       expect(provider.api).to receive(:upload_asset).with(anything, "bar.txt", {:name=>"bar.txt", :content_type=>"text/plain"})
       expect(provider).to receive(:log).with("foo.bar already exists, skipping.")
+      expect(provider).to receive(:log).with("bar.txt doesn't exist, uploading.")
       expect(provider.api).to receive(:update_release).with(anything, hash_including(:draft => false))
 
       provider.push_app
@@ -227,6 +228,7 @@ describe DPL::Provider::Releases do
 
       expect(provider.api).to receive(:delete_release_asset).with("release-url").and_return(true)
       expect(provider.api).to receive(:upload_asset).with(anything, "exists.txt", {:name=>"exists.txt", :content_type=>"text/plain"})
+      expect(provider.api).to receive(:update_release).with(anything, hash_including(:draft => false))
 
       provider.push_app
     end


### PR DESCRIPTION
Sometimes we want to updating an existing release with a new file that
has the same name. While best practice for user-facing releases is to
make a brand new release, there are some use cases where releases are
used as well known endpoints to grab the latest code.

This commit adds support for an `overwrite` option for the releases
provider, which will upload files even if others with the same name
are present on the release.