### PR TITLE
add support for zero-downtime deployment to Cloud Foundry

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -9,11 +9,11 @@ To do so, add the following to your `.travis.yml`:
 deploy:
   provider: X
   edge:
-  	source: myown/dpl
+    source: myown/dpl
     branch: foo
   on:
-  	branch: TEST_BRANCH # or all_branches: true
-  ⋮ # rest of provider X configuration
+    branch: TEST_BRANCH # or all_branches: true
+  # rest of provider X configuration
 ```
 
 This builds the `dpl` gem on the VM

--- a/lib/dpl/provider/cloud_foundry.rb
+++ b/lib/dpl/provider/cloud_foundry.rb
@@ -11,8 +11,9 @@ module DPL
         if options[:manifest]
           error 'Application must have a manifest.yml for unattended deployment' unless File.exists? options[:manifest]
         end
-        if options[:zero_downtime] && !app_name
-          error 'Application name must be specified for zero-downtime deployment'
+        if options[:zero_downtime]
+          error 'Application name must be specified for zero-downtime deployment' if !app_name
+          check_manifest_up_to_date
         end
       end
 
@@ -44,6 +45,15 @@ module DPL
 
       def manifest
         options[:manifest].nil? ? "" : " -f #{options[:manifest]}"
+      end
+
+      def install_antifreeze
+        context.shell "./cf install-plugin https://github.com/odlp/antifreeze/releases/download/v0.3.0/antifreeze-linux"
+      end
+
+      def check_manifest_up_to_date
+        install_antifreeze
+        context.shell "./cf check-manifest #{app_name}#{manifest}"
       end
 
       def install_autopilot

--- a/lib/dpl/provider/cloud_foundry.rb
+++ b/lib/dpl/provider/cloud_foundry.rb
@@ -1,11 +1,6 @@
 module DPL
   class Provider
     class CloudFoundry < Provider
-
-      def initial_go_tools_install
-        context.shell 'wget \'https://cli.run.pivotal.io/stable?release=linux64-binary&source=github\' -qO cf-linux-amd64.tgz && tar -zxvf cf-linux-amd64.tgz && rm cf-linux-amd64.tgz'
-      end
-
       def check_auth
         initial_go_tools_install
         context.shell "./cf api #{option(:api)} #{'--skip-ssl-validation' if options[:skip_ssl_validation]}"
@@ -31,6 +26,12 @@ module DPL
       end
 
       def uncleanup
+      end
+
+      private
+
+      def initial_go_tools_install
+        context.shell "wget 'https://cli.run.pivotal.io/stable?release=linux64-binary&source=github' -qO cf-linux-amd64.tgz && tar -zxvf cf-linux-amd64.tgz && rm cf-linux-amd64.tgz"
       end
 
       def manifest

--- a/lib/dpl/provider/cloud_foundry.rb
+++ b/lib/dpl/provider/cloud_foundry.rb
@@ -48,7 +48,7 @@ module DPL
       end
 
       def install_antifreeze
-        context.shell "./cf install-plugin https://github.com/odlp/antifreeze/releases/download/v0.3.0/antifreeze-linux"
+        context.shell "./cf install-plugin -f https://github.com/odlp/antifreeze/releases/download/v0.3.0/antifreeze-linux"
       end
 
       def check_manifest_up_to_date
@@ -57,7 +57,7 @@ module DPL
       end
 
       def install_autopilot
-        context.shell "./cf install-plugin https://github.com/contraband/autopilot/releases/download/0.0.3/autopilot-linux"
+        context.shell "./cf install-plugin -f https://github.com/contraband/autopilot/releases/download/0.0.3/autopilot-linux"
       end
 
       def app_name

--- a/spec/provider/cloudfoundry_spec.rb
+++ b/spec/provider/cloudfoundry_spec.rb
@@ -47,6 +47,8 @@ describe DPL::Provider::CloudFoundry do
       example do
         provider.options.update(:app_name => 'foo', :zero_downtime => true)
         File.stub(:exists?).with('worker-manifest.yml').and_return(true)
+        expect(provider.context).to receive(:shell).with('./cf install-plugin https://github.com/odlp/antifreeze/releases/download/v0.3.0/antifreeze-linux')
+        expect(provider.context).to receive(:shell).with('./cf check-manifest foo -f worker-manifest.yml')
         expect{provider.check_app}.not_to raise_error
       end
     end

--- a/spec/provider/cloudfoundry_spec.rb
+++ b/spec/provider/cloudfoundry_spec.rb
@@ -47,7 +47,7 @@ describe DPL::Provider::CloudFoundry do
       example do
         provider.options.update(:app_name => 'foo', :zero_downtime => true)
         File.stub(:exists?).with('worker-manifest.yml').and_return(true)
-        expect(provider.context).to receive(:shell).with('./cf install-plugin https://github.com/odlp/antifreeze/releases/download/v0.3.0/antifreeze-linux')
+        expect(provider.context).to receive(:shell).with('./cf install-plugin -f https://github.com/odlp/antifreeze/releases/download/v0.3.0/antifreeze-linux')
         expect(provider.context).to receive(:shell).with('./cf check-manifest foo -f worker-manifest.yml')
         expect{provider.check_app}.not_to raise_error
       end
@@ -76,7 +76,7 @@ describe DPL::Provider::CloudFoundry do
 
     example "Zero-downtime" do
       provider.options.update(:app_name => 'foo', :zero_downtime => true)
-      expect(provider.context).to receive(:shell).with('./cf install-plugin https://github.com/contraband/autopilot/releases/download/0.0.3/autopilot-linux')
+      expect(provider.context).to receive(:shell).with('./cf install-plugin -f https://github.com/contraband/autopilot/releases/download/0.0.3/autopilot-linux')
       expect(provider.context).to receive(:shell).with('./cf zero-downtime-push foo -f worker-manifest.yml')
       expect(provider.context).to receive(:shell).with('./cf logout')
       provider.push_app


### PR DESCRIPTION
Closes #328.

Zero-downtime deployments to Cloud Foundry are (most easily) achieved through the [autopilot](https://github.com/contraband/autopilot) plugin. This pull request adds support for dpl to use this plugin under the hood, through a new `zero_downtime` (and corresponding `app_name`) option.

The new functionality also uses the [antifreeze](https://github.com/odlp/antifreeze) plugin to verify that there is no configuration set on the live application that will be lost as a result of the zero-downtime deployment. While not strictly necessary for zero-downtime deployment to work, use of antifreeze is [recommended by autopilot](https://github.com/contraband/autopilot#warning), and prevents users from inadvertently breaking their applications by neglecting to add configuration to their manifests/services.

You can see a successful deploy using this branch here: https://travis-ci.org/18F/cf-cd-example/builds/218334697 Thanks!