### PR TITLE
[PyPI] Add option to skip uploading documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ For authentication you can also use Travis CI secure environment variable:
 * **password**: PyPI Password.
 * **server**: Optional. Only required if you want to release to a different index. Follows the form of 'https://mypackageindex.com/index'. Defaults to 'https://pypi.python.org/pypi'.
 * **distributions**: Optional. A space-separated list of distributions to be uploaded to PyPI. Defaults to 'sdist'.
+* **skip_upload_docs**: Optional. When set to `true`, documentation is not uploaded. Defaults to `false`.
 * **docs_dir**: Optional. A path to the directory to upload documentation from. Defaults to 'build/docs'
 
 #### Environment variables:

--- a/lib/dpl/provider/pypi.rb
+++ b/lib/dpl/provider/pypi.rb
@@ -96,7 +96,10 @@ module DPL
         context.shell "python setup.py #{pypi_distributions}"
         context.shell "twine upload -r pypi dist/*"
         context.shell "rm -rf dist/*"
-        context.shell "python setup.py upload_docs #{pypi_docs_dir_option} -r #{pypi_server}"
+        unless options[:skip_upload_docs]
+          log "Uploading documentation (skip with \"skip_upload_docs: true\")"
+          context.shell "python setup.py upload_docs #{pypi_docs_dir_option} -r #{pypi_server}"
+        end
       end
     end
   end

--- a/spec/provider/pypi_spec.rb
+++ b/spec/provider/pypi_spec.rb
@@ -62,6 +62,14 @@ describe DPL::Provider::PyPI do
       expect(provider.context).to receive(:shell).with("python setup.py upload_docs --upload-dir some/dir -r https://pypi.python.org/pypi")
       provider.push_app
     end
+
+    example "with :skip_upload_docs option" do
+      provider.options.update(:skip_upload_docs => true)
+      expect(provider.context).to receive(:shell).with("python setup.py sdist")
+      expect(provider.context).to receive(:shell).with("twine upload -r pypi dist/*")
+      expect(provider.context).to receive(:shell).with("rm -rf dist/*")
+      provider.push_app
+    end
   end
 
   describe "#write_servers" do


### PR DESCRIPTION
*Fix https://github.com/travis-ci/dpl/issues/334, close https://github.com/travis-ci/dpl/pull/349*

This is a rebase and slight refactor of work from @eric-takealot in https://github.com/travis-ci/dpl/pull/349 after a merge conflict from https://github.com/travis-ci/dpl/pull/396.

> Has this been tested?
@BanzaiMan https://github.com/travis-ci/dpl/pull/349#issuecomment-149536356

With `skip_upload_docs: true`: https://travis-ci.org/lukeyeager/DIGITS/jobs/172784593
With `skip_upload_docs: false`: https://travis-ci.org/lukeyeager/DIGITS/jobs/172785158