### PR TITLE
Fix elastic beanstalk bucket creation

### DIFF
--- a/lib/dpl/provider/elastic_beanstalk.rb
+++ b/lib/dpl/provider/elastic_beanstalk.rb
@@ -103,7 +103,7 @@ module DPL
       end
 
       def create_bucket
-        s3.buckets.create(bucket_name)
+        s3.create_bucket(bucket: bucket_name)
       end
 
       def files_to_pack

--- a/spec/provider/elastic_beanstalk_spec.rb
+++ b/spec/provider/elastic_beanstalk_spec.rb
@@ -88,8 +88,9 @@ describe DPL::Provider::ElasticBeanstalk do
       allow(s3_mock.buckets).to receive(:map).and_return([])
       allow(bucket_mock).to receive(:object).with("some/app/file.zip").and_return(s3_obj_double)
 
-      expect(provider).to receive(:s3).and_return(s3_mock).twice
-      expect(provider).to receive(:create_bucket)
+      allow(provider).to receive(:s3).and_return(s3_mock)
+      expect(provider).to receive(:create_bucket).and_call_original
+      expect(s3_mock).to receive(:create_bucket)
       expect(provider).to receive(:create_zip).and_return('/path/to/file.zip')
       expect(provider).to receive(:archive_name).and_return('file.zip')
       expect(provider).to receive(:upload).with('file.zip', '/path/to/file.zip').and_call_original


### PR DESCRIPTION
This was calling a nonexistent method.

Perhaps everyone has been pre-creating their buckets, in which case they wouldn't hit this bug.