### PR TITLE
Launchpad support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Dpl supports the following providers:
 * [Hackage](#hackage)
 * [Heroku](#heroku)
 * [Lambda](#lambda)
+* [Launchpad](#launchpad)
 * [Modulus](#modulus)
 * [Nodejitsu](#nodejitsu)
 * [NPM](#npm)
@@ -708,6 +709,24 @@ Deploy contents of a specific directory using specific module name:
         --zip="${TRAVIS_BUILD_DIR}/dist"  \
         --module_name="copy" \
         --handler_name="handler";
+```
+
+### Launchpad:
+
+#### Options:
+
+ * **slug**: Required. `~user-name/project-name/branch-name`
+ * **oauth_token**: Required. Your OAUTH token for Launchpad
+ * **oauth_token_secret**: Required. Your OAUTH token secret for Launchpad
+
+#### Example:
+
+Deploy contents of current working directory using default module:
+```
+    dpl --provider="launchpad" \
+        --slug="~user-name/project-name/branch-name" \
+        --oauth_token="${LAUNCHPAD_OAUTH_TOKEN}" \
+        --oauth_token_secret="${LAUNCHPAD_OAUTH_TOKEN_SECRET}";
 ```
 
 ### TestFairy:

--- a/lib/dpl/provider.rb
+++ b/lib/dpl/provider.rb
@@ -32,6 +32,7 @@ module DPL
     autoload :Hackage,          'dpl/provider/hackage'
     autoload :Heroku,           'dpl/provider/heroku'
     autoload :Lambda,           'dpl/provider/lambda'
+    autoload :Launchpad,        'dpl/provider/launchpad'
     autoload :Modulus,          'dpl/provider/modulus'
     autoload :Nodejitsu,        'dpl/provider/nodejitsu'
     autoload :NPM,              'dpl/provider/npm'

--- a/lib/dpl/provider/launchpad.rb
+++ b/lib/dpl/provider/launchpad.rb
@@ -1,0 +1,33 @@
+require 'net/http'
+require 'net/https'
+
+module DPL
+  class Provider
+    class Launchpad < Provider
+
+      def check_auth
+      end
+
+      def needs_key?
+        false
+      end
+
+      def push_app
+        http = Net::HTTP.new('api.launchpad.net', 443)
+        http.use_ssl = true
+        req = Net::HTTP::Post.new("/1.0/" + options[:slug] + "/+code-import")
+        req.set_form_data('ws.op' => 'requestImport')
+        req['Authorization'] =
+          'OAuth oauth_consumer_key="Travis%20Deploy", ' +
+          'oauth_nonce="' + rand(36**32).to_s(36) + '",' +
+          'oauth_signature="%26' + options[:oauth_token_secret] + '",' +
+          'oauth_signature_method="PLAINTEXT",' +
+          'oauth_timestamp="' + Time::now().to_i.to_s + '",' +
+          'oauth_token="' + options[:oauth_token] + '",' +
+          'oauth_version="1.0"'
+        response = http.request(req)
+        error('Deploy failed! Response Code: ' + response.code.to_s) if response.code != '200'
+      end
+    end
+  end
+end

--- a/lib/dpl/provider/launchpad.rb
+++ b/lib/dpl/provider/launchpad.rb
@@ -21,7 +21,7 @@ module DPL
       def push_app
         response = api_call('/1.0/' + options[:slug] + '/+code-import', {'ws.op' => 'requestImport'})
         error('Deploy failed! Launchpad credentials invalid. ' + response.code.to_s) if response.code == '401'
-        error('Error: ' + response.code + ' ' + response.body) if response.code != '200'
+        error('Error: ' + response.code.to_s + ' ' + response.body) unless response.kind_of? Net::HTTPSuccess
       end
 
       private
@@ -29,11 +29,11 @@ module DPL
         def api_call(path, data)
           req = Net::HTTP::Post.new(path)
           req.set_form_data(data)
-          req['Authorization'] = get_authorization_header
+          req['Authorization'] = authorization
           return @http.request(req)
         end
 
-        def get_authorization_header
+        def authorization
           return 'OAuth oauth_consumer_key="Travis%20Deploy", ' +
                  'oauth_nonce="' + rand(36**32).to_s(36) + '",' +
                  'oauth_signature="%26' + options[:oauth_token_secret] + '",' +

--- a/spec/provider/launchpad_spec.rb
+++ b/spec/provider/launchpad_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+require 'dpl/provider/cloudcontrol'
+
+describe DPL::Provider::Launchpad do
+  subject :provider do
+    described_class.new(DummyContext.new, :slug => '~user/repo/branch', :oauth_token => 'uezinoosinmxkewhochq', :oauth_token_secret => 'dinb6fao4jh0kfdn5mich31cbikdkpjplkmadhi80h93kbbaableeeg41mm0jab9jif8ch7i2k9a80n5')
+  end
+
+  its(:needs_key?) { should be false }
+
+  describe '#push_app' do
+    it 'on api success' do
+      expect(provider).to receive(:api_call).with('/1.0/~user/repo/branch/+code-import', {'ws.op' => 'requestImport'}).and_return double(:code => '200')
+      provider.push_app
+    end
+
+    it 'on api failure' do
+      expect(provider).to receive(:api_call).with('/1.0/~user/repo/branch/+code-import', {'ws.op' => 'requestImport'}).and_return double(:code => '401')
+      expect { provider.push_app }.to raise_error(DPL::Error)
+    end
+  end
+
+  describe 'private method' do
+    describe '#get_authorization_header' do
+      it 'should return correct oauth header' do
+        result = provider.instance_eval { get_authorization_header }
+        expect(result).to include('oauth_token="uezinoosinmxkewhochq",')
+        expect(result).to include('oauth_signature="%26dinb6fao4jh0kfdn5mich31cbikdkpjplkmadhi80h93kbbaableeeg41mm0jab9jif8ch7i2k9a80n5",')
+      end
+    end
+  end
+
+end

--- a/spec/provider/launchpad_spec.rb
+++ b/spec/provider/launchpad_spec.rb
@@ -10,20 +10,20 @@ describe DPL::Provider::Launchpad do
 
   describe '#push_app' do
     it 'on api success' do
-      expect(provider).to receive(:api_call).with('/1.0/~user/repo/branch/+code-import', {'ws.op' => 'requestImport'}).and_return double(:code => '200')
+      expect(provider).to receive(:api_call).with('/1.0/~user/repo/branch/+code-import', {'ws.op' => 'requestImport'}).and_return Net::HTTPSuccess.new("HTTP/1.1", 200, "Ok")
       provider.push_app
     end
 
     it 'on api failure' do
-      expect(provider).to receive(:api_call).with('/1.0/~user/repo/branch/+code-import', {'ws.op' => 'requestImport'}).and_return double(:code => '401')
+      expect(provider).to receive(:api_call).with('/1.0/~user/repo/branch/+code-import', {'ws.op' => 'requestImport'}).and_return double("Net::HTTPUnauthorized", code: 401, body: "", class: Net::HTTPUnauthorized)
       expect { provider.push_app }.to raise_error(DPL::Error)
     end
   end
 
   describe 'private method' do
-    describe '#get_authorization_header' do
-      it 'should return correct oauth header' do
-        result = provider.instance_eval { get_authorization_header }
+    describe '#authorization' do
+      it 'should return correct oauth' do
+        result = provider.instance_eval { authorization }
         expect(result).to include('oauth_token="uezinoosinmxkewhochq",')
         expect(result).to include('oauth_signature="%26dinb6fao4jh0kfdn5mich31cbikdkpjplkmadhi80h93kbbaableeeg41mm0jab9jif8ch7i2k9a80n5",')
       end


### PR DESCRIPTION
This PR adds support to trigger a code import on [launchpad.net](http://launchpad.net). This is useful to, for example, build and host Ubuntu packages.

Example [config](https://github.com/HPI-BP2015H/test/blob/master/.travis.yml#L3-L14) and [build](https://travis-ci.org/HPI-BP2015H/test/builds/118020367).

/cc: @timfel
