### PR TITLE
Bump Octokit to 4.6.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ group :cloud_files do
 end
 
 group :releases do
-  gem 'octokit', '~> 4.3.0'
+  gem 'octokit', '~> 4.6.0'
 end
 
 group :gcs do

--- a/lib/dpl/provider/releases.rb
+++ b/lib/dpl/provider/releases.rb
@@ -3,7 +3,7 @@ module DPL
     class Releases < Provider
       require 'pathname'
 
-      requires 'octokit', version: '~> 4.3.0' # later versions require Ruby 2.x
+      requires 'octokit', version: '~> 4.6.0' # later versions require Ruby 2.x
       requires 'mime-types', version: '~> 2.0'
 
       def travis_tag


### PR DESCRIPTION
Until 4.3.0 which is in use now Octokit opens files with the `r+b` flags, which means that all files must be writable. 
They fixed this in 4.4.0. 

Sample of release failing with 4.3.0:
https://travis-ci.org/codesuki/dpl-github-test/builds/193666231

Sample of release working with 4.6.x:
https://travis-ci.org/codesuki/dpl-github-test/builds/193667417

