### PR TITLE
Documented optional options for ruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,8 +266,13 @@ For authentication you can also use Travis CI secure environment variable:
 ### RubyGems:
 
 #### Options:
-
-* **api-key**: Rubygems Api Key.
+* **api-key**: API Key
+* **app**: ?
+* **user**: RubyGems username. Not necessary if api-key is used.
+* **password**: RubyGems password. Not necessary if api-key is used.
+* **gem**: Gem's name to be built
+* **gemspec**: Gemspec file name
+* **host**: RubyGems host
 
 #### Examples:
 


### PR DESCRIPTION
Hey guys!  I noticed there were no optional args for deploying to rubygems, and was really surprised (specifically, I was looking for _host_).  Luckily, the code is already there!  This change is to document their use.

I was a little confused on what _app_ was for.  I'll edit once we know its purpose :)
