### PR TITLE
ElasticBeanstalk option for only_create_app_version

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,6 +597,7 @@ For accounts using two factor authentication, you have to use an oauth token as 
  * **zip_file**: The zip file that you want to deploy. _**Note:**_ you also need to use the `skip_cleanup` or the zip file you are trying to upload will be removed during cleanup.
  * **bucket_name**: Bucket name to upload app to.
  * **bucket_path**: Location within Bucket to upload app to.
+ * **only_create_app_version**: only create the app version, don't actually deploy it.
 
 #### Environment variables:
 

--- a/lib/dpl/provider/elastic_beanstalk.rb
+++ b/lib/dpl/provider/elastic_beanstalk.rb
@@ -27,6 +27,10 @@ module DPL
       def check_app
       end
 
+      def only_create_app_version
+        options[:only_create_app_version]
+      end
+
       def push_app
         create_bucket unless bucket_exists?
 
@@ -39,7 +43,9 @@ module DPL
         s3_object = upload(archive_name, zip_file)
         sleep 5 #s3 eventual consistency
         version = create_app_version(s3_object)
-        update_app(version)
+        if !only_create_app_version
+          update_app(version)
+        end
       end
 
       private


### PR DESCRIPTION
Hey Gents,

These commit add an only_create_app_version option to the elastic beanstalk provider. This makes it so the version is uploaded without making it active.

Thanks.