### PR TITLE
Include submodule files in files_to_pack

### DIFF
--- a/lib/dpl/provider/elastic_beanstalk.rb
+++ b/lib/dpl/provider/elastic_beanstalk.rb
@@ -104,7 +104,7 @@ module DPL
       end
 
       def files_to_pack
-        `git ls-files -z`.split("\x0")
+        `git ls-files --recurse-submodules -z`.split("\x0")
       end
 
       def create_zip


### PR DESCRIPTION
By default, `git ls-files` does not include submodule files. Add `--recurse-submodules` to ensure they're included, which seems like a pretty reasonable default.