### PR TITLE
Pin nokogiri version in provider class

### DIFF
--- a/lib/dpl/provider/elastic_beanstalk.rb
+++ b/lib/dpl/provider/elastic_beanstalk.rb
@@ -5,6 +5,7 @@ module DPL
     class ElasticBeanstalk < Provider
       experimental 'AWS Elastic Beanstalk'
 
+      requires 'nokogiri', version: '1.6.8.1'
       requires 'aws-sdk-v1'
       requires 'rubyzip', :load => 'zip'
 


### PR DESCRIPTION
... instead of the [earlier solution](https://github.com/travis-ci/dpl/pull/555) of fixing it in the Gemfile, since the provider class installs the `aws-sdk-v1` gem during runtime