### PR TITLE
Fix Azure Web App Deployment from non-master branches

### DIFF
--- a/lib/dpl/provider/azure_webapps.rb
+++ b/lib/dpl/provider/azure_webapps.rb
@@ -32,15 +32,15 @@ module DPL
 
         if !!options[:skip_cleanup]
           log "Skipping Cleanup"
-          context.shell "git checkout master"
+          context.shell "git checkout HEAD"
           context.shell "git add . --all --force"
           context.shell "git commit -m \"Skip Cleanup Commit\""
         end
 
         if !!options[:verbose]
-          context.shell "git push --force --quiet #{git_target} master"
+          context.shell "git push --force --quiet #{git_target} HEAD:master"
         else
-          context.shell "git push --force --quiet #{git_target} master > /dev/null 2>&1"
+          context.shell "git push --force --quiet #{git_target} HEAD:master > /dev/null 2>&1"
         end
       end
     end


### PR DESCRIPTION
# This PR...

* Fixes travis-ci/travis-ci#5468
* In other words, makes it possible to deploy also from other branches than `master` to Azure Web Apps

## Proofs:

Not-working build, without the fix:
https://travis-ci.org/kaplas/travis-azure-deployment-bug/builds/102781406#L160

Working build, when using this code change:
https://travis-ci.org/kaplas/travis-azure-deployment-bug/builds/102784628#L191-L207

Also the deployment history of the Web App itself confirms, that build number 1 never got through:
<img width="541" alt="Web App Deployment history" src="https://cloud.githubusercontent.com/assets/1321686/12372842/64fcf088-bc6d-11e5-97c7-60dea86de4dd.png">
