### PR TITLE
Relax constraint on chef version

### DIFF
--- a/lib/dpl/provider/chef_supermarket.rb
+++ b/lib/dpl/provider/chef_supermarket.rb
@@ -5,10 +5,6 @@ module DPL
       # Most of the code is inspired by:
       # https://github.com/opscode/chef/blob/11.16.4/lib/chef/knife/cookbook_site_share.rb
 
-      # Compatibility with ruby 1.9
-      requires 'rack', version: '< 2.0'
-      requires 'mime-types', version: '~> 1.16'
-      requires 'chef', version: '< 12.0'
       requires 'chef', load: 'chef/config'
       requires 'chef', load: 'chef/cookbook_loader'
       requires 'chef', load: 'chef/cookbook_uploader'


### PR DESCRIPTION
Since dpl now runs with ruby >=2.2.0, constraining chef to <12.0 is not
necessary anymore.

This reverts commit ba764dddfedbae3128ff4941641094eae6718fc4.