### PR TITLE
Remove "experimental" tags from all providers

### DIFF
--- a/lib/dpl/provider/atlas.rb
+++ b/lib/dpl/provider/atlas.rb
@@ -28,8 +28,6 @@ module DPL
         fi
       EOF
 
-      experimental 'Atlas'
-
       def deploy
         assert_app_present!
         install_atlas_upload

--- a/lib/dpl/provider/cloud_files.rb
+++ b/lib/dpl/provider/cloud_files.rb
@@ -7,7 +7,6 @@ module DPL
       requires 'mime-types', load: 'mime/types', version: '~> 2.6.2' # Anything higher requires Ruby 2.x
       requires 'nokogiri', version: '~> 1.6.8.1' # 1.7.0 and up requires Ruby 2.1.0 (via fog-xml)
       requires 'fog-rackspace', load: 'fog/rackspace'
-      experimental 'Rackspace Cloud Files'
 
       def needs_key?
         false

--- a/lib/dpl/provider/elastic_beanstalk.rb
+++ b/lib/dpl/provider/elastic_beanstalk.rb
@@ -3,7 +3,6 @@ require 'time'
 module DPL
   class Provider
     class ElasticBeanstalk < Provider
-      experimental 'AWS Elastic Beanstalk'
 
       requires 'nokogiri', version: '1.6.8.1'
       requires 'aws-sdk-v1'

--- a/lib/dpl/provider/gae.rb
+++ b/lib/dpl/provider/gae.rb
@@ -1,7 +1,6 @@
 module DPL
   class Provider
     class GAE < Provider
-      experimental 'Google App Engine'
 
       BASE='https://dl.google.com/dl/cloudsdk/channels/rapid/'
       NAME='google-cloud-sdk'

--- a/lib/dpl/provider/ops_works.rb
+++ b/lib/dpl/provider/ops_works.rb
@@ -4,7 +4,6 @@ module DPL
   class Provider
     class OpsWorks < Provider
       requires 'aws-sdk', version: '~> 2'
-      experimental 'AWS OpsWorks'
 
       def opsworks
         @opsworks ||= Aws::OpsWorks::Client.new(opsworks_options)

--- a/lib/dpl/provider/pages.rb
+++ b/lib/dpl/provider/pages.rb
@@ -16,8 +16,6 @@ module DPL
 
       require 'tmpdir'
 
-      experimental 'GitHub Pages'
-
       def initialize(context, options)
         super
 

--- a/lib/dpl/provider/script.rb
+++ b/lib/dpl/provider/script.rb
@@ -2,8 +2,6 @@ module DPL
   class Provider
     class Script < Provider
 
-      experimental 'Script'
-
       def check_auth
       end
 

--- a/lib/dpl/provider/transifex.rb
+++ b/lib/dpl/provider/transifex.rb
@@ -1,7 +1,6 @@
 module DPL
   class Provider
     class Transifex < Provider
-      experimental 'Transifex'
 
       DEFAULT_CLIENT_VERSION = '>=0.11'
       DEFAULT_HOSTNAME = 'https://www.transifex.com'


### PR DESCRIPTION
This removes all "experimental" warnings.

These providers have gone through usage in the wild and most obvious issues have been addressed.