### PR TITLE
Clean up output from the git push to deis and fix tests.

### DIFF
--- a/lib/dpl/provider/deis.rb
+++ b/lib/dpl/provider/deis.rb
@@ -81,7 +81,7 @@ module DPL
       end
 
       def push_app
-        unless context.shell "git push #{verbose_flag} deis HEAD:refs/heads/master -f"
+        unless context.shell "git push #{verbose_flag} deis HEAD:refs/heads/master -f 2>&1 | tr -dc '[:alnum:][:space:][:punct:]' | sed -E 's/remote: (\\[1G)+//' | sed 's/\\[K$//'"
           error 'Deploying application failed.'
         end
       end

--- a/spec/provider/deis_spec.rb
+++ b/spec/provider/deis_spec.rb
@@ -98,7 +98,7 @@ describe DPL::Provider::Deis do
   describe "#push_app" do
     example do
       expect(provider.context).to receive(:shell).with(
-        'git push  deis HEAD:refs/heads/master -f'
+        "git push  deis HEAD:refs/heads/master -f 2>&1 | tr -dc '[:alnum:][:space:][:punct:]' | sed -E 's/remote: (\\[1G)+//' | sed 's/\\[K$//'"
       ).and_return(true)
       provider.push_app
     end


### PR DESCRIPTION
In the past the output from the deis push has been garbled due to git prepending a 'remote:' prefix combined with the deis-builder adding a e[1G unprintable character to attempt to clean it up. Travis did not handle that character as expected and would display the output wrong. These changes attempt to clean up the output so that it can be correctly displayed in travis.

Below is a sample of the output before and after this change.

```
remote:  buildpack
remote: remote: /heroku/heroku-buildpack-ruby.git
remote: ework: Ruby
remote: piling Ruby/Rack
remote: remote: remote: ent:test --path vendor/bundle --binstubs vendor/bundle/bin -j4 --deployment
remote: remote: remote: remote: initest 5.8.3
remote: remote: remote: espath 1.1.3
remote: remote: ime-types 2.99
remote: ini_portile2 2.0.0
remote: remote: remote: remote: remote: remote: remote: ons 1.2.3
remote: remote: ultipart-post 2.0.0
remote: ulti_json 1.11.2
remote: achine 1.0.9.1
```

```
       =====> Downloading Buildpack: https://github.com/heroku/heroku-buildpack-ruby.git
       =====> Detected Framework: Ruby
-----> Compiling Ruby/Rack
-----> Using Ruby version: ruby-2.3.0
-----> Installing dependencies using bundler 1.11.2
       Running: bundle install --without development:test --path vendor/bundle --binstubs vendor/bundle/bin -j4 --deployment
       Using i18n 0.7.0
       Using rake 10.4.2
       Using json 1.8.3
       Using minitest 5.8.3
       Using thread_safe 0.3.5
       Using addressable 2.4.0
       Using atomic 1.1.99
       Using jmespath 1.1.3
       Using backports 3.6.7
       Using mime-types 2.99
       Using mini_portile2 2.0.0
       Using rack 1.6.4
       Using coffee-script-source 1.10.0
       Using execjs 2.6.0
       Using sass 3.4.11
       Using concurrent-ruby 0.9.2
       Using contracts 0.12.0
       Using daemons 1.2.3
       Using dotenv 2.0.2
       Using multipart-post 2.0.0
       Using multi_json 1.11.2
       Using eventmachine 1.0.9.1
```