### PR TITLE
[bintray] Construct file path properly when includePattern starts with '('

### DIFF
--- a/lib/dpl/provider/bintray.rb
+++ b/lib/dpl/provider/bintray.rb
@@ -368,7 +368,7 @@ module DPL
       def root_path(str)
         index = str.index('(')
         path = nil
-        if index.nil?
+        if index.nil? || str.start_with?('(')
           path = str
         else
           path = str[0, index]


### PR DESCRIPTION
Given

```
{
    "files":
    [{"includePattern": "(.*\\.deb)", "uploadPattern": "$1",
        "matrixParams": {
            "deb_distribution": "stable",
            "deb_component": "main",
            "deb_architecture": "amd64"}
    }
    ]
}
```

We would end up with "" as `root_path`, and we get

```
[Bintray Upload] Warning: Path:  does not exist.
```

This commit fixes this issue.