### PR TITLE
Updated the default PyPI upload URL

### DIFF
--- a/lib/dpl/provider/pypi.rb
+++ b/lib/dpl/provider/pypi.rb
@@ -1,7 +1,7 @@
 module DPL
   class Provider
     class PyPI < Provider
-      DEFAULT_SERVER = 'https://pypi.python.org/pypi'
+      DEFAULT_SERVER = 'https://upload.pypi.org/legacy/'
       PYPIRC_FILE = '~/.pypirc'
 
       def pypi_user


### PR DESCRIPTION
The "twine" tool uses this URL by default. The only reason why Travis still uses the legacy URL is because it's overridden in ~/.pypirc by this code. This new URL points to the newer Warehouse server which is the replacement for the old Cheeseshop PyPI implementation. Uploading to Warehouse adds the distribution to both servers (unlike the legacy URL which sadly does not seem to affect Warehouse), and has proven more reliable than the older server.