### PR TITLE
Deis provider: unthrow error on push_app

### DIFF
--- a/lib/dpl/provider/deis.rb
+++ b/lib/dpl/provider/deis.rb
@@ -81,7 +81,7 @@ module DPL
       end
 
       def push_app
-        unless context.shell "git push #{verbose_flag} deis HEAD:refs/heads/master -f 2>&1 | tr -dc '[:alnum:][:space:][:punct:]' | sed -E 's/remote: (\\[1G)+//' | sed 's/\\[K$//'"
+        unless context.shell "git push #{verbose_flag} deis HEAD:refs/heads/master -f 2>&1 | tr -dc '[:alnum:][:space:][:punct:]' | sed -E 's/remote: (\\[1G)+//' | sed 's/\\[K$//'; exit ${PIPESTATUS[1]}"
           error 'Deploying application failed.'
         end
       end

--- a/spec/provider/deis_spec.rb
+++ b/spec/provider/deis_spec.rb
@@ -98,7 +98,7 @@ describe DPL::Provider::Deis do
   describe "#push_app" do
     example do
       expect(provider.context).to receive(:shell).with(
-        "git push  deis HEAD:refs/heads/master -f 2>&1 | tr -dc '[:alnum:][:space:][:punct:]' | sed -E 's/remote: (\\[1G)+//' | sed 's/\\[K$//'"
+        "git push  deis HEAD:refs/heads/master -f 2>&1 | tr -dc '[:alnum:][:space:][:punct:]' | sed -E 's/remote: (\\[1G)+//' | sed 's/\\[K$//'; exit ${PIPESTATUS[1]}"
       ).and_return(true)
       provider.push_app
     end


### PR DESCRIPTION
Hi,

We ran into some issue when using dpl with the deis provider. In some case the build triggered by deis failed but the error was not caught by dpl.

This fix remove the piped script on the `git push` and instead check the returned status code.

