### PR TITLE
Add npm publish tags support

### DIFF
--- a/lib/dpl/provider/npm.rb
+++ b/lib/dpl/provider/npm.rb
@@ -29,7 +29,10 @@ module DPL
         log "NPM API key format changed recently. If your deployment fails, check your API key in ~/.npmrc."
         log "http://docs.travis-ci.com/user/deployment/npm/"
         log "#{NPMRC_FILE} size: #{File.size(File.expand_path(NPMRC_FILE))}"
-        context.shell "env NPM_API_KEY=#{option(:api_key)} npm publish"
+
+        command = "env NPM_API_KEY=#{option(:api_key)} npm publish"
+        command << " --tag #{option(:tag)}" if options[:tag]
+        context.shell "#{command}"
         FileUtils.rm(File.expand_path(NPMRC_FILE))
       end
 


### PR DESCRIPTION
Trying to add support of npm publish tags.
I see people was already asking for this feature for some time: https://github.com/travis-ci/dpl/issues/415

Here is a build conf which is using added feature: https://travis-ci.org/mamont/test-travis-proj/
It's first time I see ruby, but I'm eager to address any possible comments in order to have that (or similar) functionality in mainstream.