### PR TITLE
Initially create a draft GitHub Releases 

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,6 +520,9 @@ You first need to create an [Atlas account](https://atlas.hashicorp.com/account/
 * **file_glob**: If files should be interpreted as globs (\* and \*\* wildcards). Defaults to false.
 * **release-number**: Overide automatic release detection, set a release manually.
 
+Additionally, options can be passed to [Octokit](https://github.com/octokit/octokit.rb) client.
+These are documented in https://github.com/octokit/octokit.rb/blob/master/lib/octokit/client/releases.rb.
+
 #### GitHub Two Factor Authentication
 
 For accounts using two factor authentication, you have to use an oauth token as a username and password will not work.

--- a/lib/dpl/provider/releases.rb
+++ b/lib/dpl/provider/releases.rb
@@ -119,7 +119,7 @@ module DPL
           end
         end
 
-        api.update_release(release_url, options.merge({:draft => false}))
+        api.update_release(release_url, {:draft => false}.merge(options))
       end
     end
   end

--- a/lib/dpl/provider/releases.rb
+++ b/lib/dpl/provider/releases.rb
@@ -96,7 +96,7 @@ module DPL
 
         #If for some reason GitHub hasn't already created a release for the tag, create one
         if tag_matched == false
-          release_url = api.create_release(slug, get_tag, options).rels[:self].href
+          release_url = api.create_release(slug, get_tag, options.merge({:draft => true})).rels[:self].href
         end
 
         files.each do |file|
@@ -118,6 +118,8 @@ module DPL
             api.upload_asset(release_url, file, {:name => filename, :content_type => content_type})
           end
         end
+
+        api.update_release(release_url, options.merge({:draft => false}))
       end
     end
   end

--- a/spec/provider/releases_spec.rb
+++ b/spec/provider/releases_spec.rb
@@ -252,5 +252,25 @@ describe DPL::Provider::Releases do
 
       provider.push_app
     end
+
+    example "When draft is true" do
+      allow_message_expectations_on_nil
+
+      provider.options.update(:file => ["bar.txt"])
+      provider.options.update(:release_number => "1234")
+      provider.options.update(:draft => true)
+
+      allow(provider).to receive(:slug).and_return("foo/bar")
+
+      allow(provider.api).to receive(:release)
+      allow(provider.api.release).to receive(:rels).and_return({:assets => nil})
+      allow(provider.api.release.rels[:assets]).to receive(:get).and_return({:data => nil})
+      allow(provider.api.release.rels[:assets].get).to receive(:data).and_return([])
+
+      expect(provider.api).to receive(:upload_asset).with("https://api.github.com/repos/foo/bar/releases/1234", "bar.txt", {:name=>"bar.txt", :content_type=>"text/plain"})
+      expect(provider.api).to receive(:update_release).with(anything, hash_including(:draft => true))
+
+      provider.push_app
+    end
   end
 end

--- a/spec/provider/releases_spec.rb
+++ b/spec/provider/releases_spec.rb
@@ -112,7 +112,7 @@ describe DPL::Provider::Releases do
       expect(provider.context).not_to receive(:shell).with("git fetch --tags")
       expect(provider).to receive(:log).with("Deploying to repo: foo/bar")
       expect(provider).to receive(:log).with("Current tag is: bar")
-      
+
       provider.check_app
     end
   end
@@ -174,6 +174,7 @@ describe DPL::Provider::Releases do
 
       expect(provider.api).to receive(:upload_asset).with(anything, "test/foo.bar", {:name=>"foo.bar", :content_type=>"application/octet-stream"})
       expect(provider.api).to receive(:upload_asset).with(anything, "bar.txt", {:name=>"bar.txt", :content_type=>"text/plain"})
+      expect(provider.api).to receive(:update_release).with(anything, hash_including(:draft => false))
 
       provider.push_app
     end
@@ -199,6 +200,7 @@ describe DPL::Provider::Releases do
 
       expect(provider.api).to receive(:upload_asset).with(anything, "bar.txt", {:name=>"bar.txt", :content_type=>"text/plain"})
       expect(provider).to receive(:log).with("foo.bar already exists, skipping.")
+      expect(provider.api).to receive(:update_release).with(anything, hash_including(:draft => false))
 
       provider.push_app
     end
@@ -227,6 +229,7 @@ describe DPL::Provider::Releases do
 
       expect(provider.api).to receive(:upload_asset).with(anything, "test/foo.bar", {:name=>"foo.bar", :content_type=>"application/octet-stream"})
       expect(provider.api).to receive(:upload_asset).with(anything, "bar.txt", {:name=>"bar.txt", :content_type=>"text/plain"})
+      expect(provider.api).to receive(:update_release).with(anything, hash_including(:draft => false))
 
       provider.push_app
     end
@@ -245,6 +248,7 @@ describe DPL::Provider::Releases do
       allow(provider.api.release.rels[:assets].get).to receive(:data).and_return([])
 
       expect(provider.api).to receive(:upload_asset).with("https://api.github.com/repos/foo/bar/releases/1234", "bar.txt", {:name=>"bar.txt", :content_type=>"text/plain"})
+      expect(provider.api).to receive(:update_release).with(anything, hash_including(:draft => false))
 
       provider.push_app
     end


### PR DESCRIPTION
Resolves https://github.com/travis-ci/travis-ci/issues/5424

Webhook is fired once when a GitHub Release is published. We defer publishing to the end, so that the first webhook notification for the ReleaseEvent contains the list of files in the payload.

Notice that if the deployment happens multiple times in a build matrix, the first will win.