### PR TITLE
Use the last SDK version

### DIFF
--- a/lib/dpl/provider/code_deploy.rb
+++ b/lib/dpl/provider/code_deploy.rb
@@ -3,7 +3,7 @@ require 'json'
 module DPL
   class Provider
     class CodeDeploy < Provider
-      requires 'aws-sdk', pre: true, version: '~> 2.6.32'
+      requires 'aws-sdk', pre: true, version: '~> 2.8.5'
 
       def code_deploy
         @code_deploy ||= Aws::CodeDeploy::Client.new(code_deploy_options)


### PR DESCRIPTION
This **PR** enable `aws-sdk` `2.8` instead of `2.6`

Successful build on https://travis-ci.org/waghanza/dpl/builds/210637656