### PR TITLE
Fixes Cloud Foundry deployment

### DIFF
--- a/lib/dpl/provider/cloud_foundry.rb
+++ b/lib/dpl/provider/cloud_foundry.rb
@@ -9,7 +9,7 @@ module DPL
       def check_auth
         initial_go_tools_install
         context.shell "./cf api #{option(:api)} #{'--skip-ssl-validation' if options[:skip_ssl_validation]}"
-        context.shell "./cf login --u #{option(:username)} --p #{option(:password)} --o #{option(:organization)} --s #{option(:space)}"
+        context.shell "./cf login -u #{option(:username)} -p #{option(:password)} -o #{option(:organization)} -s #{option(:space)}"
       end
 
       def check_app

--- a/spec/provider/cloudfoundry_spec.rb
+++ b/spec/provider/cloudfoundry_spec.rb
@@ -15,7 +15,7 @@ describe DPL::Provider::CloudFoundry do
     example do
       expect(provider.context).to receive(:shell).with('wget \'https://cli.run.pivotal.io/stable?release=linux64-binary&source=github\' -qO cf-linux-amd64.tgz && tar -zxvf cf-linux-amd64.tgz && rm cf-linux-amd64.tgz')
       expect(provider.context).to receive(:shell).with('./cf api api.run.awesome.io --skip-ssl-validation')
-      expect(provider.context).to receive(:shell).with('./cf login --u mallomar --p myreallyawesomepassword --o myorg --s outer')
+      expect(provider.context).to receive(:shell).with('./cf login -u mallomar -p myreallyawesomepassword -o myorg -s outer')
       provider.check_auth
     end
   end


### PR DESCRIPTION
The Cloud Foundry CLI now uses a single dash instead of double. 