### PR TITLE
Pin aws-sdk to '~> 2.6.32' for CodeDeploy

### DIFF
--- a/lib/dpl/provider/code_deploy.rb
+++ b/lib/dpl/provider/code_deploy.rb
@@ -3,7 +3,7 @@ require 'json'
 module DPL
   class Provider
     class CodeDeploy < Provider
-      requires 'aws-sdk', pre: true
+      requires 'aws-sdk', pre: true, version: '~> 2.6.32'
 
       def code_deploy
         @code_deploy ||= Aws::CodeDeploy::Client.new(code_deploy_options)


### PR DESCRIPTION
aws-sdk 3.0.0.rc1 has incorrect dependency.
See https://github.com/aws/aws-sdk-ruby/issues/1356