### PR TITLE
Fix Google Cloud SDK v114.0.0 GAE deploy error

### DIFF
--- a/README.md
+++ b/README.md
@@ -796,7 +796,6 @@ In order to use this provider, please make sure you have the [App Engine Admin A
 * **version**: The version of the app that will be created or replaced by this deployment. If you do not specify a version, one will be generated for you. See [`gcloud preview app deploy`](https://cloud.google.com/sdk/gcloud/reference/preview/app/deploy)
 * **no_promote**: Flag to not promote the deployed version. See [`gcloud preview app deploy`](https://cloud.google.com/sdk/gcloud/reference/preview/app/deploy)
 * **verbosity**: Let's you adjust the verbosity when invoking `"gcloud"`. Defaults to `"warning"`. See [`gcloud`](https://cloud.google.com/sdk/gcloud/reference/).
-* **docker_build**: If deploying a Managed VM, specifies where to build your image. Typical values are `"remote"` to build on Google Cloud Engine and `"local"` which requires Docker to be set up properly (to utilize this on Travis CI, read [Using Docker on Travis CI](http://blog.travis-ci.com/2015-08-19-using-docker-on-travis-ci/)). Defaults to `"remote"`.
 * **no_stop_previous_version**: Flag to prevent your deployment from stopping the previously promoted version. This is from the future, so might not work (yet). See [`gcloud preview app deploy`](https://cloud.google.com/sdk/gcloud/reference/preview/app/deploy)
 
 #### Environment variables:

--- a/lib/dpl/provider/gae.rb
+++ b/lib/dpl/provider/gae.rb
@@ -58,10 +58,6 @@ module DPL
         options[:no_promote]
       end
 
-      def use_cloud_build
-        options[:use_cloud_build] || 'false'
-      end
-
       def verbosity
         options[:verbosity] || 'warning'
       end
@@ -75,7 +71,6 @@ module DPL
       end
 
       def push_app
-        context.shell "#{GCLOUD} config set app/use_cloud_build #{use_cloud_build}"
         command = GCLOUD
         command << ' --quiet'
         command << " --verbosity \"#{verbosity}\""

--- a/lib/dpl/provider/gae.rb
+++ b/lib/dpl/provider/gae.rb
@@ -62,10 +62,6 @@ module DPL
         options[:verbosity] || 'warning'
       end
 
-      def docker_build
-        options[:docker_build] || 'remote'
-      end
-
       def no_stop_previous_version
         options[:no_stop_previous_version]
       end
@@ -77,7 +73,6 @@ module DPL
         command << " --project \"#{project}\""
         command << " preview app deploy \"#{config}\""
         command << " --version \"#{version}\""
-        command << " --docker-build \"#{docker_build}\""
         command << " --#{no_promote ? 'no-' : ''}promote"
         command << (no_stop_previous_version ? ' --no-stop-previous-version' : '')
         unless context.shell(command)

--- a/spec/provider/gae_spec.rb
+++ b/spec/provider/gae_spec.rb
@@ -8,7 +8,7 @@ describe DPL::Provider::GAE do
 
   describe '#push_app' do
     example 'with defaults' do
-      allow(provider.context).to receive(:shell).with("#{DPL::Provider::GAE::GCLOUD} --quiet --verbosity \"warning\" --project \"test\" preview app deploy \"app.yaml\" --version \"\" --docker-build \"remote\" --promote").and_return(true)
+      allow(provider.context).to receive(:shell).with("#{DPL::Provider::GAE::GCLOUD} --quiet --verbosity \"warning\" --project \"test\" preview app deploy \"app.yaml\" --version \"\" --promote").and_return(true)
       provider.push_app
     end
   end

--- a/spec/provider/gae_spec.rb
+++ b/spec/provider/gae_spec.rb
@@ -8,7 +8,6 @@ describe DPL::Provider::GAE do
 
   describe '#push_app' do
     example 'with defaults' do
-      allow(provider.context).to receive(:shell).with("#{DPL::Provider::GAE::GCLOUD} config set app/use_cloud_build false").and_return(true)
       allow(provider.context).to receive(:shell).with("#{DPL::Provider::GAE::GCLOUD} --quiet --verbosity \"warning\" --project \"test\" preview app deploy \"app.yaml\" --version \"\" --docker-build \"remote\" --promote").and_return(true)
       provider.push_app
     end


### PR DESCRIPTION
`use_cloud_build` and `docker_build` options had already been deprecated in Google Cloud SDK v112.0.0 and removed in Google Cloud SDK v114.0.0

If we kept the `use_cloud_build` option, we will get the error below while deploying to GAE with Google Cloud SDK v114.0.0:
`ERROR: (gcloud.config.set) Section "app" has no property "use_cloud_build".`

If we kept the `docker_build` option, we will get the error below while deploying to GAE with Google Cloud SDK v114.0.0:
```
ERROR: (gcloud.preview.app.deploy) Docker builds now use Container Builder by default. To run a Docker build on
your own host, you can run:
    docker build -t gcr.io/<project>/<service.version> .
    gcloud docker push gcr.io/<project>/<service.version>
    gcloud preview app deploy --image-url=gcr.io/<project>/<service.version>
```

This PR can fix these two errors.
Since this script will always get the newest version of Google Cloud SDK from <https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz>,
I didn't deal with the backward compatibility.