### PR TITLE
Update README.md for the bintray provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ As a rule of thumb, you should switch to the Git strategy if you run into issues
 		"released": "2015-01-04",
 		"vcs_tag": "0.5",
 	 	"attributes": [{"name": "VerAtt1", "values" : ["VerVal1"], "type": "string"},
-  					   {"name": "VerAtt2", "values" : [1, 3.3, 5], "type": "number"},
+  					   {"name": "VerAtt2", "values" : [1, 3.2, 5], "type": "number"},
 					   {"name": "VerAtt3", "values" : ["2015-01-01T19:43:37+0100"], "type": "date"}],
 		"gpgSign": false
 	},

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ As a rule of thumb, you should switch to the Git strategy if you run into issues
 	The files will be uploaded to Bintray under the gems folder.
 	2. All files under build/docs. The files will be uploaded to Bintray under the docs folder.
 
-	Note: Regular expressions defined as part of the includePattern and excludePattern properties must be wrapped with brackets. */
+	Note: Regular expressions defined as part of the includePattern property must be wrapped with brackets. */
 
 	"files":
 		[


### PR DESCRIPTION
Hello, I am with JFrog (home of Bintray). There was a small change that was needed to be made for the documentation of the Bintray provider section:

"Removed small documentation mistake about having to use brackets for the excludePattern param in the bintray descriptor example."

We have verified this to be incorrect. There is no need to use brackets for the 'excludePattern' param.

Thank you.