### PR TITLE
Set remote to unique value in Deis provider

### DIFF
--- a/spec/provider/deis_spec.rb
+++ b/spec/provider/deis_spec.rb
@@ -65,16 +65,6 @@ describe DPL::Provider::Deis do
   describe "#setup_git_ssh" do
     example do
       expect(provider.context).to receive(:shell).with(
-        './deis git:remote --app=example'
-      ).and_return(true)
-
-      git_conf = double
-      git_remote = double
-      allow(Git).to receive(:open).and_return(git_conf)
-      allow(git_conf).to receive(:remote).and_return(git_remote)
-      allow(git_remote).to receive(:url).and_return("ssh://git@fake-git-repo.travis-ci.com:2222/dpl-test.git")
-
-      expect(provider.context).to receive(:shell).with(
         /grep -c 'PTY allocation request failed'/
       ).and_return(false)
 
@@ -98,7 +88,7 @@ describe DPL::Provider::Deis do
   describe "#push_app" do
     example do
       expect(provider.context).to receive(:shell).with(
-        "bash -c 'git push  deis HEAD:refs/heads/master -f 2>&1 | tr -dc \"[:alnum:][:space:][:punct:]\" | sed -E \"s/remote: (\\[1G)+//\" | sed \"s/\\[K$//\"; exit ${PIPESTATUS[0]}'"
+        "bash -c 'git push  ssh://git@deis-builder.deisapps.com:2222/example.git HEAD:refs/heads/master -f 2>&1 | tr -dc \"[:alnum:][:space:][:punct:]\" | sed -E \"s/remote: (\\[1G)+//\" | sed \"s/\\[K$//\"; exit ${PIPESTATUS[0]}'"
       ).and_return(true)
       provider.push_app
     end
@@ -107,7 +97,7 @@ describe DPL::Provider::Deis do
   describe "#run" do
     example do
       expect(provider.context).to receive(:shell).with(
-        './deis run -- shell command'
+        './deis run -a example -- shell command'
       ).and_return(true)
       provider.run('shell command')
     end


### PR DESCRIPTION
I ran into an issue while trying to setup two deis deploys in my `.travis.yml` file. The same remote name ("deis") is currently used for both, which causes the second to error with the following message:

```
Error: Remote deis already exists, please run 'deis git:remote -f' to overwrite
```

This PR sets the remote name to the unique combo of controller-app. Some other implementation ideas include:

- allow the user to set a `remote` options -  this doesn't seem necessary if we can generate a unique name, nor do I see it being useful for any other situation
- specify the `-f` option to the `git:remote` command

I ended up going with creating a separate remote for each deploy instead of using `-f` because it mimics the way we perform manual deploys. If anyone has strong opinions on other implementation ideas, please let me know.