### PR TITLE
Added Maven Repository support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Dpl supports the following providers:
 * [Script](#script)
 * [Surge.sh](#surgesh)
 * [TestFairy](#testfairy)
+* [Maven Repository](#maven-repository)
 
 ## Installation:
 
@@ -836,4 +837,16 @@ In order to use this provider, please make sure you have the [App Engine Admin A
 
 #### Example:
     dpl --provider=surge --project=<project-path> --domain=<domain-name>
-    
+
+
+### Maven Repository
+
+#### Options:
+
+* **id**: Required. The repository id.
+* **url**: Required. The url of repository host to push to.
+* **gpg-passphase**: Required. The passphase for GPG signing.
+* **secret-key-file**: Required. The file of secret key used for GPG signing.
+
+#### Example:
+     dpl --provider=maven --id=<ID> --url=<url>  --gpg-passphrase=<passphrase> --secret-key-file=<file>

--- a/README.md
+++ b/README.md
@@ -843,14 +843,14 @@ In order to use this provider, please make sure you have the [App Engine Admin A
 
 #### Options:
 
-* **id**: Required. The repository id.
-* **url**: Required. The url of repository host to push to.
 * **gpg-passphase**: Required. The passphase for GPG signing.
 * **secret-key-file**: Required. The file of secret key used for GPG signing.
 * **username**: Required. The username for Nexus repository server authorizing.
 * **password**: Required. The password for Nexus repository server authorizing.
 * **retry-count**: Optional. The times a failed deployment will be retried before giving up. Default is 1.
+* **id**: Optional. The repository id. Default value: `nexus-releases`.
+* **url**: Optional. The url of repository server to push to. Default value: `https://oss.sonatype.org/service/local/staging/deploy/maven2/`.
 
 #### Example:
 
-     dpl --provider=maven --id=<ID> --url=<url>  --gpg-passphrase=<******> --secret-key-file=<file> --username=<username> --passoword=<*****>
+     dpl --provider=maven --gpg-passphrase=<******> --secret-key-file=<file> --username=<username> --passoword=<*****>

--- a/README.md
+++ b/README.md
@@ -847,6 +847,10 @@ In order to use this provider, please make sure you have the [App Engine Admin A
 * **url**: Required. The url of repository host to push to.
 * **gpg-passphase**: Required. The passphase for GPG signing.
 * **secret-key-file**: Required. The file of secret key used for GPG signing.
+* **username**: Required. The username for Nexus repository server authorizing.
+* **password**: Required. The password for Nexus repository server authorizing.
+* **retry-count**: Optional. The times a failed deployment will be retried before giving up. Default is 1.
 
 #### Example:
-     dpl --provider=maven --id=<ID> --url=<url>  --gpg-passphrase=<passphrase> --secret-key-file=<file>
+
+     dpl --provider=maven --id=<ID> --url=<url>  --gpg-passphrase=<******> --secret-key-file=<file> --username=<username> --passoword=<*****>

--- a/lib/dpl/provider.rb
+++ b/lib/dpl/provider.rb
@@ -45,7 +45,7 @@ module DPL
     autoload :Surge,            'dpl/provider/surge'
     autoload :TestFairy,        'dpl/provider/testfairy'
     autoload :Transifex,        'dpl/provider/transifex'
-
+    autoload :Maven,		'dpl/provider/maven'
 
     def self.new(context, options)
       return super if self < Provider

--- a/lib/dpl/provider/maven.rb
+++ b/lib/dpl/provider/maven.rb
@@ -4,6 +4,8 @@ module DPL
       requires 'builder'
 
       SETTINGS_XML = './settings.xml'
+      DEFAULT_ID = "nexus-releases"
+      DEFAULT_URL = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
 
       def needs_key?
         false
@@ -24,14 +26,6 @@ module DPL
 
       def gpg_passphrase
         options[:gpg_passphrase]|| raise(Error, "missing gpg_passphrase")
-      end
-
-      def id
-        options[:id]|| raise(Error, "missing id")
-      end
-
-      def url
-        options[:url] || raise(Error, "missing url")
       end
 
       def settings_xml
@@ -60,6 +54,14 @@ module DPL
         options[:retry_count] || 1
       end
 
+      def id
+        options[:id]|| DEFAULT_ID
+      end
+
+      def url
+        options[:url] || DEFAULT_URL
+      end
+      
       def push_app
         File.open(SETTINGS_XML, 'w') { |file| file.write(settings_xml) }
         context.shell "gpg --import #{secret_key_file()}"

--- a/lib/dpl/provider/maven.rb
+++ b/lib/dpl/provider/maven.rb
@@ -1,0 +1,40 @@
+module DPL
+  class Provider
+    class Maven < Provider
+
+      def needs_key?
+        false
+      end
+
+      def check_app
+      end
+
+      def setup_auth
+      end
+
+      def check_auth
+      end
+
+      def secret_key_file
+        options[:secret_key_file]|| raise(Error, "missing secret_key_file")
+      end
+
+      def gpg_passphrase
+        options[:gpg_passphrase]|| raise(Error, "missing gpg_passphrase")
+      end
+
+      def id
+        options[:id]|| raise(Error, "missing id")
+      end
+
+      def url
+        options[:url]|| raise(Error, "missing url")
+      end
+
+      def push_app
+        context.shell "gpg --import #{secret_key_file()}"
+        context.shell "mvn verify gpg:sign deploy:deploy -Dgpg.passphrase=#{gpg_passphrase()} -DaltDeploymentRepository=#{id()}::default::#{url()}"
+      end
+    end
+  end
+end

--- a/lib/dpl/provider/maven.rb
+++ b/lib/dpl/provider/maven.rb
@@ -1,6 +1,9 @@
 module DPL
   class Provider
     class Maven < Provider
+      requires 'builder'
+
+      SETTINGS_XML = './settings.xml'
 
       def needs_key?
         false
@@ -28,12 +31,40 @@ module DPL
       end
 
       def url
-        options[:url]|| raise(Error, "missing url")
+        options[:url] || raise(Error, "missing url")
+      end
+
+      def settings_xml
+        xml = Builder::XmlMarkup.new( :indent => 2 )
+        xml.instruct! :xml, :encoding => "UTF-8"
+        xml.settings do |p|
+          p.servers do |q|
+            q.server do |server|
+              server.id id
+              server.username username
+              server.password password 
+            end
+          end
+        end
+      end
+
+      def username
+        options[:username] || raise(Error, "missing username")
+      end
+
+      def password
+        options[:password] || raise(Error, "missing password")
+      end
+
+      def retry_count
+        options[:retry_count] || 1
       end
 
       def push_app
+        File.open(SETTINGS_XML, 'w') { |file| file.write(settings_xml) }
         context.shell "gpg --import #{secret_key_file()}"
-        context.shell "mvn verify gpg:sign deploy:deploy -Dgpg.passphrase=#{gpg_passphrase()} -DaltDeploymentRepository=#{id()}::default::#{url()}"
+        context.shell "mvn verify gpg:sign deploy:deploy --settings settings.xml -Dgpg.passphrase=#{gpg_passphrase()} -DaltDeploymentRepository=#{id()}::default::#{url()} -DretryFailedDeploymentCount=#{retry_count()}"
+        File.delete(SETTINGS_XML)
       end
     end
   end


### PR DESCRIPTION
I have added support for Maven repository deployment.

This provider utilizes maven (as well as `maven-gpg-plugin` and `maven-deploy-plugin`) to GPG-sign files and deploy them to Nexus repository. It mainly eases the pain of creating maven's `settings.xml` for each project and invoking maven command.

The provider requires the following options:
- username/password for authorizing with Nexus repository's sever.
- secret-key-file for GPG signing the jars to be deployed.

And it allows user to switch the url and id of repository. 
