### PR TITLE
Unshallow before Heroku git deployment

### DIFF
--- a/lib/dpl/provider/heroku/git.rb
+++ b/lib/dpl/provider/heroku/git.rb
@@ -11,6 +11,9 @@ module DPL
         def push_app
           git_remote = options[:git] || git_url
           write_netrc if git_remote.start_with?("https://")
+          log "$ git fetch origin $TRAVIS_BRANCH --unshallow"
+          context.shell "git fetch origin $TRAVIS_BRANCH --unshallow"
+          log "$ git push #{git_remote} HEAD:refs/heads/master -f"
           context.shell "git push #{git_remote} HEAD:refs/heads/master -f"
         end
 

--- a/spec/provider/heroku_git_spec.rb
+++ b/spec/provider/heroku_git_spec.rb
@@ -72,6 +72,7 @@ describe DPL::Provider::Heroku do
     describe "#push_app" do
       example do
         provider.options[:git] = "git://something"
+        expect(provider.context).to receive(:shell).with("git fetch origin $TRAVIS_BRANCH --unshallow")
         expect(provider.context).to receive(:shell).with("git push git://something HEAD:refs/heads/master -f")
         provider.push_app
         expect(provider.context.env['GIT_HTTP_USER_AGENT']).to include("dpl/#{DPL::VERSION}")


### PR DESCRIPTION
Heroku rejects pushes from a shallow clone like ours since Heroku
may not have all the objects necessary to build the application
reliably.