### PR TITLE
Fix #291, add support for S3 storage class

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,6 +316,7 @@ For authentication you can also use Travis CI secure environment variable:
 * **bucket**: S3 Bucket.
 * **region**: S3 Region. Defaults to us-east-1.
 * **upload-dir**: S3 directory to upload to. Defaults to root directory.
+* **storage-class**: S3 storage class to upload as. Defaults to "STANDARD". Other values are "STANDARD_IA" or "REDUCED_REDUNDANCY". Details can be found [here](https://aws.amazon.com/s3/storage-classes/).
 * **local-dir**: Local directory to upload from. Can be set from a global perspective (~/travis/build) or relative perspective (build) Defaults to project root.
 * **detect-encoding**: Set HTTP header `Content-Encoding` for files compressed with `gzip` and `compress` utilities. Defaults to not set.
 * **cache_control**: Set HTTP header `Cache-Control` to suggest that the browser cache the file. Defaults to `no-cache`. Valid options are `no-cache`, `no-store`, `max-age=<seconds>`,`s-maxage=<seconds>` `no-transform`, `public`, `private`.

--- a/lib/dpl/provider/s3.rb
+++ b/lib/dpl/provider/s3.rb
@@ -50,6 +50,7 @@ module DPL
             opts[:cache_control] = get_option_value_by_filename(options[:cache_control], filename) if options[:cache_control]
             opts[:acl]           = options[:acl].gsub(/_/, '-') if options[:acl]
             opts[:expires]       = get_option_value_by_filename(options[:expires], filename) if options[:expires]
+            opts[:storage_class] = options[:storage_class] if options[:storage_class]
             unless File.directory?(filename)
               log "uploading #{filename.inspect} with #{opts.inspect}"
               result = api.bucket(option(:bucket)).object(upload_path(filename)).upload_file(filename, opts)

--- a/spec/provider/s3_spec.rb
+++ b/spec/provider/s3_spec.rb
@@ -127,6 +127,13 @@ describe DPL::Provider::S3 do
       provider.push_app
     end
 
+    example "Sets Storage Class" do
+      provider.options.update(:storage_class => "STANDARD_AI")
+      expect(Dir).to receive(:glob).and_yield(__FILE__)
+      expect_any_instance_of(Aws::S3::Object).to receive(:upload_file).with(anything(), hash_including(:storage_class => "STANDARD_AI"))
+      provider.push_app
+    end
+
     example "Sets Website Index Document" do
       provider.options.update(:index_document_suffix => "test/index.html")
       expect(Dir).to receive(:glob).and_yield(__FILE__)


### PR DESCRIPTION
Add support for S3 Storage Classes.

AWS Docs here: https://aws.amazon.com/s3/storage-classes/