### PR TITLE
add additional logging to clarify what gem dpl is looking up

### DIFF
--- a/lib/dpl/provider/rubygems.rb
+++ b/lib/dpl/provider/rubygems.rb
@@ -24,6 +24,7 @@ module DPL
       def check_app
         setup_auth
         setup_gem
+        log "Looking up gem #{options[:gem]}"
         info = ::Gems.info(options[:gem])
         log "Found gem #{info['name']}"
       end

--- a/spec/provider/rubygems_spec.rb
+++ b/spec/provider/rubygems_spec.rb
@@ -35,6 +35,7 @@ describe DPL::Provider::RubyGems do
   describe "#check_app" do
     example do
       expect(::Gems).to receive(:info).with('example').and_return({'name' => 'example'})
+      expect(provider).to receive(:log).with("Looking up gem example")
       expect(provider).to receive(:log).with("Found gem example")
       provider.check_app
     end


### PR DESCRIPTION
I believe this one line of logging will help clarify errors people get when their git repo name doesn't match up with the gem name they are attempting to deploy. See: https://github.com/travis-ci/dpl/issues/574

Here is a build with the additional log line added: 
https://travis-ci.org/sepulworld/tfmod-generator/builds/234107707#L232

If RubyGems responds with:
```
/home/travis/.rvm/rubies/ruby-2.2.6/lib/ruby/2.2.0/json/common.rb:155:in `parse': 776: unexpected token at 'This rubygem could not be found.' (JSON::ParserError)
```
We will easily see the discrepancy with the gem name we are trying to lookup and that gem name we expect it to be looking up. 