### PR TITLE
Add support for Server-Side Encryption to S3 Provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ For authentication you can also use Travis CI secure environment variable:
 * **region**: S3 Region. Defaults to us-east-1.
 * **upload-dir**: S3 directory to upload to. Defaults to root directory.
 * **storage-class**: S3 storage class to upload as. Defaults to "STANDARD". Other values are "STANDARD_IA" or "REDUCED_REDUNDANCY". Details can be found [here](https://aws.amazon.com/s3/storage-classes/).
+* **server-side-encryption**: When set to `true`, use S3 Server Side Encryption (SSE-AES256). Defaults to non-encrypted.
 * **local-dir**: Local directory to upload from. Can be set from a global perspective (~/travis/build) or relative perspective (build) Defaults to project root.
 * **detect-encoding**: Set HTTP header `Content-Encoding` for files compressed with `gzip` and `compress` utilities. Defaults to not set.
 * **cache_control**: Set HTTP header `Cache-Control` to suggest that the browser cache the file. Defaults to `no-cache`. Valid options are `no-cache`, `no-store`, `max-age=<seconds>`,`s-maxage=<seconds>` `no-transform`, `public`, `private`.

--- a/lib/dpl/provider/s3.rb
+++ b/lib/dpl/provider/s3.rb
@@ -51,7 +51,7 @@ module DPL
             opts[:acl]                    = options[:acl].gsub(/_/, '-') if options[:acl]
             opts[:expires]                = get_option_value_by_filename(options[:expires], filename) if options[:expires]
             opts[:storage_class]          = options[:storage_class] if options[:storage_class]
-            opts[:server_side_encryption] = "aes256" if options[:server_side_encryption]
+            opts[:server_side_encryption] = :aes256 if options[:server_side_encryption]
             unless File.directory?(filename)
               log "uploading #{filename.inspect} with #{opts.inspect}"
               result = api.bucket(option(:bucket)).object(upload_path(filename)).upload_file(filename, opts)

--- a/lib/dpl/provider/s3.rb
+++ b/lib/dpl/provider/s3.rb
@@ -51,7 +51,7 @@ module DPL
             opts[:acl]                    = options[:acl].gsub(/_/, '-') if options[:acl]
             opts[:expires]                = get_option_value_by_filename(options[:expires], filename) if options[:expires]
             opts[:storage_class]          = options[:storage_class] if options[:storage_class]
-            opts[:server_side_encryption] = :aes256 if options[:server_side_encryption]
+            opts[:server_side_encryption] = "AES256" if options[:server_side_encryption]
             unless File.directory?(filename)
               log "uploading #{filename.inspect} with #{opts.inspect}"
               result = api.bucket(option(:bucket)).object(upload_path(filename)).upload_file(filename, opts)

--- a/lib/dpl/provider/s3.rb
+++ b/lib/dpl/provider/s3.rb
@@ -46,11 +46,12 @@ module DPL
         glob_args << File::FNM_DOTMATCH if options[:dot_match]
         Dir.chdir(options.fetch(:local_dir, Dir.pwd)) do
           Dir.glob(*glob_args) do |filename|
-            opts                 = content_data_for(filename)
-            opts[:cache_control] = get_option_value_by_filename(options[:cache_control], filename) if options[:cache_control]
-            opts[:acl]           = options[:acl].gsub(/_/, '-') if options[:acl]
-            opts[:expires]       = get_option_value_by_filename(options[:expires], filename) if options[:expires]
-            opts[:storage_class] = options[:storage_class] if options[:storage_class]
+            opts                          = content_data_for(filename)
+            opts[:cache_control]          = get_option_value_by_filename(options[:cache_control], filename) if options[:cache_control]
+            opts[:acl]                    = options[:acl].gsub(/_/, '-') if options[:acl]
+            opts[:expires]                = get_option_value_by_filename(options[:expires], filename) if options[:expires]
+            opts[:storage_class]          = options[:storage_class] if options[:storage_class]
+            opts[:server_side_encryption] = "aes256" if options[:server_side_encryption]
             unless File.directory?(filename)
               log "uploading #{filename.inspect} with #{opts.inspect}"
               result = api.bucket(option(:bucket)).object(upload_path(filename)).upload_file(filename, opts)

--- a/spec/provider/s3_spec.rb
+++ b/spec/provider/s3_spec.rb
@@ -134,6 +134,13 @@ describe DPL::Provider::S3 do
       provider.push_app
     end
 
+    example "Sets SSE" do
+      provider.options.update(:server_side_encryption => true)
+      expect(Dir).to receive(:glob).and_yield(__FILE__)
+      expect_any_instance_of(Aws::S3::Object).to receive(:upload_file).with(anything(), hash_including(:server_side_encryption => "AES256"))
+      provider.push_app
+    end
+
     example "Sets Website Index Document" do
       provider.options.update(:index_document_suffix => "test/index.html")
       expect(Dir).to receive(:glob).and_yield(__FILE__)


### PR DESCRIPTION
A small change to add support for encryption artifacts uploaded to AWS S3. Default to false to avoid 
breaking existing users. Docs are updated, but my rspec is very rusty. Would appreciate assistance/
mentoring to get a proper test created.