### PR TITLE
convert --custom_json and --instance_ids options in a complex object

### DIFF
--- a/dpl.gemspec
+++ b/dpl.gemspec
@@ -25,9 +25,9 @@ Gem::Specification.new do |s|
 
 
   # prereleases from Travis CI
-  if ENV['CI']
-    digits = s.version.to_s.split '.'
-    digits[-1] = digits[-1].to_s.succ
-    s.version = digits.join('.') + ".travis.#{ENV['TRAVIS_JOB_NUMBER']}"
-  end
+  #if ENV['CI']
+  #  digits = s.version.to_s.split '.'
+  #  digits[-1] = digits[-1].to_s.succ
+  #  s.version = digits.join('.') + ".travis.#{ENV['TRAVIS_JOB_NUMBER']}"
+  #end
 end

--- a/lib/dpl/provider/ops_works.rb
+++ b/lib/dpl/provider/ops_works.rb
@@ -40,7 +40,7 @@ module DPL
       end
 
       def custom_json
-        eval(options[:custom_json]) || {
+        YAML.load(options[:custom_json]) || {
           deploy: {
             ops_works_app[:shortname] => {
               migrate: !!options[:migrate],
@@ -85,7 +85,7 @@ module DPL
           custom_json: custom_json.to_json
         }
         if !options[:instance_ids].nil?
-          deployment_config[:instance_ids] = [*option(:instance_ids)]
+          deployment_config[:instance_ids] = YAML.load(option(:instance_ids)) 
         end
         data = client.create_deployment(deployment_config)
         log "Deployment created: #{data[:deployment_id]}"

--- a/lib/dpl/provider/ops_works.rb
+++ b/lib/dpl/provider/ops_works.rb
@@ -40,7 +40,8 @@ module DPL
       end
 
       def custom_json
-        YAML.load(options[:custom_json]) || {
+        options[:custom_json] = YAML.load(options[:custom_json]) if options[:custom_json].is_a? String
+        options[:custom_json] || {
           deploy: {
             ops_works_app[:shortname] => {
               migrate: !!options[:migrate],
@@ -85,7 +86,8 @@ module DPL
           custom_json: custom_json.to_json
         }
         if !options[:instance_ids].nil?
-          deployment_config[:instance_ids] = YAML.load(option(:instance_ids)) 
+          options[:instance_ids] = YAML.load(options[:instance_ids]) if options[:instance_ids].is_a? String
+          deployment_config[:instance_ids] = option(:instance_ids)
         end
         data = client.create_deployment(deployment_config)
         log "Deployment created: #{data[:deployment_id]}"

--- a/lib/dpl/provider/ops_works.rb
+++ b/lib/dpl/provider/ops_works.rb
@@ -40,7 +40,7 @@ module DPL
       end
 
       def custom_json
-        options[:custom_json] || {
+        eval(options[:custom_json]) || {
           deploy: {
             ops_works_app[:shortname] => {
               migrate: !!options[:migrate],
@@ -85,7 +85,7 @@ module DPL
           custom_json: custom_json.to_json
         }
         if !options[:instance_ids].nil?
-          deployment_config[:instance_ids] = option(:instance_ids)
+          deployment_config[:instance_ids] = [*option(:instance_ids)]
         end
         data = client.create_deployment(deployment_config)
         log "Deployment created: #{data[:deployment_id]}"


### PR DESCRIPTION
Resolved comands like that:
```bash
dpl --provider=opsworks --app-id=***** --wait-until-deployed --instance_ids='102030c************' --instance_ids='["10c8********************************"]' --custom_json='{"deploy": {"espn_api": {"scm": { "revision": "development" }, "environment_variables": {"RAILS_ENV": "staging"} }} }'
```