### PR TITLE
elasticbeanstalk zip_file to uses File.expand_path

### DIFF
--- a/lib/dpl/provider/elastic_beanstalk.rb
+++ b/lib/dpl/provider/elastic_beanstalk.rb
@@ -39,7 +39,7 @@ module DPL
         create_bucket unless bucket_exists?
 
         if options[:zip_file]
-          zip_file = File.join(Dir.pwd, options[:zip_file])
+          zip_file = File.expand_path(options[:zip_file])
         else
           zip_file = create_zip
         end

--- a/spec/provider/elastic_beanstalk_spec.rb
+++ b/spec/provider/elastic_beanstalk_spec.rb
@@ -87,6 +87,58 @@ describe DPL::Provider::ElasticBeanstalk do
       provider.push_app
     end
 
+    example 'zip_file is an absolute path' do
+      provider.options.update(:zip_file => '/absolute/path/to/file.zip')
+      expect(provider).to receive(:s3).and_return(s3_mock).twice
+      expect(provider).to receive(:create_bucket)
+      expect(provider).to receive(:archive_name).and_return('file.zip')
+      expect(provider).to receive(:upload).with('file.zip', '/absolute/path/to/file.zip').and_call_original
+      expect(provider).to receive(:sleep).with(5)
+      expect(provider).to receive(:create_app_version).with(bucket_mock).and_return(app_version)
+      expect(provider).to receive(:update_app).with(app_version)
+
+      provider.push_app
+    end
+
+    example 'zip_file is an relative path' do
+      provider.options.update(:zip_file => 'relative/path/to/file.zip')
+      expect(provider).to receive(:s3).and_return(s3_mock).twice
+      expect(provider).to receive(:create_bucket)
+      expect(provider).to receive(:archive_name).and_return('file.zip')
+      expect(provider).to receive(:upload).with('file.zip', File.join(Dir.pwd, 'relative/path/to/file.zip')).and_call_original
+      expect(provider).to receive(:sleep).with(5)
+      expect(provider).to receive(:create_app_version).with(bucket_mock).and_return(app_version)
+      expect(provider).to receive(:update_app).with(app_version)
+
+      provider.push_app
+    end
+
+    example 'zip_file is a path with ~/' do
+      provider.options.update(:zip_file => '~/file.zip')
+      expect(provider).to receive(:s3).and_return(s3_mock).twice
+      expect(provider).to receive(:create_bucket)
+      expect(provider).to receive(:archive_name).and_return('file.zip')
+      expect(provider).to receive(:upload).with('file.zip', File.join(ENV['HOME'], 'file.zip')).and_call_original
+      expect(provider).to receive(:sleep).with(5)
+      expect(provider).to receive(:create_app_version).with(bucket_mock).and_return(app_version)
+      expect(provider).to receive(:update_app).with(app_version)
+
+      provider.push_app
+    end
+
+    example 'zip_file is has no path' do
+      provider.options.update(:zip_file => 'file.zip')
+      expect(provider).to receive(:s3).and_return(s3_mock).twice
+      expect(provider).to receive(:create_bucket)
+      expect(provider).to receive(:archive_name).and_return('file.zip')
+      expect(provider).to receive(:upload).with('file.zip', File.join(Dir.pwd, 'file.zip')).and_call_original
+      expect(provider).to receive(:sleep).with(5)
+      expect(provider).to receive(:create_app_version).with(bucket_mock).and_return(app_version)
+      expect(provider).to receive(:update_app).with(app_version)
+
+      provider.push_app
+    end
+
     context 'only creates app version' do
       let(:only_create_app_version) { true }
 


### PR DESCRIPTION
If I set `zip_file` to something that contained a fullpath such as `${TRAVIS_BUILD_DIR}/artifact.zip` DPL would try to deploy `${TRAVIS_BUILD_DIR}/${TRAVIS_BUILD_DIR}/artifact.zip`. This PR is intended to fix this.