### PR TITLE
Changed required ruby version in README from 1.8.7 to 1.9.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Dpl supports the following providers:
 
 Dpl is published to rubygems.
 
-* Dpl requires ruby with a version greater than 1.8.7
+* Dpl requires ruby with a version greater than 1.9.3
 * To install: `gem install dpl`
 
 ## Usage:


### PR DESCRIPTION
The ruby version in [dpl.gemspec](https://github.com/travis-ci/dpl/blob/63cf1de1e482d90ba12ad06d16a96c135b4c16b7/dpl.gemspec#L17) does not match what is in the [README](https://github.com/travis-ci/dpl/blob/63cf1de1e482d90ba12ad06d16a96c135b4c16b7/README.md#installation). This PR corrects the README.