### PR TITLE
Fix anynines support

### DIFF
--- a/lib/dpl/provider/anynines.rb
+++ b/lib/dpl/provider/anynines.rb
@@ -4,7 +4,7 @@ module DPL
 
       def check_auth
         initial_go_tools_install
-        context.shell "./cf api https://api.de.a9s.eu"
+        context.shell "./cf api https://api.aws.ie.a9s.eu"
         context.shell "./cf login --u #{option(:username)} --p #{option(:password)} --o #{option(:organization)} --s #{option(:space)}"
       end
 

--- a/lib/dpl/provider/anynines.rb
+++ b/lib/dpl/provider/anynines.rb
@@ -5,7 +5,7 @@ module DPL
       def check_auth
         initial_go_tools_install
         context.shell "./cf api https://api.aws.ie.a9s.eu"
-        context.shell "./cf login --u #{option(:username)} --p #{option(:password)} --o #{option(:organization)} --s #{option(:space)}"
+        context.shell "./cf login -u #{option(:username)} -p #{option(:password)} -o #{option(:organization)} -s #{option(:space)}"
       end
 
     end

--- a/spec/provider/anynines_spec.rb
+++ b/spec/provider/anynines_spec.rb
@@ -13,7 +13,7 @@ describe DPL::Provider::Anynines do
     example do
       expect(provider.context).to receive(:shell).with('wget \'https://cli.run.pivotal.io/stable?release=linux64-binary&source=github\' -qO cf-linux-amd64.tgz && tar -zxvf cf-linux-amd64.tgz && rm cf-linux-amd64.tgz')
       expect(provider.context).to receive(:shell).with('./cf api https://api.aws.ie.a9s.eu')
-      expect(provider.context).to receive(:shell).with('./cf login --u mallomar --p myreallyawesomepassword --o myorg --s outer')
+      expect(provider.context).to receive(:shell).with('./cf login -u mallomar -p myreallyawesomepassword -o myorg -s outer')
       provider.check_auth
     end
   end

--- a/spec/provider/anynines_spec.rb
+++ b/spec/provider/anynines_spec.rb
@@ -12,7 +12,7 @@ describe DPL::Provider::Anynines do
   describe "#check_auth" do
     example do
       expect(provider.context).to receive(:shell).with('wget \'https://cli.run.pivotal.io/stable?release=linux64-binary&source=github\' -qO cf-linux-amd64.tgz && tar -zxvf cf-linux-amd64.tgz && rm cf-linux-amd64.tgz')
-      expect(provider.context).to receive(:shell).with('./cf api https://api.de.a9s.eu')
+      expect(provider.context).to receive(:shell).with('./cf api https://api.aws.ie.a9s.eu')
       expect(provider.context).to receive(:shell).with('./cf login --u mallomar --p myreallyawesomepassword --o myorg --s outer')
       provider.check_auth
     end


### PR DESCRIPTION
This PR fixes the URL needed for Anynines and fixes the `cf login` command.