### PR TITLE
Ansible deploy type

### DIFF
--- a/README.md
+++ b/README.md
@@ -965,7 +965,6 @@ In order to use this provider, please make sure you have the [App Engine Admin A
 * **vault-password**: Optional. Vault password file.
 * **extra-args**: Optional. Additional string of arguments to append to the ansible-playbook command.
 
-
 #### Examples:
 
     dpl --provider=ansible

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ See [TESTING.md](TESTING.md).
 ## Supported Providers:
 Dpl supports the following providers:
 
+* [Ansible](#ansible)
 * [Anynines](#anynines)
 * [AppFog](#appfog)
 * [Atlas by HashiCorp](#atlas)
@@ -928,3 +929,43 @@ In order to use this provider, please make sure you have the [App Engine Admin A
 #### Examples:
 
     dpl --provider=bluemixcf --username=<username> --password=<password> --organization=<organization> --region=<region> --space=<space> --skip-ssl-validation
+
+### Ansible:
+
+#### Options:
+
+* **playbook**: Optional. Ansible playbook to execute. Default ```.playbook.yml```.
+* **debug**: Optional Boolean. When set to true, print the Ansible command line before executing.
+* **become**: Optional Boolean. When true, run operations with become (nopasswd implied).
+* **check**: Optional Boolean. When true, try to predict some of the chnges that will occur without making any changes.
+* **flush-cache**: Optional Boolean. When true, clear the fact cache.
+* **force-handlers**: Optional Boolean. When true, run handlers even if a task fails.
+* **syntax-check**: Optional Boolean. When true, performs a syntax check on the playbook, but does not execute it.
+* **verbose**: Optional Boolean. When true, enable verbose mode.
+* **version**: Optional Boolean. When true, show program's version number and exit.
+* **list-hosts**: Optional Boolean. When true, outputs a list of matching hosts; does not execute anything else.
+* **list-tags**: Optional Boolean. When true, list all available tags.
+* **list-tasks**: Optional Boolean. When true, list all tasks that would be executed.
+* **connection**: Optional. The connection type to use (default=smart).
+* **extra-vars**: Optional. Set additional variables as key=value or YAML/JSON.
+* **forks**: Optional. Specify number of parallel processes to use (default 5).
+* **inventory**: Optional. Specify inventory host path (default=/etc/ansible/hosts) or comma separated host list.
+* **limit**: Optional.
+* **module-path**: Optional. Specify path(s) to module library (default=None).
+* **private-key**: Optional. Private key file used to authenticate the connection.
+* **start-at-task**: Optional. Start the playbook at the task matching this name.
+* **ssh-common-args**: Optional. Specify common arguments to pass to sftp/scp/ssh (e.g.ProxyCommand).
+* **sftp-extra-args**: Optional. Specify extra arguments to pass to sftp only (e.g. -f, -l).
+* **scp-extra-args**: Optional. Specify extra arguments to pass to scp only (e.g. -l).
+* **ssh-extra-args**: Optional. Specify extra arguments to pass to ssh only (e.g. -R).
+* **skip-tags**: Optional. Only run plays and tasks whose tags do not match these values.
+* **tags**: Optional. Only run plays and tasks tagged with these values.
+* **timeout**: Optional. Override the connection timeout in seconds (default=10).
+* **user**: Optional. Connect as this user (default=None).
+* **vault-password**: Optional. Vault password file.
+* **extra-args**: Optional. Additional string of arguments to append to the ansible-playbook command.
+
+
+#### Examples:
+
+    dpl --provider=ansible

--- a/lib/dpl/provider.rb
+++ b/lib/dpl/provider.rb
@@ -6,6 +6,7 @@ module DPL
   class Provider
     include FileUtils
 
+    autoload :Ansible,             'dpl/provider/ansible'
     autoload :Anynines,            'dpl/provider/anynines'
     autoload :Appfog,              'dpl/provider/appfog'
     autoload :Atlas,               'dpl/provider/atlas'

--- a/lib/dpl/provider.rb
+++ b/lib/dpl/provider.rb
@@ -92,12 +92,12 @@ module DPL
 
     def self.pip(name, command = name, version = nil)
       if version
-        puts "pip install --user #{name}==#{version}"
-        context.shell("pip uninstall --user -y #{name}") unless `which #{command}`.chop.empty?
-        context.shell("pip install --user #{name}==#{version}", retry: true)
+        puts "pip install --quiet --user #{name}==#{version}"
+        context.shell("pip uninstall --quiet --user -y #{name}") unless `which #{command}`.chop.empty?
+        context.shell("pip install --quiet --user #{name}==#{version}", retry: true)
       else
-        puts "pip install --user #{name}"
-        context.shell("pip install --user #{name}", retry: true) if `which #{command}`.chop.empty?
+        puts "pip install --quiet --user #{name}"
+        context.shell("pip install --quiet --user #{name}", retry: true) if `which #{command}`.chop.empty?
       end
       context.shell("export PATH=$PATH:$HOME/.local/bin")
     end

--- a/lib/dpl/provider/ansible.rb
+++ b/lib/dpl/provider/ansible.rb
@@ -1,0 +1,78 @@
+module DPL
+  class Provider
+    class Ansible < Provider
+      pip 'ansible'
+
+      def check_auth
+      end
+
+      def check_app
+        playbook_file = playbook
+        context.shell 'ansible-playbook --version'
+        error "Application must have a playbook for unattended deployment. #{playbook_file} not found." unless File.exists? playbook_file
+      end
+
+      def needs_key?
+        false
+      end
+
+      def push_app
+        shell_cmd = assemble_cmd(options)
+        if options[:debug]
+          puts shell_cmd
+        end
+        context.shell shell_cmd
+      end
+
+      def cleanup
+      end
+
+      def uncleanup
+      end
+
+      def playbook
+        return options[:playbook].nil? ? ".playbook.yml" : "#{options[:playbook]}"
+      end
+
+      def get_twodash_only_array
+        result = ["become", "check", "diff", "flush-cache", "force-handlers",
+          "syntax-check", "verbose", "version", "list-hosts", "list-tags",
+          "list-tasks"]
+        return result
+      end
+
+      def get_twodash_equal_array
+        result = ["connection", "extra-vars", "forks", "inventory", "limit",
+          "module-path", "private-key", "start-at-task", "ssh-common-args",
+          "sftp-extra-args", "scp-extra-args", "ssh-extra-args", "skip-tags",
+          "tags", "timeout", "user", "vault-password"]
+        return result
+      end
+
+      def assemble_cmd(options)
+        twodash_only_template = " --%{key}"
+        twodash_equal_template = " --%{key}=%{value}"
+        twodash_only = get_twodash_only_array
+        twodash_equal = get_twodash_equal_array
+        cmd = "ansible-playbook #{playbook}"
+
+        options.each do |key, value|
+          key = key.to_s
+          key.tr!("_","-") if key.include?("_")
+          next_arg=""
+          option = {key: key, value: value}
+          if twodash_only.include?(key) && value
+            next_arg = twodash_only_template % option
+          elsif twodash_equal.include?(key)
+            next_arg = twodash_equal_template % option
+          elsif key == "extra-args"
+            next_arg = " " << value
+          end
+          cmd << next_arg
+        end
+        return cmd
+      end
+
+    end
+  end
+end

--- a/spec/provider/ansible.rb
+++ b/spec/provider/ansible.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+require 'dpl/provider/ansible'
+
+describe DPL::Provider::Ansible do
+  subject :provider do
+    described_class.new(DummyContext.new, {} )
+  end
+
+  describe "#push_app" do
+    example "Default All" do
+      expect(provider.context).to receive(:shell).with('ansible-playbook .playbook.yml')
+      provider.push_app
+    end
+
+    example "Set playbook" do
+      provider.options.update(:playbook => "myplaybook.yml")
+      expect(provider.context).to receive(:shell).with('ansible-playbook myplaybook.yml')
+      provider.push_app
+    end
+
+    example "Set verbose" do
+      provider.options.update(:verbose => true)
+      expect(provider.context).to receive(:shell).with('ansible-playbook .playbook.yml --verbose')
+      provider.push_app
+    end
+
+    example "Handle extra-args" do
+      provider.options.update('extra-args' => "-some -extra -args")
+      expect(provider.context).to receive(:shell).with('ansible-playbook .playbook.yml -some -extra -args')
+      provider.push_app
+    end
+  end
+
+end

--- a/spec/provider_spec.rb
+++ b/spec/provider_spec.rb
@@ -60,14 +60,14 @@ describe DPL::Provider do
 
     example "missing" do
       expect(example_provider).to receive(:`).with("which foo").and_return("")
-      expect(example_provider.context).to receive(:shell).with("pip install --user foo", retry: true)
+      expect(example_provider.context).to receive(:shell).with("pip install --quiet --user foo", retry: true)
       expect(example_provider.context).to receive(:shell).with("export PATH=$PATH:$HOME/.local/bin")
       example_provider.pip("foo")
     end
 
     example "specific version" do
       expect(example_provider).to receive(:`).with("which foo").and_return("")
-      expect(example_provider.context).to receive(:shell).with("pip install --user foo==1.0", retry: true)
+      expect(example_provider.context).to receive(:shell).with("pip install --quiet --user foo==1.0", retry: true)
       expect(example_provider.context).to receive(:shell).with("export PATH=$PATH:$HOME/.local/bin")
       example_provider.pip("foo", "foo", "1.0")
     end


### PR DESCRIPTION
Create a new provider that installs Ansible, and runs the playbook. Playbook options are represented in the YAML as described in README.md

Quiet the pip install so only error and critical messages are displayed.

Example successful deployment using the ansible type can be found at: 
https://travis-ci.org/adamkingit/echo-vcap/builds/201333182