### PR TITLE
packagecloud client bump to 1.0.5

### DIFF
--- a/lib/dpl/provider/packagecloud.rb
+++ b/lib/dpl/provider/packagecloud.rb
@@ -65,7 +65,7 @@ module DPL
         source_files = {}
         glob_args = ["**/*"]
         package = ::Packagecloud::Package.new(file: orig_filename)
-        result = @client.package_contents(@repo, package)
+        result = @client.package_contents(@repo, package, get_distro(@dist))
         if result.succeeded
           package_contents_files = result.response["files"].map { |x| x["filename"] }
           Dir.chdir(options.fetch(:local_dir, Dir.pwd)) do

--- a/lib/dpl/provider/packagecloud.rb
+++ b/lib/dpl/provider/packagecloud.rb
@@ -64,7 +64,7 @@ module DPL
       def get_source_files_for(orig_filename)
         source_files = {}
         glob_args = ["**/*"]
-        package = ::Packagecloud::Package.new(file: orig_filename)
+        package = ::Packagecloud::Package.new(:file => orig_filename)
         result = @client.package_contents(@repo, package, get_distro(@dist))
         if result.succeeded
           package_contents_files = result.response["files"].map { |x| x["filename"] }
@@ -98,12 +98,12 @@ module DPL
                   if is_source_package?(filename)
                     log "Processing source package: #{filename}"
                     source_files = get_source_files_for(filename)
-                    packages << ::Packagecloud::Package.new(file: filename, source_files: source_files)
+                    packages << ::Packagecloud::Package.new(:file => filename, :source_files => source_files)
                   else
-                    packages << ::Packagecloud::Package.new(file: filename)
+                    packages << ::Packagecloud::Package.new(:file => filename)
                   end
                 else
-                  packages << ::Packagecloud::Package.new(file: filename)
+                  packages << ::Packagecloud::Package.new(:file => filename)
                 end
               end
             end

--- a/lib/dpl/provider/packagecloud.rb
+++ b/lib/dpl/provider/packagecloud.rb
@@ -2,7 +2,7 @@ module DPL
   class Provider
     class Packagecloud < Provider
       requires 'json_pure', :version => '< 2.0', :load => 'json/pure'
-      requires 'packagecloud-ruby', :version => "1.0.4", :load => 'packagecloud'
+      requires 'packagecloud-ruby', :version => "1.0.5", :load => 'packagecloud'
 
       def check_auth
         setup_auth
@@ -65,9 +65,6 @@ module DPL
         source_files = {}
         glob_args = ["**/*"]
         package = ::Packagecloud::Package.new(file: orig_filename)
-        puts "debug: calling content for #{orig_filename}"
-        puts package.file.read
-        package.file.rewind
         result = @client.package_contents(@repo, package)
         if result.succeeded
           package_contents_files = result.response["files"].map { |x| x["filename"] }

--- a/lib/dpl/provider/packagecloud.rb
+++ b/lib/dpl/provider/packagecloud.rb
@@ -65,6 +65,8 @@ module DPL
         source_files = {}
         glob_args = ["**/*"]
         package = ::Packagecloud::Package.new(file: orig_filename)
+        puts "debug: calling content for #{orig_filename}"
+        puts package.inspect
         result = @client.package_contents(@repo, package)
         if result.succeeded
           package_contents_files = result.response["files"].map { |x| x["filename"] }

--- a/lib/dpl/provider/packagecloud.rb
+++ b/lib/dpl/provider/packagecloud.rb
@@ -66,7 +66,8 @@ module DPL
         glob_args = ["**/*"]
         package = ::Packagecloud::Package.new(file: orig_filename)
         puts "debug: calling content for #{orig_filename}"
-        puts package.inspect
+        puts package.file.read
+        package.file.rewind
         result = @client.package_contents(@repo, package)
         if result.succeeded
           package_contents_files = result.response["files"].map { |x| x["filename"] }

--- a/lib/dpl/provider/packagecloud.rb
+++ b/lib/dpl/provider/packagecloud.rb
@@ -2,7 +2,7 @@ module DPL
   class Provider
     class Packagecloud < Provider
       requires 'json_pure', :version => '< 2.0', :load => 'json/pure'
-      requires 'packagecloud-ruby', :version => "0.2.17", :load => 'packagecloud'
+      requires 'packagecloud-ruby', :version => "1.0.4", :load => 'packagecloud'
 
       def check_auth
         setup_auth
@@ -64,7 +64,7 @@ module DPL
       def get_source_files_for(orig_filename)
         source_files = {}
         glob_args = ["**/*"]
-        package = ::Packagecloud::Package.new(open(orig_filename))
+        package = ::Packagecloud::Package.new(file: orig_filename)
         result = @client.package_contents(@repo, package)
         if result.succeeded
           package_contents_files = result.response["files"].map { |x| x["filename"] }
@@ -98,12 +98,12 @@ module DPL
                   if is_source_package?(filename)
                     log "Processing source package: #{filename}"
                     source_files = get_source_files_for(filename)
-                    packages << ::Packagecloud::Package.new(open(filename), get_distro(@dist), source_files, filename)
+                    packages << ::Packagecloud::Package.new(file: filename, source_files: source_files)
                   else
-                    packages << ::Packagecloud::Package.new(open(filename), get_distro(@dist), {}, filename)
+                    packages << ::Packagecloud::Package.new(file: filename)
                   end
                 else
-                  packages << ::Packagecloud::Package.new(open(filename), nil, {}, filename)
+                  packages << ::Packagecloud::Package.new(file: filename)
                 end
               end
             end
@@ -111,7 +111,7 @@ module DPL
         end
 
         packages.each do |package|
-          result = @client.put_package(@repo, package)
+          result = @client.put_package(@repo, package, get_distro(@dist))
           if result.succeeded
             log "Successfully pushed #{package.filename} to #{@username}/#{@repo}"
           else

--- a/lib/dpl/version.rb
+++ b/lib/dpl/version.rb
@@ -1,3 +1,3 @@
 module DPL
-  VERSION = '1.8.24'
+  VERSION = '1.8.25'
 end


### PR DESCRIPTION
Bumps the [`packagecloud-ruby`](https://github.com/computology/packagecloud-ruby) client in the [`packagecloud`](https://github.com/travis-ci/dpl#packagecloud) provider to [`v1.0.5`](https://rubygems.org/gems/packagecloud-ruby/versions/1.0.5) which fixes several bugs and adds python support.

### Successful  builds with this branch:

#### [computology/python-test-packages](https://github.com/computology/python-test-packages)
https://github.com/computology/python-test-packages/blob/master/.travis.yml#L20
https://travis-ci.org/computology/python-test-packages#L1348

#### [capotej/http](https://github.com/capotej/http)
https://travis-ci.org/capotej/http/builds/182718448
https://github.com/capotej/http/blob/master/.travis.yml#L34

Not sure if any authentication/verification is needed, but [I work for packagecloud.io](https://github.com/orgs/computology/people).

Let me know if you need anything else to merge this, thanks!