### PR TITLE
Fix Rubygems support for packagecloud provider

### DIFF
--- a/lib/dpl/provider/packagecloud.rb
+++ b/lib/dpl/provider/packagecloud.rb
@@ -46,6 +46,9 @@ module DPL
 
       def dist_required?(filename)
         ext = File.extname(filename).gsub!('.','')
+        if ext.nil?
+          error "filename: #{filename} has no extension!"
+        end
         ["rpm", "deb", "dsc", "whl", "egg", "egg-info", "gz", "zip", "tar", "bz2", "z"].include?(ext.downcase)
       end
 
@@ -107,11 +110,13 @@ module DPL
         end
 
         packages.each do |package|
+          log "Pushing package: #{package.filename}"
           if dist_required?(package.filename)
             result = @client.put_package(@repo, package, get_distro(@dist))
           else
             result = @client.put_package(@repo, package)
           end
+
           if result.succeeded
             log "Successfully pushed #{package.filename} to #{@username}/#{@repo}"
           else

--- a/lib/dpl/provider/packagecloud.rb
+++ b/lib/dpl/provider/packagecloud.rb
@@ -20,6 +20,9 @@ module DPL
       def setup_auth
         @username = option(:username)
         @token = option(:token)
+        if @token.nil?
+          error "Token required!"
+        end
         @repo = option(:repository)
         @dist = option(:dist) if options[:dist]
         @creds = ::Packagecloud::Credentials.new(@username, @token)

--- a/lib/dpl/provider/packagecloud.rb
+++ b/lib/dpl/provider/packagecloud.rb
@@ -19,12 +19,7 @@ module DPL
 
       def setup_auth
         @username = option(:username)
-        if options[:token].nil?
-          error "PACKAGECLOUD_TOKEN not found! Please set ENV var before continuing."
-        end
         @token = option(:token)
-        if @token.nil?
-        end
         @repo = option(:repository)
         @dist = option(:dist) if options[:dist]
         @creds = ::Packagecloud::Credentials.new(@username, @token)

--- a/lib/dpl/provider/packagecloud.rb
+++ b/lib/dpl/provider/packagecloud.rb
@@ -94,14 +94,10 @@ module DPL
               if is_supported_package?(filename)
                 error_if_dist_required(filename)
                 log "Detected supported package: #{filename}"
-                if dist_required?(filename)
-                  if is_source_package?(filename)
-                    log "Processing source package: #{filename}"
-                    source_files = get_source_files_for(filename)
-                    packages << ::Packagecloud::Package.new(:file => filename, :source_files => source_files)
-                  else
-                    packages << ::Packagecloud::Package.new(:file => filename)
-                  end
+                if is_source_package?(filename)
+                  log "Processing source package: #{filename}"
+                  source_files = get_source_files_for(filename)
+                  packages << ::Packagecloud::Package.new(:file => filename, :source_files => source_files)
                 else
                   packages << ::Packagecloud::Package.new(:file => filename)
                 end
@@ -111,7 +107,11 @@ module DPL
         end
 
         packages.each do |package|
-          result = @client.put_package(@repo, package, get_distro(@dist))
+          if dist_required?(package.filename)
+            result = @client.put_package(@repo, package, get_distro(@dist))
+          else
+            result = @client.put_package(@repo, package)
+          end
           if result.succeeded
             log "Successfully pushed #{package.filename} to #{@username}/#{@repo}"
           else

--- a/lib/dpl/provider/packagecloud.rb
+++ b/lib/dpl/provider/packagecloud.rb
@@ -53,8 +53,7 @@ module DPL
       end
 
       def error_if_dist_required(filename)
-        ext = File.extname(filename).gsub!('.','')
-        if dist_required?(ext) && @dist.nil?
+        if dist_required?(filename) && @dist.nil?
           error "Distribution needed for rpm, deb, python, and dsc packages, example --dist='ubuntu/breezy'"
         end
       end

--- a/lib/dpl/provider/packagecloud.rb
+++ b/lib/dpl/provider/packagecloud.rb
@@ -92,8 +92,8 @@ module DPL
           Dir.glob(*glob_args) do |filename|
             unless File.directory?(filename)
               if is_supported_package?(filename)
-                error_if_dist_required(filename)
                 log "Detected supported package: #{filename}"
+                error_if_dist_required(filename)
                 if is_source_package?(filename)
                   log "Processing source package: #{filename}"
                   source_files = get_source_files_for(filename)

--- a/lib/dpl/provider/packagecloud.rb
+++ b/lib/dpl/provider/packagecloud.rb
@@ -46,13 +46,13 @@ module DPL
 
       def dist_required?(filename)
         ext = File.extname(filename).gsub!('.','')
-        ["rpm", "deb", "dsc"].include?(ext)
+        ["rpm", "deb", "dsc", "whl", "egg", "egg-info", "gz", "zip", "tar", "bz2", "z"].include?(ext.downcase)
       end
 
       def error_if_dist_required(filename)
         ext = File.extname(filename).gsub!('.','')
         if dist_required?(ext) && @dist.nil?
-          error "Distribution needed for rpm, deb, and dsc packages, example --dist='ubuntu/breezy'"
+          error "Distribution needed for rpm, deb, python, and dsc packages, example --dist='ubuntu/breezy'"
         end
       end
 

--- a/lib/dpl/provider/packagecloud.rb
+++ b/lib/dpl/provider/packagecloud.rb
@@ -19,9 +19,11 @@ module DPL
 
       def setup_auth
         @username = option(:username)
+        if options[:token].nil?
+          error "PACKAGECLOUD_TOKEN not found! Please set ENV var before continuing."
+        end
         @token = option(:token)
         if @token.nil?
-          error "Token required!"
         end
         @repo = option(:repository)
         @dist = option(:dist) if options[:dist]


### PR DESCRIPTION
This fixes a [regression](https://github.com/computology/packagecloud-ruby/issues/19) introduced with the [my latest changes to dpl](https://github.com/travis-ci/dpl/pull/541)

Tested this branch with every package type we support:

## Python
[travis job](https://travis-ci.org/computology/python-test-packages#L1352)
[travis.yml](https://github.com/computology/python-test-packages/blob/master/.travis.yml#L20)

## Rubygems
[travis job](https://travis-ci.org/computology/rubygem-test-package#L466)
[travis.yml](https://github.com/computology/rubygem-test-package/blob/master/.travis.yml#L17)

## RPM
[travis job](https://travis-ci.org/capotej/http/jobs/184411156#L953)
[travis.yml](https://github.com/capotej/http/blob/master/.travis.yml#L34)

## Debian / Debian Source Packages
[travis job](https://travis-ci.org/capotej/http/jobs/184411161#L950)
[travis.yml](https://github.com/capotej/http/blob/master/.travis.yml#L34)

Thanks in advance!