### PR TITLE
Pin octokit to `~> 4.3.0`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ group :cloud_files do
 end
 
 group :releases do
-  gem 'octokit'
+  gem 'octokit', '~> 4.3.0'
 end
 
 group :gcs do

--- a/lib/dpl/provider/releases.rb
+++ b/lib/dpl/provider/releases.rb
@@ -3,7 +3,7 @@ module DPL
     class Releases < Provider
       require 'pathname'
 
-      requires 'octokit'
+      requires 'octokit', version: '~> 4.3.0' # later versions require Ruby 2.x
       requires 'mime-types', version: '~> 2.0'
 
       def travis_tag


### PR DESCRIPTION
Since version 4.4.0 requires Ruby 2.x.

Resolves https://github.com/travis-ci/travis-ci/issues/6772