### PR TITLE
Add cloud-build option to GAE 

### DIFF
--- a/lib/dpl/provider/gae.rb
+++ b/lib/dpl/provider/gae.rb
@@ -58,6 +58,10 @@ module DPL
         options[:no_promote]
       end
 
+      def use_cloud_build
+        options[:use_cloud_build] || 'false'
+      end
+
       def verbosity
         options[:verbosity] || 'warning'
       end
@@ -67,10 +71,11 @@ module DPL
       end
 
       def no_stop_previous_version
-          options[:no_stop_previous_version]
+        options[:no_stop_previous_version]
       end
 
       def push_app
+        context.shell "#{GCLOUD} config set app/use_cloud_build #{use_cloud_build}"
         command = GCLOUD
         command << ' --quiet'
         command << " --verbosity \"#{verbosity}\""

--- a/spec/provider/gae_spec.rb
+++ b/spec/provider/gae_spec.rb
@@ -8,7 +8,8 @@ describe DPL::Provider::GAE do
 
   describe '#push_app' do
     example 'with defaults' do
-      expect(provider.context).to receive(:shell).with("#{DPL::Provider::GAE::GCLOUD} --quiet --verbosity \"warning\" --project \"test\" preview app deploy \"app.yaml\" --version \"\" --docker-build \"remote\" --promote").and_return(true)
+      allow(provider.context).to receive(:shell).with("#{DPL::Provider::GAE::GCLOUD} config set app/use_cloud_build false").and_return(true)
+      allow(provider.context).to receive(:shell).with("#{DPL::Provider::GAE::GCLOUD} --quiet --verbosity \"warning\" --project \"test\" preview app deploy \"app.yaml\" --version \"\" --docker-build \"remote\" --promote").and_return(true)
       provider.push_app
     end
   end


### PR DESCRIPTION
When deploying it'll allow to let the container builder to perform the docker builds as per google docs. https://cloud.google.com/sdk/gcloud/reference/config/set

use_cloud_build
    If True, use the Container Builder API to perform docker builds, rather than a temporary VM. See https://cloud.google.com/container-builder/docs/ for more information. 