### PR TITLE
Pin nokogiri at 1.6.8 that works with ruby 1.9.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,7 @@ end
 
 group :elastic_beanstalk do
   gem 'rubyzip', '~> 1.1'
+  gem 'nokogiri', '~>1.6.8'
   gem 'aws-sdk-v1'
 end
 


### PR DESCRIPTION
`nokogiri` used by gem `aws-sdk-v1` (for elastic beanstlak deployments) was updated on December 27 to version 1.7.0 from 1.6.8.1

The newer version uses ruby >=2.1.0

As a temporary change, to avoid making big changes during feature freeze, I am pinning nokogiri to ~>1.6.8 that works with ruby >=1.9.3
