### PR TITLE
gae: Use Container Builder by default, add docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -831,6 +831,7 @@ In order to use this provider, please make sure you have the [App Engine Admin A
 * **no_promote**: Flag to not promote the deployed version. See [`gcloud preview app deploy`](https://cloud.google.com/sdk/gcloud/reference/preview/app/deploy)
 * **verbosity**: Let's you adjust the verbosity when invoking `"gcloud"`. Defaults to `"warning"`. See [`gcloud`](https://cloud.google.com/sdk/gcloud/reference/).
 * **docker_build**: If deploying a Managed VM, specifies where to build your image. Typical values are `"remote"` to build on Google Cloud Engine and `"local"` which requires Docker to be set up properly (to utilize this on Travis CI, read [Using Docker on Travis CI](http://blog.travis-ci.com/2015-08-19-using-docker-on-travis-ci/)). Defaults to `"remote"`.
+* **cloud_build**: By default, the provider will attempt to use [Google Cloud Container Builder](https://cloud.google.com/container-builder/docs/) to build the Docker image that will be deployed (this requires the [Container Builder API](https://console.developers.google.com/apis/api/cloudbuild.googleapis.com/overview) to be enabled for your project). If you want to avoid this, set this option to `"false"`. When building locally, this will not have any effect.
 * **no_stop_previous_version**: Flag to prevent your deployment from stopping the previously promoted version. This is from the future, so might not work (yet). See [`gcloud preview app deploy`](https://cloud.google.com/sdk/gcloud/reference/preview/app/deploy)
 
 #### Environment variables:

--- a/lib/dpl/provider/gae.rb
+++ b/lib/dpl/provider/gae.rb
@@ -59,7 +59,7 @@ module DPL
       end
 
       def use_cloud_build
-        options[:use_cloud_build] || 'false'
+        options[:use_cloud_build] || 'true'
       end
 
       def verbosity

--- a/spec/provider/gae_spec.rb
+++ b/spec/provider/gae_spec.rb
@@ -8,7 +8,7 @@ describe DPL::Provider::GAE do
 
   describe '#push_app' do
     example 'with defaults' do
-      allow(provider.context).to receive(:shell).with("#{DPL::Provider::GAE::GCLOUD} config set app/use_cloud_build false").and_return(true)
+      allow(provider.context).to receive(:shell).with("#{DPL::Provider::GAE::GCLOUD} config set app/use_cloud_build true").and_return(true)
       allow(provider.context).to receive(:shell).with("#{DPL::Provider::GAE::GCLOUD} --quiet --verbosity \"warning\" --project \"test\" preview app deploy \"app.yaml\" --version \"\" --docker-build \"remote\" --promote").and_return(true)
       provider.push_app
     end


### PR DESCRIPTION
Reading a [recent announcement from the Google Cloud Platform team](https://groups.google.com/forum/#!topic/google-cloud-sdk/DuOdQPy9PoQ), I understand that Cloud Container Builder should be the default way to build Docker images as part of the deployment process, and developers will see that change automatically without altering any configs.

So the deployment provider should reflect this as well, e.g. promote Cloud Container Builder to opt-out.

Building on #410 I also added a line of documentation that introduces the parameter with it's new semantics.