### PR TITLE
ElasticBeanstalk provider: finish the build after EB env update completes

### DIFF
--- a/lib/dpl/provider/elastic_beanstalk.rb
+++ b/lib/dpl/provider/elastic_beanstalk.rb
@@ -1,3 +1,5 @@
+require 'time'
+
 module DPL
   class Provider
     class ElasticBeanstalk < Provider
@@ -32,6 +34,7 @@ module DPL
       end
 
       def push_app
+        @start_time = Time.now
         create_bucket unless bucket_exists?
 
         if options[:zip_file]
@@ -45,6 +48,7 @@ module DPL
         version = create_app_version(s3_object)
         if !only_create_app_version
           update_app(version)
+          wait_until_deployed if options[:wait_until_deployed]
         end
       end
 
@@ -136,6 +140,40 @@ module DPL
           :auto_create_application => false
         }
         eb.create_application_version(options)
+      end
+
+      # Wait until EB environment update finishes
+      def wait_until_deployed
+        errorEvents = 0 # errors counter, should remain 0 for successful deployment
+        events = []
+
+        loop do
+          environment = eb.describe_environments({
+            :application_name  => app_name,
+            :environment_names => [env_name]
+          })[:environments].first
+
+          eb.describe_events({
+            :environment_name  => env_name,
+            :start_time        => @start_time.utc.iso8601,
+          })[:events].reverse.each do |event|
+            message = "#{event[:event_date]} [#{event[:severity]}] #{event[:message]}"
+            unless events.include?(message)
+              events.push(message)
+              if event[:severity] == "ERROR"
+                errorEvents += 1
+                warn(message)
+              else
+                log(message)
+              end
+            end
+          end
+
+          break if environment[:status] == "Ready"
+          sleep 5
+        end
+
+        if errorEvents > 0 then error("Deployment failed.") end
       end
 
       def update_app(version)

--- a/spec/provider/elastic_beanstalk_spec.rb
+++ b/spec/provider/elastic_beanstalk_spec.rb
@@ -17,6 +17,7 @@ describe DPL::Provider::ElasticBeanstalk do
   let(:bucket_name) { "travis-elasticbeanstalk-test-builds-#{region}" }
   let(:bucket_path) { "some/app"}
   let(:only_create_app_version) { nil }
+  let(:wait_until_deployed) { nil }
 
   let(:bucket_mock) do
     dbl = double("bucket mock", write: nil)
@@ -33,7 +34,8 @@ describe DPL::Provider::ElasticBeanstalk do
     described_class.new(
       DummyContext.new, :access_key_id => access_key_id, :secret_access_key => secret_access_key,
       :region => region, :app => app, :env => env, :bucket_name => bucket_name, :bucket_path => bucket_path,
-      :only_create_app_version => only_create_app_version
+      :only_create_app_version => only_create_app_version,
+      :wait_until_deployed => wait_until_deployed
     )
   end
 
@@ -84,12 +86,12 @@ describe DPL::Provider::ElasticBeanstalk do
 
       provider.push_app
     end
-    
+
     context 'only creates app version' do
       let(:only_create_app_version) { true }
-      
+
       example 'verify the app is not updated' do
-      
+
         expect(provider).to receive(:s3).and_return(s3_mock).twice
         expect(provider).to receive(:create_bucket)
         expect(provider).to receive(:create_zip).and_return('/path/to/file.zip')
@@ -119,6 +121,24 @@ describe DPL::Provider::ElasticBeanstalk do
         expect(provider_without_bucket_path).to receive(:update_app).with(app_version)
 
         provider_without_bucket_path.push_app
+      end
+    end
+
+    context 'When wait_until_deployed option is set' do
+      let(:wait_until_deployed) { true }
+
+      example 'Waits until deployment completes' do
+        expect(provider).to receive(:s3).and_return(s3_mock).twice
+        expect(provider).to receive(:create_bucket)
+        expect(provider).to receive(:create_zip).and_return('/path/to/file.zip')
+        expect(provider).to receive(:archive_name).and_return('file.zip')
+        expect(provider).to receive(:upload).with('file.zip', '/path/to/file.zip').and_call_original
+        expect(provider).to receive(:sleep).with(5)
+        expect(provider).to receive(:create_app_version).with(bucket_mock).and_return(app_version)
+        expect(provider).to receive(:update_app).with(app_version)
+        expect(provider).to receive(:wait_until_deployed)
+
+        provider.push_app
       end
     end
   end


### PR DESCRIPTION
This PR adds a possibility to finish the build after ElasticBeanstalk environment update completes, if `wait_until_deployed` config option provided. It also prints out EB events messages during the build.

Tested both failing and successful builds:
Failing build (reason - broken .ebextensions config file): [23984152](https://travis-ci.com/planorama/PlanoLive/builds/23984152)
Successful build: [37741814](https://travis-ci.com/planorama/PlanoLive/jobs/37741814)