### PR TITLE
Invoke GAE deployment commands with Python 2.7

### DIFF
--- a/lib/dpl/provider/gae.rb
+++ b/lib/dpl/provider/gae.rb
@@ -11,7 +11,7 @@ module DPL
       GCLOUD="#{INSTALL}/#{NAME}/bin/gcloud"
 
       def with_python_2_7(cmd)
-        "source #{context.env['HOME']}/virtualenv/python2.7/bin/activate; #{cmd}"
+        context.shell("bash -c 'source #{context.env['HOME']}/virtualenv/python2.7/bin/activate; #{cmd}'")
       end
 
       def install_deploy_dependencies
@@ -27,7 +27,7 @@ module DPL
 
         $stderr.puts 'Bootstrapping Google Cloud SDK ...'
 
-        unless context.shell(with_python_2_7("#{BOOTSTRAP} --usage-reporting=false --command-completion=false --path-update=false"))
+        unless with_python_2_7("#{BOOTSTRAP} --usage-reporting=false --command-completion=false --path-update=false")
           error 'Could not bootstrap Google Cloud SDK.'
         end
       end
@@ -37,7 +37,7 @@ module DPL
       end
 
       def check_auth
-        unless context.shell(with_python_2_7("#{GCLOUD} -q --verbosity debug auth activate-service-account --key-file #{keyfile}"))
+        unless with_python_2_7("#{GCLOUD} -q --verbosity debug auth activate-service-account --key-file #{keyfile}")
           error 'Authentication failed.'
         end
       end
@@ -79,7 +79,7 @@ module DPL
         command << " --version \"#{version}\"" unless version.to_s.empty?
         command << " --#{no_promote ? 'no-' : ''}promote"
         command << ' --no-stop-previous-version' unless no_stop_previous_version.to_s.empty?
-        unless context.shell(with_python_2_7(command))
+        unless with_python_2_7(command)
           log 'Deployment failed.'
           context.shell('find $HOME/.config/gcloud/logs -type f -print -exec cat {} \;')
           error ''

--- a/lib/dpl/provider/gae.rb
+++ b/lib/dpl/provider/gae.rb
@@ -11,7 +11,7 @@ module DPL
       GCLOUD="#{INSTALL}/#{NAME}/bin/gcloud"
 
       def with_python_2_7(cmd)
-        "source #{ENV['HOME']}/virtualenv/python2.7/bin/activate; #{cmd}"
+        "source #{context.env['HOME']}/virtualenv/python2.7/bin/activate; #{cmd}"
       end
 
       def install_deploy_dependencies

--- a/lib/dpl/provider/gae.rb
+++ b/lib/dpl/provider/gae.rb
@@ -11,6 +11,9 @@ module DPL
       GCLOUD="#{INSTALL}/#{NAME}/bin/gcloud"
 
       def install_deploy_dependencies
+        $stderr.puts 'Switching to Python 2.7 ...'
+        context.shell("source ~/virtualenv/python2.7/bin/activate")
+
         if File.exists? GCLOUD
           return
         end

--- a/lib/dpl/provider/gae.rb
+++ b/lib/dpl/provider/gae.rb
@@ -10,10 +10,11 @@ module DPL
       BOOTSTRAP="#{INSTALL}/#{NAME}/bin/bootstrapping/install.py"
       GCLOUD="#{INSTALL}/#{NAME}/bin/gcloud"
 
-      def install_deploy_dependencies
-        $stderr.puts 'Switching to Python 2.7 ...'
-        context.shell("source ~/virtualenv/python2.7/bin/activate")
+      def with_python_2_7(cmd)
+        "source #{ENV['HOME']}/virtualenv/python2.7/bin/activate; #{cmd}"
+      end
 
+      def install_deploy_dependencies
         if File.exists? GCLOUD
           return
         end
@@ -26,7 +27,7 @@ module DPL
 
         $stderr.puts 'Bootstrapping Google Cloud SDK ...'
 
-        unless context.shell("#{BOOTSTRAP} --usage-reporting=false --command-completion=false --path-update=false")
+        unless context.shell(with_python_2_7("#{BOOTSTRAP} --usage-reporting=false --command-completion=false --path-update=false"))
           error 'Could not bootstrap Google Cloud SDK.'
         end
       end
@@ -36,7 +37,7 @@ module DPL
       end
 
       def check_auth
-        unless context.shell("#{GCLOUD} -q --verbosity debug auth activate-service-account --key-file #{keyfile}")
+        unless context.shell(with_python_2_7("#{GCLOUD} -q --verbosity debug auth activate-service-account --key-file #{keyfile}"))
           error 'Authentication failed.'
         end
       end
@@ -78,7 +79,7 @@ module DPL
         command << " --version \"#{version}\"" unless version.to_s.empty?
         command << " --#{no_promote ? 'no-' : ''}promote"
         command << ' --no-stop-previous-version' unless no_stop_previous_version.to_s.empty?
-        unless context.shell(command)
+        unless context.shell(with_python_2_7(command))
           log 'Deployment failed.'
           context.shell('find $HOME/.config/gcloud/logs -type f -print -exec cat {} \;')
           error ''

--- a/lib/dpl/version.rb
+++ b/lib/dpl/version.rb
@@ -1,3 +1,3 @@
 module DPL
-  VERSION = '1.8.28'
+  VERSION = '1.8.29'
 end

--- a/spec/provider/gae_spec.rb
+++ b/spec/provider/gae_spec.rb
@@ -6,9 +6,11 @@ describe DPL::Provider::GAE do
     described_class.new(DummyContext.new, project: 'test')
   end
 
+
   describe '#push_app' do
     example 'with defaults' do
-      allow(provider.context).to receive(:shell).with("#{DPL::Provider::GAE::GCLOUD} --quiet --verbosity \"warning\" --project \"test\" app deploy \"app.yaml\" --promote").and_return(true)
+      expect(provider.context.env).to receive(:[]).with('HOME').and_return('/home/travis')
+      allow(provider.context).to receive(:shell).with("bash -c 'source /home/travis/virtualenv/python2.7/bin/activate; #{DPL::Provider::GAE::GCLOUD} --quiet --verbosity \"warning\" --project \"test\" app deploy \"app.yaml\" --promote'").and_return(true)
       provider.push_app
     end
   end


### PR DESCRIPTION
Resolves https://github.com/travis-ci/travis-ci/issues/6913.

This works by spawning a new bash process, activate Python 2.7, and execute the commands. See the issue above for tests.