### PR TITLE
update npm deploy provider to see parts of the key

### DIFF
--- a/lib/dpl/provider/npm.rb
+++ b/lib/dpl/provider/npm.rb
@@ -22,8 +22,7 @@ module DPL
 
       def check_auth
         setup_auth
-        api_key = option(:api_key).gsub(/[^-]/, '*')[0..-5] + option(:api_key)[-4..-1]
-        log "Authenticated with email #{option(:email)} and api-key #{api_key}"
+        log "Authenticated with email #{option(:email)} and API key #{option(:api_key)[-4..-1].rjust(20, '*')}"
       end
 
       def push_app

--- a/lib/dpl/provider/npm.rb
+++ b/lib/dpl/provider/npm.rb
@@ -22,7 +22,8 @@ module DPL
 
       def check_auth
         setup_auth
-        log "Authenticated with email #{option(:email)}"
+        api_key = option(:api_key).gsub(/[^-]/, '*')[0..-5] + option(:api_key)[-4..-1]
+        log "Authenticated with email #{option(:email)} and api-key #{api_key}"
       end
 
       def push_app

--- a/spec/provider/npm_spec.rb
+++ b/spec/provider/npm_spec.rb
@@ -13,7 +13,7 @@ describe DPL::Provider::NPM do
   describe "#check_auth" do
     example do
       expect(provider).to receive(:setup_auth)
-      expect(provider).to receive(:log).with("Authenticated with email foo@blah.com")
+      expect(provider).to receive(:log).with("Authenticated with email foo@blah.com and API key #{'test'.rjust(20, '*')}");
       provider.check_auth
     end
   end


### PR DESCRIPTION
Hey,

this PR adds logging for the provided api-key to the npm provider. This will only display the last 4 characters and obfuscate the rest. It helped me personally getting the npm deploy running, as I mistakenly encrypted the values wrongly (I used --pro with the travis cli although this repo was public and --org would have been correct).
