### PR TITLE
Add a check to wait for the SSH key to start working

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -82,3 +82,7 @@ end
 group :chef_supermarket do
   gem 'chef'
 end
+
+group :deis do
+  gem 'git'
+end

--- a/lib/dpl/provider/deis.rb
+++ b/lib/dpl/provider/deis.rb
@@ -1,6 +1,9 @@
 module DPL
   class Provider
     class Deis < Provider
+      
+      requires 'git'
+
       def install_deploy_dependencies
         context.shell "curl -sSL http://deis.io/deis-cli/install.sh | sh -s #{option(:cli_version)}"
       end
@@ -53,7 +56,9 @@ module DPL
         max_retries=30
 
         #Parse out the git remote host and port
-        git_remote=`cat .git/config  | grep -A1 '[remote] "deis"' | tail -n 1 | sed 's/.*url = //'`
+        #git_remote=`cat .git/config  | grep -A1 '[remote] "deis"' | tail -n 1 | sed 's/.*url = //'`
+        git=Git.open("./")
+        git_remote=git.remote("deis").url
         remote_uri=git_remote.split("ssh://")[1].split("/")[0]
         remote_host=remote_uri.split(":")[0]
         remote_port=remote_uri.split(":")[1]

--- a/lib/dpl/provider/deis.rb
+++ b/lib/dpl/provider/deis.rb
@@ -55,8 +55,7 @@ module DPL
         retry_count=0
         max_retries=30
 
-        #Parse out the git remote host and port
-        #git_remote=`cat .git/config  | grep -A1 '[remote] "deis"' | tail -n 1 | sed 's/.*url = //'`
+        #Get the deis git remote host and port
         git=Git.open("./")
         git_remote=git.remote("deis").url
         remote_uri=git_remote.split("ssh://")[1].split("/")[0]

--- a/lib/dpl/provider/deis.rb
+++ b/lib/dpl/provider/deis.rb
@@ -59,8 +59,7 @@ module DPL
         git=Git.open("./")
         git_remote=git.remote("deis").url
         remote_uri=git_remote.split("ssh://")[1].split("/")[0]
-        remote_host=remote_uri.split(":")[0]
-        remote_port=remote_uri.split(":")[1]
+        remote_host, remote_port = remote_uri.split(":")
         puts "Git remote is #{remote_host} at port #{remote_port}"
 
         #Try and connect to the github remote via ssh.

--- a/spec/provider/deis_spec.rb
+++ b/spec/provider/deis_spec.rb
@@ -67,6 +67,15 @@ describe DPL::Provider::Deis do
       expect(provider.context).to receive(:shell).with(
         './deis git:remote --app=example'
       ).and_return(true)
+
+      expect(provider.context).to receive(:shell).with(
+        /grep -c 'PTY allocation request failed'/
+      ).and_return(false)
+
+      expect(provider.context).to receive(:shell).with(
+        /grep -c 'PTY allocation request failed'/
+      ).and_return(true)
+
       provider.setup_git_ssh('foo', 'key_file')
     end
   end

--- a/spec/provider/deis_spec.rb
+++ b/spec/provider/deis_spec.rb
@@ -68,6 +68,12 @@ describe DPL::Provider::Deis do
         './deis git:remote --app=example'
       ).and_return(true)
 
+      git_conf = double
+      git_remote = double
+      allow(Git).to receive(:open).and_return(git_conf)
+      allow(git_conf).to receive(:remote).and_return(git_remote)
+      allow(git_remote).to receive(:url).and_return("ssh://git@fake-git-repo.travis-ci.com:2222/dpl-test.git")
+
       expect(provider.context).to receive(:shell).with(
         /grep -c 'PTY allocation request failed'/
       ).and_return(false)


### PR DESCRIPTION
This is for #352. Although for some reason just using master seemed to work, it does seem that there is a timing issue that should be explicitly solved.

The problem seems to be that Deis reports ssh keys are added slightly before they can actually be used for a code push. In my testing it seems to take < 2 seconds for the key to be usable.

This code just gets the deis remote information from the git config file (for some reason `git remove -v show deis` was not working) and attempts to SSH into the remote until it gets a 'PTY allocation request failed message'. That doesn't seem like the cleanest way of going about it, but since you can't actually SSH in it was the only test I could come up with. Seems to work for me.

Edit: I realize that this doesn't pass tests right now, if this implementation looks ok then I will go and fix the tests.