### PR TITLE
[WIP] Log better, and exit with consistent command status

### DIFF
--- a/bin/dpl
+++ b/bin/dpl
@@ -2,4 +2,4 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
 require 'dpl/cli'
-DPL::CLI.run(ARGV)
+exit DPL::CLI.run(ARGV)

--- a/lib/dpl/cli.rb
+++ b/lib/dpl/cli.rb
@@ -30,6 +30,7 @@ module DPL
     def run
       provider = Provider.new(self, options)
       provider.deploy
+      exit provider.deploy_status.exitstatus
     rescue Error => error
       options[:debug] ? raise(error) : die(error.message)
     end
@@ -50,8 +51,8 @@ module DPL
       }
     end
 
-    def shell(command)
-      system(command)
+    def shell(command, opts = {})
+      DPL::Provider.shell command, opts
     end
 
     def die(message)

--- a/lib/dpl/provider/script.rb
+++ b/lib/dpl/provider/script.rb
@@ -15,10 +15,7 @@ module DPL
       end
 
       def push_app
-        context.shell script
-        if $?.exitstatus != 0
-          raise Error, "Script failed with status #{$?.exitstatus}"
-        end
+        @deploy_status = context.shell script
       end
 
       def script


### PR DESCRIPTION
The idea is to call the system command while capturing STDERR
and STDOUT.
Also capture the "shell" commands' exit status, and use it to
exit the `dpl` command itself, so that nonzero deployment could
be used to signify deployment failure, which will mark the build
a failure as well.