### PR TITLE
Pin mime-type for chef_supermarket provider

### DIFF
--- a/lib/dpl/provider/chef_supermarket.rb
+++ b/lib/dpl/provider/chef_supermarket.rb
@@ -6,6 +6,8 @@ module DPL
       # https://github.com/opscode/chef/blob/11.16.4/lib/chef/knife/cookbook_site_share.rb
 
       # Compatibility with ruby 1.9
+      requires 'rack', version: '< 2.0'
+      requires 'mime-types', version: '~> 1.16'
       requires 'chef', version: '< 12.0'
       requires 'chef', load: 'chef/config'
       requires 'chef', load: 'chef/cookbook_loader'


### PR DESCRIPTION
To be ruby 1.9 compatible we already enforced chef <12
Chef 11.18 needs mime-type ~> 1.16

This PR do the same as #365 but for chef_supermarket provider

Cc: @aboten