### PR TITLE
Fix GAE deployment version error in gcloud sdk v138.0.0.

### DIFF
--- a/lib/dpl/provider/gae.rb
+++ b/lib/dpl/provider/gae.rb
@@ -47,7 +47,7 @@ module DPL
       end
 
       def version
-        options[:version] || ''
+        options[:version]
       end
 
       def config
@@ -72,7 +72,7 @@ module DPL
         command << " --verbosity \"#{verbosity}\""
         command << " --project \"#{project}\""
         command << " app deploy \"#{config}\""
-        command << " --version \"#{version}\""
+        command << (version ? " --version \"#{version}\"" : '')
         command << " --#{no_promote ? 'no-' : ''}promote"
         command << (no_stop_previous_version ? ' --no-stop-previous-version' : '')
         unless context.shell(command)

--- a/spec/provider/gae_spec.rb
+++ b/spec/provider/gae_spec.rb
@@ -8,7 +8,7 @@ describe DPL::Provider::GAE do
 
   describe '#push_app' do
     example 'with defaults' do
-      allow(provider.context).to receive(:shell).with("#{DPL::Provider::GAE::GCLOUD} --quiet --verbosity \"warning\" --project \"test\" app deploy \"app.yaml\" --version \"\" --promote").and_return(true)
+      allow(provider.context).to receive(:shell).with("#{DPL::Provider::GAE::GCLOUD} --quiet --verbosity \"warning\" --project \"test\" app deploy \"app.yaml\" --promote").and_return(true)
       provider.push_app
     end
   end


### PR DESCRIPTION
In gcloud sdk v138.0.0,
gcloud app deploy with args `--version ""` will get error below:

ERROR: (gcloud.app.deploy) argument --version/-v: Bad value []: May only
contain lowercase letters, digits, and hyphens. Must begin and end with
a letter or digit. Must not exceed 63 characters.

So, if user didn't set the version and we want to use the gcloud
default generated version in this deployment, we just don't add
`--version`.