### PR TITLE
Allow for runtime to be an option for lambdas

### DIFF
--- a/README.md
+++ b/README.md
@@ -687,6 +687,7 @@ For accounts using two factor authentication, you have to use an oauth token as 
  * **description**: Optional. The description of the Lambda being created / updated. Defaults to "Deploy build #{context.env['TRAVIS_BUILD_NUMBER']} to AWS Lambda via Travis CI"
  * **timeout**: Optional. The function execution time at which Lambda should terminate the function. Defaults to 3 (seconds).
  * **memory_size**: Optional. The amount of memory in MB to allocate to this Lambda. Defaults to 128.
+ * **runtime**: Optional. The Lambda runtime to use. Defaults to `node`.
 
 #### Examples:
 

--- a/lib/dpl/provider/lambda.rb
+++ b/lib/dpl/provider/lambda.rb
@@ -20,6 +20,9 @@ module DPL
       end
 
       def push_app
+        # Options defined at
+        #   https://docs.aws.amazon.com/sdkforruby/api/Aws/LambdaPreview/Client.html
+        #   https://docs.aws.amazon.com/lambda/latest/dg/API_CreateFunction.html
         response = lambda.upload_function({
           function_name:  options[:name]           || option(:function_name),
           description:    options[:description]    || default_description,
@@ -28,8 +31,8 @@ module DPL
           role:           option(:role),
           handler:        handler,
           function_zip:   function_zip,
-          runtime:        default_runtime,
-          mode:           default_mode
+          runtime:        options[:runtime]        || default_runtime,
+          mode:           default_mode,
         })
 
         log "Uploaded lambda: #{response.function_name}."


### PR DESCRIPTION
This should fix #397. Amazon Lambdas now support four different runtimes.