### PR TITLE
Fixes issue with `go get atlas-upload-cli` not working

### DIFF
--- a/lib/dpl/provider/atlas.rb
+++ b/lib/dpl/provider/atlas.rb
@@ -23,7 +23,6 @@ module DPL
           fi
           eval "$(gimme 1.6)" &> /dev/null
 
-          unset GIT_HTTP_USER_AGENT
           go get #{ATLAS_UPLOAD_CLI_GO_REMOTE}
           cp $HOME/gopath/bin/atlas-upload-cli $HOME/bin/atlas-upload
         fi
@@ -61,7 +60,9 @@ module DPL
       private
 
       def install_atlas_upload
-        context.shell ATLAS_UPLOAD_INSTALL_SCRIPT
+        without_git_http_user_agent do
+          context.shell ATLAS_UPLOAD_INSTALL_SCRIPT
+        end
       end
 
       def assert_app_present!
@@ -95,6 +96,13 @@ module DPL
       def atlas_app
         @atlas_app ||= options.fetch(:app).to_s
       end
+
+      def without_git_http_user_agent(&block)
+        git_http_user_agent = ENV.delete("GIT_HTTP_USER_AGENT")
+        yield
+        ENV["GIT_HTTP_USER_AGENT"] = git_http_user_agent
+      end
+
     end
   end
 end

--- a/lib/dpl/provider/atlas.rb
+++ b/lib/dpl/provider/atlas.rb
@@ -16,14 +16,16 @@ module DPL
             chmod +x $HOME/bin/gimme
           fi
 
-          export GOPATH="$HOME/gopath:$GOPATH"
-          eval "$(gimme 1.4.2)" &>/dev/null
+          if [ -z $GOPATH ]; then
+            export GOPATH="$HOME/gopath"
+          else
+            export GOPATH="$HOME/gopath:$GOPATH"
+          fi
+          eval "$(gimme 1.6)" &> /dev/null
 
+          unset GIT_HTTP_USER_AGENT
           go get #{ATLAS_UPLOAD_CLI_GO_REMOTE}
-          pushd $HOME/gopath/src/#{ATLAS_UPLOAD_CLI_GO_REMOTE} &>/dev/null
-          make &>/dev/null
-          cp bin/atlas-upload $HOME/bin/atlas-upload
-          popd &>/dev/null
+          cp $HOME/gopath/bin/atlas-upload-cli $HOME/bin/atlas-upload
         fi
       EOF
 


### PR DESCRIPTION
- Better handling of an empty `$GOPATH`
- the way `dpl` sets `GIT_HTTP_USER_AGENT` seems
  to cause issues with `go get` now, but removing it
  resolves the issue
- No longer any need to `make` the binary, `go get ...`
  installs and makes a working binary