### PR TITLE
Allow setting the S3 bucket name and upload folder through environment vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,9 @@ It is possible to set file-specific `Cache-Control` and `Expires` headers using 
 
  * **AWS_ACCESS_KEY_ID**: AWS Access Key ID. Used if the `access-key-id` option is omitted.
  * **AWS_SECRET_ACCESS_KEY**: AWS Secret Key. Used if the `secret-access-key` option is omitted.
-
+ * **S3_BUCKET**: S3 Bucket. Used if the `bucket` option is omitted.
+ * **S3_UPLOAD_DIR**: S3 directory to upload to. Used if the `upload-dir` option is omitted.
+ 
 ##### Example:
 
     --cache_control="no-cache: index.html"

--- a/lib/dpl/provider/s3.rb
+++ b/lib/dpl/provider/s3.rb
@@ -46,7 +46,7 @@ module DPL
       end
 
       def upload_path(filename)
-        [upload_dir, filename].compact.join("/")
+        [upload_dir, filename].compact.join("/").gsub(/^\/+|(?<=\/)\/+|\/+$/, '')
       end
 
       def push_app

--- a/lib/dpl/provider/s3.rb
+++ b/lib/dpl/provider/s3.rb
@@ -37,8 +37,16 @@ module DPL
         log "Logging in with Access Key: #{access_key_id[-4..-1].rjust(20, '*')}"
       end
 
+      def bucket_name
+        options[:bucket] || context.env['S3_BUCKET']
+      end
+
+      def upload_dir
+        options[:upload_dir] || context.env['S3_UPLOAD_DIR']
+      end
+
       def upload_path(filename)
-        [options[:upload_dir], filename].compact.join("/")
+        [upload_dir, filename].compact.join("/")
       end
 
       def push_app
@@ -53,13 +61,13 @@ module DPL
             opts[:expires]       = get_option_value_by_filename(options[:expires], filename) if options[:expires]
             unless File.directory?(filename)
               log "uploading %p" % filename
-              api.bucket(option(:bucket)).object(upload_path(filename)).upload_file(filename, opts)
+              api.bucket(bucket_name).object(upload_path(filename)).upload_file(filename, opts)
             end
           end
         end
 
         if suffix = options[:index_document_suffix]
-          api.bucket(option(:bucket)).website.put(
+          api.bucket(bucket_name).website.put(
             website_configuration: {
               index_document: {
                 suffix: suffix


### PR DESCRIPTION
Allowing to set the bucket name and upload folder through env vars, makes it possible to control these parameters through the build script.

Use cases:
- Choose a bucket or upload folder based on the branch name
- Choose a the upload folder based on the tag (version)

The PR also contains a patch to clean up the `upload_path` for S3.
