### PR TITLE
Deis provider needs to execute push in bash

### DIFF
--- a/lib/dpl/provider/deis.rb
+++ b/lib/dpl/provider/deis.rb
@@ -81,7 +81,7 @@ module DPL
       end
 
       def push_app
-        unless context.shell "git push #{verbose_flag} deis HEAD:refs/heads/master -f 2>&1 | tr -dc '[:alnum:][:space:][:punct:]' | sed -E 's/remote: (\\[1G)+//' | sed 's/\\[K$//'; exit ${PIPESTATUS[1]}"
+        unless context.shell "bash -c 'git push #{verbose_flag} deis HEAD:refs/heads/master -f 2>&1 | tr -dc \"[:alnum:][:space:][:punct:]\" | sed -E \"s/remote: (\\[1G)+//\" | sed \"s/\\[K$//\"; exit ${PIPESTATUS[0]}'"
           error 'Deploying application failed.'
         end
       end

--- a/spec/provider/deis_spec.rb
+++ b/spec/provider/deis_spec.rb
@@ -98,7 +98,7 @@ describe DPL::Provider::Deis do
   describe "#push_app" do
     example do
       expect(provider.context).to receive(:shell).with(
-        "git push  deis HEAD:refs/heads/master -f 2>&1 | tr -dc '[:alnum:][:space:][:punct:]' | sed -E 's/remote: (\\[1G)+//' | sed 's/\\[K$//'; exit ${PIPESTATUS[1]}"
+        "bash -c 'git push  deis HEAD:refs/heads/master -f 2>&1 | tr -dc \"[:alnum:][:space:][:punct:]\" | sed -E \"s/remote: (\\[1G)+//\" | sed \"s/\\[K$//\"; exit ${PIPESTATUS[0]}'"
       ).and_return(true)
       provider.push_app
     end


### PR DESCRIPTION
#479 wasn't working as expected. PIPESTATUS is a bash feature and the context.shell is a simple sh session. The result of this would be that all deploys would get marked as failed. 

To fix this I am executing the deployment in a bash session.