### PR TITLE
Allow users to specify default text charset

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,7 @@ For authentication you can also use Travis CI secure environment variable:
 * **acl**: Sets the access control for the uploaded objects. Defaults to `private`. Valid options are `private`, `public_read`, `public_read_write`, `authenticated_read`, `bucket_owner_read`, `bucket_owner_full_control`.
 * **dot_match**: When set to `true`, upload files starting a `.`.
 * **index_document_suffix**: Set the index document of a S3 website.
+* **default_text_charset**: Set the default character set to append to the content-type of text files you are uploading.
 
 #### File-specific `Cache-Control` and `Expires` headers
 

--- a/lib/dpl/provider.rb
+++ b/lib/dpl/provider.rb
@@ -212,12 +212,12 @@ module DPL
       options[:detect_encoding]
     end
 
-    def default_text_encoding?
-      options[:default_text_encoding]
+    def default_text_charset?
+      options[:default_text_charset]
     end
 
-    def default_text_encoding
-      options[:default_text_encoding].downcase
+    def default_text_charset
+      options[:default_text_charset].downcase
     end
 
     def encoding_for(path)
@@ -228,9 +228,7 @@ module DPL
       when /compress'd/
         'compress'
       when /text/
-        if default_text_encoding?
-          default_text_encoding
-        end
+        'text'
       when /data/
         # Shrugs?
       end

--- a/lib/dpl/provider.rb
+++ b/lib/dpl/provider.rb
@@ -212,6 +212,14 @@ module DPL
       options[:detect_encoding]
     end
 
+    def default_text_encoding?
+      !options[:default_text_encoding].empty?
+    end
+
+    def default_text_encoding
+      options[:default_text_encoding].downcase
+    end
+
     def encoding_for(path)
       file_cmd_output = `file '#{path}'`
       case file_cmd_output
@@ -219,6 +227,12 @@ module DPL
         'gzip'
       when /compress'd/
         'compress'
+      when /text/
+        if default_text_encoding?
+          default_text_encoding
+        end
+      when /data/
+        # Shrugs?
       end
     end
 

--- a/lib/dpl/provider.rb
+++ b/lib/dpl/provider.rb
@@ -213,7 +213,7 @@ module DPL
     end
 
     def default_text_encoding?
-      !options[:default_text_encoding].empty?
+      options[:default_text_encoding]
     end
 
     def default_text_encoding

--- a/lib/dpl/provider/s3.rb
+++ b/lib/dpl/provider/s3.rb
@@ -84,9 +84,13 @@ module DPL
         content_type = MIME::Types.type_for(path).first
         content_data[:content_type] = content_type.to_s
 
+        encoding = encoding_for(path)
         if detect_encoding?
-          encoding = encoding_for(path)
           content_data[:content_encoding] = encoding if encoding
+        end
+
+        if encoding == 'text' && default_text_charset?
+          content_data[:content_type] = "#{content_data[:content_type]}; charset=#{default_text_charset}"
         end
 
         return content_data

--- a/lib/dpl/provider/s3.rb
+++ b/lib/dpl/provider/s3.rb
@@ -46,13 +46,12 @@ module DPL
         glob_args << File::FNM_DOTMATCH if options[:dot_match]
         Dir.chdir(options.fetch(:local_dir, Dir.pwd)) do
           Dir.glob(*glob_args) do |filename|
-            content_type = MIME::Types.type_for(filename).first.to_s
-            opts         = { :content_type => content_type }.merge(encoding_option_for(filename))
+            opts                 = content_data_for(filename)
             opts[:cache_control] = get_option_value_by_filename(options[:cache_control], filename) if options[:cache_control]
             opts[:acl]           = options[:acl].gsub(/_/, '-') if options[:acl]
             opts[:expires]       = get_option_value_by_filename(options[:expires], filename) if options[:expires]
             unless File.directory?(filename)
-              log "uploading %p" % filename
+              log "uploading #{filename.inspect} with #{opts.inspect}"
               api.bucket(option(:bucket)).object(upload_path(filename)).upload_file(filename, opts)
             end
           end
@@ -80,12 +79,17 @@ module DPL
       end
 
       private
-      def encoding_option_for(path)
-        if detect_encoding? && encoding_for(path)
-          {:content_encoding => encoding_for(path)}
-        else
-          {}
+      def content_data_for(path)
+        content_data = {}
+        content_type = MIME::Types.type_for(path).first
+        content_data[:content_type] = content_type.to_s
+
+        if detect_encoding?
+          encoding = encoding_for(path)
+          content_data[:content_encoding] = encoding if encoding
         end
+
+        return content_data
       end
 
       def get_option_value_by_filename(option_values, filename)

--- a/spec/provider_spec.rb
+++ b/spec/provider_spec.rb
@@ -163,7 +163,7 @@ describe DPL::Provider do
     example do
       path = 'foo.js'
       expect(provider).to receive(:`).at_least(1).times.with("file '#{path}'").and_return("#{path}: ASCII text, with very long line")
-      expect(provider.encoding_for(path)).to eq('')
+      expect(provider.encoding_for(path)).to eq(nil)
     end
 
     example do

--- a/spec/provider_spec.rb
+++ b/spec/provider_spec.rb
@@ -159,6 +159,19 @@ describe DPL::Provider do
       expect(provider).to receive(:`).at_least(1).times.with("file '#{path}'").and_return("#{path}: empty")
       expect(provider.encoding_for(path)).to be_nil
     end
+
+    example do
+      path = 'foo.js'
+      expect(provider).to receive(:`).at_least(1).times.with("file '#{path}'").and_return("#{path}: ASCII text, with very long line")
+      expect(provider.encoding_for(path)).to eq('')
+    end
+
+    example do
+      path = 'foo.js'
+      provider.options.update(:default_text_encoding => 'UTF-8')
+      expect(provider).to receive(:`).at_least(1).times.with("file '#{path}'").and_return("#{path}: ASCII text, with very long line")
+      expect(provider.encoding_for(path)).to eq('utf-8')
+    end
   end
 
   describe "#log" do

--- a/spec/provider_spec.rb
+++ b/spec/provider_spec.rb
@@ -163,14 +163,14 @@ describe DPL::Provider do
     example do
       path = 'foo.js'
       expect(provider).to receive(:`).at_least(1).times.with("file '#{path}'").and_return("#{path}: ASCII text, with very long line")
-      expect(provider.encoding_for(path)).to eq(nil)
+      expect(provider.encoding_for(path)).to eq('text')
     end
 
     example do
       path = 'foo.js'
-      provider.options.update(:default_text_encoding => 'UTF-8')
+      provider.options.update(:default_text_charset => 'UTF-8')
       expect(provider).to receive(:`).at_least(1).times.with("file '#{path}'").and_return("#{path}: ASCII text, with very long line")
-      expect(provider.encoding_for(path)).to eq('utf-8')
+      expect(provider.encoding_for(path)).to eq('text')
     end
   end
 


### PR DESCRIPTION
We're running into issues where AWS isn't getting our charset right. This allows us to specify it for text files.