### PR TITLE
Adopt to Heroku API V3

### DIFF
--- a/lib/dpl/provider/heroku/generic.rb
+++ b/lib/dpl/provider/heroku/generic.rb
@@ -14,7 +14,10 @@ module DPL
         end
 
         def api_options
-          api_options = { headers: { 'User-Agent' => user_agent(::Heroku::API::HEADERS.fetch('User-Agent')) } }
+          api_options = { headers: {
+            'User-Agent' => user_agent(::Heroku::API::HEADERS.fetch('User-Agent')),
+            "Accept" => "application/vnd.heroku+json; version=3",
+          } }
           if options[:user] and options[:password]
             api_options[:user]     = options[:user]
             api_options[:password] = options[:password]

--- a/spec/provider/heroku_api_spec.rb
+++ b/spec/provider/heroku_api_spec.rb
@@ -8,7 +8,7 @@ describe DPL::Provider::Heroku do
   end
 
   let(:expected_headers) do
-    { "User-Agent" => "dpl/#{DPL::VERSION} heroku-rb/#{Heroku::API::VERSION}" }
+    { "User-Agent" => "dpl/#{DPL::VERSION} heroku-rb/#{Heroku::API::VERSION}", "Accept" => "application/vnd.heroku+json; version=3" }
   end
 
   describe "#ssh" do

--- a/spec/provider/heroku_git_spec.rb
+++ b/spec/provider/heroku_git_spec.rb
@@ -8,7 +8,7 @@ describe DPL::Provider::Heroku do
   end
 
   let(:expected_headers) do
-    { "User-Agent" => "dpl/#{DPL::VERSION} heroku-rb/#{Heroku::API::VERSION}" }
+    { "User-Agent" => "dpl/#{DPL::VERSION} heroku-rb/#{Heroku::API::VERSION}", "Accept" => "application/vnd.heroku+json; version=3" }
   end
 
   describe "#api" do


### PR DESCRIPTION
Heroku retired the older VPI versions https://devcenter.heroku.com/changelog-items/1147, and we need to adopt to V3 on all Heroku API calls, including `#get_user`.

Tested: https://travis-ci.org/travis-ci/docs-travis-ci-com/builds/235764486#L770