### PR TITLE
Update OpsWorks deployment

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,3 +89,7 @@ end
 group :deis do
   gem 'git'
 end
+
+group :opsworks do
+  gem 'aws-sdk', '>= 2.0.18.pre'
+end

--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ It is possible to set file-specific `Cache-Control` and `Expires` headers using 
 * **layer-ids**: A layer id. (Use this option multiple times to specify multiple layer ids. Default: [])
 * **migrate**: Migrate the database. (Default: false)
 * **wait-until-deployed**: Wait until the app is deployed and return the deployment status. (Default: false)
-* **custom_json**: Override custom_json options. If using this, default configuration will be overriden. See the code [here](https://github.com/travis-ci/dpl/blob/master/lib/dpl/provider/ops_works.rb#L34). More about `custom_json` [here](http://docs.aws.amazon.com/opsworks/latest/userguide/workingcookbook-json.html).
+* **custom_json**: Override custom_json options. If using this, default configuration will be overriden. See the code [here](https://github.com/travis-ci/dpl/blob/master/lib/dpl/provider/ops_works.rb#L43). More about `custom_json` [here](http://docs.aws.amazon.com/opsworks/latest/userguide/workingcookbook-json.html).
 
 #### Environment variables:
 

--- a/README.md
+++ b/README.md
@@ -375,6 +375,8 @@ It is possible to set file-specific `Cache-Control` and `Expires` headers using 
 * **access-key-id**: AWS Access Key ID. Can be obtained from [here](https://console.aws.amazon.com/iam/home?#security_credential).
 * **secret-access-key**: AWS Secret Key. Can be obtained from [here](https://console.aws.amazon.com/iam/home?#security_credential).
 * **app-id**: The app ID.
+* **instance-ids**: An instance id. (Use this option multiple times to specify multiple instance ids. Default: [])
+* **layer-ids**: A layer id. (Use this option multiple times to specify multiple layer ids. Default: [])
 * **migrate**: Migrate the database. (Default: false)
 * **wait-until-deployed**: Wait until the app is deployed and return the deployment status. (Default: false)
 * **custom_json**: Override custom_json options. If using this, default configuration will be overriden. See the code [here](https://github.com/travis-ci/dpl/blob/master/lib/dpl/provider/ops_works.rb#L34). More about `custom_json` [here](http://docs.aws.amazon.com/opsworks/latest/userguide/workingcookbook-json.html).
@@ -387,6 +389,7 @@ It is possible to set file-specific `Cache-Control` and `Expires` headers using 
 #### Examples:
 
     dpl --provider=opsworks --access-key-id=<access-key-id> --secret-access-key=<secret-access-key> --app-id=<app-id> --migrate --wait-until-deployed
+    dpl --provider=opsworks --access-key-id=<access-key-id> --secret-access-key=<secret-access-key> --app-id=<app-id> --layer-ids=<layer-id>
 
 ### Anynines:
 

--- a/lib/dpl/provider/ops_works.rb
+++ b/lib/dpl/provider/ops_works.rb
@@ -3,7 +3,7 @@ require 'timeout'
 module DPL
   class Provider
     class OpsWorks < Provider
-      requires 'aws-sdk'
+      requires 'aws-sdk', version: '~> 2'
       experimental 'AWS OpsWorks'
 
       def opsworks
@@ -37,12 +37,7 @@ module DPL
         options[:secret_access_key] || context.env['AWS_SECRET_ACCESS_KEY'] || raise(Error, "missing secret_access_key")
       end
 
-      def setup_auth
-        Aws.config.update(credentials: ::Aws::Credentials.new(access_key_id, secret_access_key))
-      end
-
       def check_auth
-        setup_auth
         log "Logging in with Access Key: #{access_key_id[-4..-1].rjust(20, '*')}"
       end
 

--- a/lib/dpl/provider/ops_works.rb
+++ b/lib/dpl/provider/ops_works.rb
@@ -3,15 +3,18 @@ require 'timeout'
 module DPL
   class Provider
     class OpsWorks < Provider
-      requires 'aws-sdk-v1'
+      requires 'aws-sdk'
       experimental 'AWS OpsWorks'
 
-      def api
-        @api ||= AWS::OpsWorks.new
+      def opsworks
+        @opsworks ||= Aws::OpsWorks::Client.new(opsworks_options)
       end
 
-      def client
-        @client ||= api.client
+      def opsworks_options
+        {
+          region:      region || 'us-east-1',
+          credentials: ::Aws::Credentials.new(access_key_id, secret_access_key)
+        }
       end
 
       def needs_key?
@@ -20,6 +23,10 @@ module DPL
 
       def check_app
 
+      end
+
+      def region
+        options[:region] || context.env['AWS_DEFAULT_REGION']
       end
 
       def access_key_id
@@ -31,12 +38,12 @@ module DPL
       end
 
       def setup_auth
-        AWS.config(access_key_id: access_key_id, secret_access_key: secret_access_key)
+        Aws.config.update(credentials: ::Aws::Credentials.new(access_key_id, secret_access_key))
       end
 
       def check_auth
         setup_auth
-        log "Logging in with Access Key: #{option(:access_key_id)[-4..-1].rjust(20, '*')}"
+        log "Logging in with Access Key: #{access_key_id[-4..-1].rjust(20, '*')}"
       end
 
       def custom_json
@@ -61,7 +68,7 @@ module DPL
       end
 
       def fetch_ops_works_app
-        data = client.describe_apps(app_ids: [option(:app_id)])
+        data = opsworks.describe_apps(app_ids: [option(:app_id)])
         unless data[:apps] && data[:apps].count == 1
           raise Error, "App #{option(:app_id)} not found.", error.backtrace
         end
@@ -87,7 +94,11 @@ module DPL
         if !options[:instance_ids].nil?
           deployment_config[:instance_ids] = Array(option(:instance_ids))
         end
-        data = client.create_deployment(deployment_config)
+        if !options[:layer_ids].nil?
+          deployment_config[:layer_ids] = Array(option(:layer_ids))
+        end
+        log "creating deployment #{deployment_config.to_json}"
+        data = opsworks.create_deployment(deployment_config)
         log "Deployment created: #{data[:deployment_id]}"
         return unless options[:wait_until_deployed]
         print "Deploying "
@@ -103,7 +114,7 @@ module DPL
       def wait_until_deployed(deployment_id)
         deployment = nil
         loop do
-          result = client.describe_deployments(deployment_ids: [deployment_id])
+          result = opsworks.describe_deployments(deployment_ids: [deployment_id])
           deployment = result[:deployments].first
           break unless deployment[:status] == "running"
           print "."
@@ -118,10 +129,8 @@ module DPL
 
       def deploy
         super
-      rescue AWS::Errors::ClientError => error
-        raise Error, "Stopping Deploy, OpsWorks error: #{error.message}", error.backtrace
-      rescue AWS::Errors::ServerError => error
-        raise Error, "Stopping Deploy, OpsWorks server error: #{error.message}", error.backtrace
+      rescue Aws::Errors::ServiceError => error
+        raise Error, "Stopping Deploy, OpsWorks service error: #{error.message}", error.backtrace
       end
     end
   end

--- a/spec/provider/ops_works_spec.rb
+++ b/spec/provider/ops_works_spec.rb
@@ -80,6 +80,15 @@ describe DPL::Provider::OpsWorks do
       ).and_return({})
       provider.push_app
     end
+
+    example 'with :layer-ids' do
+      provider.options.update(app_id: 'app-id', layer_ids: ['layer-id'])
+      expect(client).to receive(:describe_apps).with(app_ids: ['app-id']).and_return({apps: [ops_works_app]})
+      expect(client).to receive(:create_deployment).with(
+        stack_id: 'stack-id', app_id: 'app-id', layer_ids:['layer-id'], command: {name: 'deploy'}, comment: 'Deploy build 123 via Travis CI', custom_json: custom_json
+      ).and_return({})
+      provider.push_app
+    end
   end
 
   describe "#api" do

--- a/spec/provider/ops_works_spec.rb
+++ b/spec/provider/ops_works_spec.rb
@@ -1,30 +1,36 @@
 require 'spec_helper'
-require 'aws-sdk-v1'
+require 'aws-sdk'
 require 'dpl/provider'
 require 'dpl/provider/ops_works'
 
 describe DPL::Provider::OpsWorks do
 
-  before (:each) do
-    AWS.stub!
+  subject :provider do
+    described_class.new(DummyContext.new, :access_key_id => 'qwertyuiopasdfghjklz', :secret_access_key => 'qwertyuiopasdfghjklzqwertyuiopasdfghjklz')
   end
 
-  subject :provider do
-    described_class.new(DummyContext.new, :access_key_id => 'qwertyuiopasdfghjklz', :secret_access_key => 'qwertyuiopasdfghjklzqwertyuiopasdfghjklz', :bucket => 'my-bucket')
+  describe '#opsworks_options' do
+    context 'without region' do
+      example do
+        options = provider.opsworks_options
+        expect(options[:region]).to eq('us-east-1')
+      end
+    end
+
+    context 'with region' do
+      example do
+        region = 'us-west-1'
+        provider.options.update(:region => region)
+        options = provider.opsworks_options
+        expect(options[:region]).to eq(region)
+      end
+    end
   end
 
   describe "#check_auth" do
     example do
-      expect(provider).to receive(:setup_auth)
       expect(provider).to receive(:log).with('Logging in with Access Key: ****************jklz')
       provider.check_auth
-    end
-  end
-
-  describe "#setup_auth" do
-    example do
-      expect(AWS).to receive(:config).with(:access_key_id => 'qwertyuiopasdfghjklz', :secret_access_key => 'qwertyuiopasdfghjklzqwertyuiopasdfghjklz').once.and_call_original
-      provider.setup_auth
     end
   end
 
@@ -34,67 +40,88 @@ describe DPL::Provider::OpsWorks do
     end
   end
 
-  describe "#push_app" do
-    let(:client) { double(:ops_works_client) }
-    let(:ops_works_app) { {shortname: 'app', stack_id: 'stack-id'} }
-    before do
-      expect(provider).to receive(:current_sha).and_return('sha')
-      expect(provider.api).to receive(:client).and_return(client)
-      expect(provider.context.env).to receive(:[]).with('TRAVIS_BUILD_NUMBER').and_return('123')
+  describe DPL::Provider::OpsWorks do
+    access_key_id = 'someaccesskey'
+    secret_access_key = 'somesecretaccesskey'
+    region = 'us-east-1'
+
+    client_options = {
+      stub_responses: true,
+      region: region,
+      credentials: Aws::Credentials.new(access_key_id, secret_access_key)
+    }
+
+    subject :provider do
+      described_class.new(DummyContext.new, {
+        access_key_id: access_key_id,
+        secret_access_key: secret_access_key
+      })
     end
 
-    let(:custom_json) { "{\"deploy\":{\"app\":{\"migrate\":false,\"scm\":{\"revision\":\"sha\"}}}}" }
-    example 'without :migrate option' do
-      provider.options.update(app_id: 'app-id')
-      expect(client).to receive(:describe_apps).with(app_ids: ['app-id']).and_return({apps: [ops_works_app]}
-      )
-      expect(client).to receive(:create_deployment).with(
-        stack_id: 'stack-id', app_id: 'app-id', command: {name: 'deploy'}, comment: 'Deploy build 123 via Travis CI', custom_json: custom_json
-      ).and_return({})
-      provider.push_app
+    before :each do
+      expect(provider).to receive(:opsworks_options).and_return(client_options)
     end
 
-    let(:custom_json_with_migrate) { "{\"deploy\":{\"app\":{\"migrate\":true,\"scm\":{\"revision\":\"sha\"}}}}" }
-    example 'with :migrate option' do
-      provider.options.update(app_id: 'app-id', migrate: true)
-      expect(client).to receive(:describe_apps).with(app_ids: ['app-id']).and_return({apps: [ops_works_app]})
-      expect(client).to receive(:create_deployment).with(
-        stack_id: 'stack-id', app_id: 'app-id', command: {name: 'deploy'}, comment: 'Deploy build 123 via Travis CI', custom_json: custom_json_with_migrate
-      ).and_return({})
-      provider.push_app
+    describe '#opsworks' do
+      example do
+        expect(Aws::OpsWorks::Client).to receive(:new).with(client_options).once
+        provider.opsworks
+      end
     end
 
-    example 'with :wait_until_deployed' do
-      provider.options.update(app_id: 'app-id', wait_until_deployed: true)
-      expect(client).to receive(:describe_apps).with(app_ids: ['app-id']).and_return({apps: [ops_works_app]})
-      expect(client).to receive(:create_deployment).and_return({deployment_id: 'deployment_id'})
-      expect(client).to receive(:describe_deployments).with({deployment_ids: ['deployment_id']}).and_return({deployments: [status: 'running']}, {deployments: [status: 'successful']})
-      provider.push_app
-    end
+    describe "#push_app" do
+      let(:client) { provider.opsworks }
+      let(:ops_works_app) { {shortname: 'app', stack_id: 'stack-id'} }
+      before do
+        expect(provider).to receive(:current_sha).and_return('sha')
+        expect(provider.context.env).to receive(:[]).with('TRAVIS_BUILD_NUMBER').and_return('123')
+      end
 
-    example 'with :instance-ids' do
-      provider.options.update(app_id: 'app-id', instance_ids: ['instance-id'])
-      expect(client).to receive(:describe_apps).with(app_ids: ['app-id']).and_return({apps: [ops_works_app]})
-      expect(client).to receive(:create_deployment).with(
-        stack_id: 'stack-id', app_id: 'app-id', instance_ids:['instance-id'], command: {name: 'deploy'}, comment: 'Deploy build 123 via Travis CI', custom_json: custom_json
-      ).and_return({})
-      provider.push_app
-    end
+      let(:custom_json) { "{\"deploy\":{\"app\":{\"migrate\":false,\"scm\":{\"revision\":\"sha\"}}}}" }
+      example 'without :migrate option' do
+        provider.options.update(app_id: 'app-id')
+        expect(client).to receive(:describe_apps).with(app_ids: ['app-id']).and_return({apps: [ops_works_app]})
+        expect(client).to receive(:create_deployment).with(
+          stack_id: 'stack-id', app_id: 'app-id', command: {name: 'deploy'}, comment: 'Deploy build 123 via Travis CI', custom_json: custom_json
+        ).and_return({})
+        provider.push_app
+      end
 
-    example 'with :layer-ids' do
-      provider.options.update(app_id: 'app-id', layer_ids: ['layer-id'])
-      expect(client).to receive(:describe_apps).with(app_ids: ['app-id']).and_return({apps: [ops_works_app]})
-      expect(client).to receive(:create_deployment).with(
-        stack_id: 'stack-id', app_id: 'app-id', layer_ids:['layer-id'], command: {name: 'deploy'}, comment: 'Deploy build 123 via Travis CI', custom_json: custom_json
-      ).and_return({})
-      provider.push_app
-    end
-  end
+      let(:custom_json_with_migrate) { "{\"deploy\":{\"app\":{\"migrate\":true,\"scm\":{\"revision\":\"sha\"}}}}" }
+      example 'with :migrate option' do
+        provider.options.update(app_id: 'app-id', migrate: true)
+        expect(client).to receive(:describe_apps).with(app_ids: ['app-id']).and_return({apps: [ops_works_app]})
+        expect(client).to receive(:create_deployment).with(
+          stack_id: 'stack-id', app_id: 'app-id', command: {name: 'deploy'}, comment: 'Deploy build 123 via Travis CI', custom_json: custom_json_with_migrate
+        ).and_return({})
+        provider.push_app
+      end
 
-  describe "#api" do
-    example do
-      expect(AWS::OpsWorks).to receive(:new)
-      provider.api
+      example 'with :wait_until_deployed' do
+        provider.options.update(app_id: 'app-id', wait_until_deployed: true)
+        expect(client).to receive(:describe_apps).with(app_ids: ['app-id']).and_return({apps: [ops_works_app]})
+        expect(client).to receive(:create_deployment).and_return({deployment_id: 'deployment_id'})
+        expect(client).to receive(:describe_deployments).with({deployment_ids: ['deployment_id']}).and_return({deployments: [status: 'running']}, {deployments: [status: 'successful']})
+        provider.push_app
+      end
+
+      example 'with :instance-ids' do
+        provider.options.update(app_id: 'app-id', instance_ids: ['instance-id'])
+        expect(client).to receive(:describe_apps).with(app_ids: ['app-id']).and_return({apps: [ops_works_app]})
+        expect(client).to receive(:create_deployment).with(
+          stack_id: 'stack-id', app_id: 'app-id', instance_ids:['instance-id'], command: {name: 'deploy'}, comment: 'Deploy build 123 via Travis CI', custom_json: custom_json
+        ).and_return({})
+        provider.push_app
+      end
+
+      example 'with :layer-ids' do
+        provider.options.update(app_id: 'app-id', layer_ids: ['layer-id'])
+        expect(client).to receive(:describe_apps).with(app_ids: ['app-id']).and_return({apps: [ops_works_app]})
+        expect(client).to receive(:create_deployment).with(
+          stack_id: 'stack-id', app_id: 'app-id', layer_ids:['layer-id'], command: {name: 'deploy'}, comment: 'Deploy build 123 via Travis CI', custom_json: custom_json
+        ).and_return({})
+        provider.push_app
+      end
     end
   end
 end


### PR DESCRIPTION
Hey this PR updates the AWS OpsWorks provider.

##### changes 

- switch to aws sdk v2
- add layer-ids option to opsworks deployment
- fix access key id lookup

afterwards it should be possible to add the `layer-id` option to the .travis.yml like:

```yml
deploy:
  provider: opsworks
  app-id: <app-id>
  layer-ids:
    - <layer-id>
```

This PR relates to #191 travis-ci/travis-ci#2905