### PR TITLE
Fix Heroku instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,17 +69,17 @@ Running dpl in a terminal that saves history is insecure as your password/api ke
 
 #### Options:
 * **api-key**: Heroku API Key
-* **strategy[git/anvil]**: Deployment strategy for Dpl. Defaults to anvil.
+* **strategy**: Deployment strategy for Dpl. Defaults to `api`. Other options are `git`, `git ssh`, and `git deploykey`.
 * **app**: Heroku app name. Defaults to the name of your git repo.
 * **username**: heroku username. Not necessary if api-key is used. Requires git strategy.
 * **password**: heroku password. Not necessary if api-key is used. Requires git strategy.
 
-#### Git vs Anvil Deploy:
-* Anvil will run the [buildpack](https://devcenter.heroku.com/articles/buildpacks) compilation step on the Travis CI VM, whereas the Git strategy will run it on a Heroku dyno, which provides the same environment the application will then run under and might be slightly faster.
+#### API vs Git vs Anvil Deploy:
+* API deploy will tar up the current directory (minus the git repo) and send it to Heroku.
+* Git deploy will send the contents of the git repo only, so may not contain any local changes.
+* Anvil deploys are no longer supported since Heroku shut down the Anvil service.
 * The Git strategy allows using *user* and *password* instead of *api-key*.
 * When using Git, Heroku might send you an email for every deploy, as it adds a temporary SSH key to your account.
-
-As a rule of thumb, you should switch to the Git strategy if you run into issues with Anvil or if you're using the [user-env-compile](https://devcenter.heroku.com/articles/labs-user-env-compile) plugin.
 
 #### Examples:
 


### PR DESCRIPTION
Default Heroku deploy strategy is `api` and `anvil` doesn't work.