### PR TITLE
Prerelease on branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -539,6 +539,7 @@ You first need to create an [Atlas account](https://atlas.hashicorp.com/account/
 * **file_glob**: If files should be interpreted as globs (\* and \*\* wildcards). Defaults to false.
 * **overwrite**: If files with the same name should be overwritten. Defaults to false.
 * **release-number**: Overide automatic release detection, set a release manually.
+* **prerelease**: Identify the release as a prerelease.
 
 Additionally, options can be passed to [Octokit](https://github.com/octokit/octokit.rb) client.
 These are documented in https://github.com/octokit/octokit.rb/blob/master/lib/octokit/client/releases.rb.

--- a/README.md
+++ b/README.md
@@ -540,6 +540,7 @@ You first need to create an [Atlas account](https://atlas.hashicorp.com/account/
 * **overwrite**: If files with the same name should be overwritten. Defaults to false.
 * **release-number**: Overide automatic release detection, set a release manually.
 * **prerelease**: Identify the release as a prerelease.
+* **prerelease_on_branch**: Explicitly specify branches to identify as prerelease.
 
 Additionally, options can be passed to [Octokit](https://github.com/octokit/octokit.rb) client.
 These are documented in https://github.com/octokit/octokit.rb/blob/master/lib/octokit/client/releases.rb.

--- a/lib/dpl/provider/releases.rb
+++ b/lib/dpl/provider/releases.rb
@@ -74,10 +74,15 @@ module DPL
         end
       end
 
-      def prerelease
+      def prerelease(release_url)
+        if api.release(release_url).rels[:self].get.data.respond_to? (:target_commitish)
+          branch = api.release(release_url).rels[:self].get.data.target_commitish
+        else
+          branch = get_branch
+        end
         if options[:prerelease]
           if options[:prerelease_on_branch]
-            options[:prerelease_on_branch].include? get_branch
+            options[:prerelease_on_branch].include? branch
           else
             true
           end
@@ -132,7 +137,7 @@ module DPL
           release_url = api.create_release(slug, get_tag, options.merge({:draft => true})).rels[:self].href
         end
 
-        options[:prerelease] = prerelease
+        options[:prerelease] = prerelease(release_url)
 
         files.each do |file|
           existing_url = nil


### PR DESCRIPTION
This adds option to explicitly specify branches to identify as prerelease on GitHub.

example:

```bash
dpl --provider=releases --api-key=key --file="build.tar.gz" --repo=mariogrip/github-binary-release --prerelease=true prerelease_on_branch=master
```

example running on travis:
https://github.com/mariogrip/github-binary-release/releases
https://github.com/mariogrip/github-binary-release
https://travis-ci.org/mariogrip/github-binary-release