### PR TITLE
Add packagecloud re-upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -643,6 +643,7 @@ For accounts using two factor authentication, you have to use an oauth token as 
  * **repository**: Required. The repository to push to.
  * **local_dir**: Optional. The sub-directory of the built assets for deployment. Default to current path.
  * **dist**: Required for deb and rpm. The complete list of supported strings can be found on the [packagecloud.io docs](https://packagecloud.io/docs#os_distro_version)
+ * **force**: Optional. Wheter package has to be (re)uploaded / deleted before upload
 
 #### Examples:
 

--- a/lib/dpl/provider/packagecloud.rb
+++ b/lib/dpl/provider/packagecloud.rb
@@ -88,6 +88,7 @@ module DPL
       end
 
       def push_app
+        forced = options.fetch(:force) { nil }
         packages = []
         glob_args = Array(options.fetch(:package_glob, '**/*'))
         Dir.chdir(options.fetch(:local_dir, Dir.pwd)) do
@@ -109,6 +110,11 @@ module DPL
         end
 
         packages.each do |package|
+          if forced
+            log "Deleting package: #{package.filename}"
+            distro, distro_release = @dist.split("/")
+            @client.delete_package(@repo, distro, distro_release, package.filename)
+          end
           log "Pushing package: #{package.filename}"
           if dist_required?(package.filename)
             result = @client.put_package(@repo, package, get_distro(@dist))


### PR DESCRIPTION
Hello,

For some reason, I wanted to upload the same version of a package on [PackageCloud](https://packagecloud.io).

Currently, uploading the same version cause **deploy** phase to fail.

This `PR` add ability to order package **re**upload.

A successful usage could be found on https://travis-ci.org/waghanza/pkg-geoip2/builds/223850598
