### PR TITLE
use recommended (HTTPS) URLs for downloading Cloud Foundry CLI

### DIFF
--- a/lib/dpl/provider/cloud_foundry.rb
+++ b/lib/dpl/provider/cloud_foundry.rb
@@ -3,7 +3,7 @@ module DPL
     class CloudFoundry < Provider
 
       def initial_go_tools_install
-        context.shell 'wget http://go-cli.s3-website-us-east-1.amazonaws.com/releases/latest/cf-linux-amd64.tgz -qO cf-linux-amd64.tgz && tar -zxvf cf-linux-amd64.tgz && rm cf-linux-amd64.tgz'
+        context.shell 'wget https://cli.run.pivotal.io/stable?release=linux64-binary&source=github -qO cf-linux-amd64.tgz && tar -zxvf cf-linux-amd64.tgz && rm cf-linux-amd64.tgz'
       end
 
       def check_auth

--- a/spec/provider/anynines_spec.rb
+++ b/spec/provider/anynines_spec.rb
@@ -11,7 +11,7 @@ describe DPL::Provider::Anynines do
 
   describe "#check_auth" do
     example do
-      expect(provider.context).to receive(:shell).with('wget http://go-cli.s3-website-us-east-1.amazonaws.com/releases/latest/cf-linux-amd64.tgz -qO cf-linux-amd64.tgz && tar -zxvf cf-linux-amd64.tgz && rm cf-linux-amd64.tgz')
+      expect(provider.context).to receive(:shell).with('wget https://cli.run.pivotal.io/stable?release=linux64-binary&source=github -qO cf-linux-amd64.tgz && tar -zxvf cf-linux-amd64.tgz && rm cf-linux-amd64.tgz')
       expect(provider.context).to receive(:shell).with('./cf api https://api.de.a9s.eu')
       expect(provider.context).to receive(:shell).with('./cf login --u mallomar --p myreallyawesomepassword --o myorg --s outer')
       provider.check_auth

--- a/spec/provider/cloudfoundry_spec.rb
+++ b/spec/provider/cloudfoundry_spec.rb
@@ -13,7 +13,7 @@ describe DPL::Provider::CloudFoundry do
 
   describe "#check_auth" do
     example do
-      expect(provider.context).to receive(:shell).with('wget http://go-cli.s3-website-us-east-1.amazonaws.com/releases/latest/cf-linux-amd64.tgz -qO cf-linux-amd64.tgz && tar -zxvf cf-linux-amd64.tgz && rm cf-linux-amd64.tgz')
+      expect(provider.context).to receive(:shell).with('wget https://cli.run.pivotal.io/stable?release=linux64-binary&source=github -qO cf-linux-amd64.tgz && tar -zxvf cf-linux-amd64.tgz && rm cf-linux-amd64.tgz')
       expect(provider.context).to receive(:shell).with('./cf api api.run.awesome.io --skip-ssl-validation')
       expect(provider.context).to receive(:shell).with('./cf login --u mallomar --p myreallyawesomepassword --o myorg --s outer')
       provider.check_auth


### PR DESCRIPTION
Fixes https://github.com/travis-ci/dpl/issues/382.

See corresponding pull request to ultimately use HTTPS for the download URL: https://github.com/cloudfoundry/CLAW/pull/2