### PR TITLE
amend #563, test for apostrophe

### DIFF
--- a/lib/dpl/provider/gae.rb
+++ b/lib/dpl/provider/gae.rb
@@ -11,12 +11,19 @@ module DPL
       GCLOUD="#{INSTALL}/#{NAME}/bin/gcloud"
 
       def with_python_2_7(cmd)
+        cmd.gsub!(/'/, "'\\\\''")
         context.shell("bash -c 'source #{context.env['HOME']}/virtualenv/python2.7/bin/activate; #{cmd}'")
       end
 
       def install_deploy_dependencies
         if File.exists? GCLOUD
           return
+        end
+
+        $stderr.puts 'Python 2.7 Version'
+
+        unless with_python_2_7("python -c 'import sys; print(sys.version)'")
+          error 'Could not use python2.7'
         end
 
         $stderr.puts 'Downloading Google Cloud SDK ...'

--- a/spec/provider/gae_spec.rb
+++ b/spec/provider/gae_spec.rb
@@ -16,10 +16,11 @@ describe DPL::Provider::GAE do
   end
 
 
-  describe '#with_python_2_7'
+  describe '#with_python_2_7' do
     example 'with apostrophe' do
-        expect(provider.context.env).to receive(:[]).with('HOME').and_return('/home/travis')
-        expect(provider.context).to receive(:shell).with("bash -c 'source /home/travis/virtualenv/python2.7/bin/activate; python -c '\''import sys; print(sys.version)'\''").and_return(true)
-        provider.with_python_2_7("python -c 'import sys; print(sys.version)'")
+      expect(provider.context.env).to receive(:[]).with('HOME').and_return('/home/travis')
+      allow(provider.context).to receive(:shell).with("bash -c 'source /home/travis/virtualenv/python2.7/bin/activate; python -c '\\''import sys; print(sys.version)'\\'''").and_return(true)
+      provider.with_python_2_7("python -c 'import sys; print(sys.version)'")
     end
+  end
 end

--- a/spec/provider/gae_spec.rb
+++ b/spec/provider/gae_spec.rb
@@ -14,4 +14,12 @@ describe DPL::Provider::GAE do
       provider.push_app
     end
   end
+
+
+  describe '#with_python_2_7'
+    example 'with apostrophe' do
+        expect(provider.context.env).to receive(:[]).with('HOME').and_return('/home/travis')
+        expect(provider.context).to receive(:shell).with("bash -c 'source /home/travis/virtualenv/python2.7/bin/activate; python -c '\''import sys; print(sys.version)'\''").and_return(true)
+        provider.with_python_2_7("python -c 'import sys; print(sys.version)'")
+    end
 end


### PR DESCRIPTION
Amending pull #563 to include printing the python2.7 version before installing and executing gcloud and escaping the apostrophes.