### PR TITLE
Add vpc-config for lambda provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -711,6 +711,8 @@ For accounts using two factor authentication, you have to use an oauth token as 
  * **memory_size**: Optional. The amount of memory in MB to allocate to this Lambda. Defaults to 128.
  * **runtime**: Optional. The Lambda runtime to use. Defaults to `node`.
  * **publish**: If `true`, a [new version](http://docs.aws.amazon.com/lambda/latest/dg/versioning-intro.html#versioning-intro-publish-version) of the Lambda function will be created instead of replacing the code of the existing one.
+ * **subnet_ids**: Optional. To create a function in VPC, use this array of strings to specify the subnet ids.
+ * **security_group_ids**: Optional. When creating a function in VPC, use this array of strings to specify the security group ids.
 
 #### Examples:
 


### PR DESCRIPTION
Added two keys `subnet_ids` and `security_group_ids` for lambda provider to create the lambda function in a vpc.

Usage:
```
subnet_ids: ["subnet-xxxxxxxx", "subnet-yyyyyyyy"]
security_group_ids: ["sg-xxxxxxxx"]
```

Also replaced the usage of `lambda.list_functions` by `lambda.get_function_configuration` since `list_functions` only show the functions in the first page if I have too many functions.

Here's a successful build: https://travis-ci.org/pishen/dpl-lambda-vpc/builds/231525826