### PR TITLE
Add Heroku API v3 header to `curl` commands

### DIFF
--- a/lib/dpl/provider/heroku/api.rb
+++ b/lib/dpl/provider/heroku/api.rb
@@ -81,7 +81,7 @@ module DPL
 
         def upload_archive
           log "uploading application archive"
-          context.shell "curl #{Shellwords.escape(put_url)} -X PUT -H 'Content-Type:' --data-binary @#{archive_file}"
+          context.shell "curl #{Shellwords.escape(put_url)} -X PUT -H 'Content-Type:' -H 'Accept: application/vnd.heroku+json; version=3' --data-binary @#{archive_file}"
         end
 
         def trigger_build
@@ -99,7 +99,7 @@ module DPL
           if response.success?
             @build_id  = JSON.parse(response.body)['id']
             output_stream_url = JSON.parse(response.body)['output_stream_url']
-            context.shell "curl #{Shellwords.escape(output_stream_url)}"
+            context.shell "curl #{Shellwords.escape(output_stream_url)} -H 'Accept: application/vnd.heroku+json; version=3'"
           else
             handle_error_response(response)
           end

--- a/spec/provider/heroku_api_spec.rb
+++ b/spec/provider/heroku_api_spec.rb
@@ -189,7 +189,7 @@ describe DPL::Provider::Heroku do
       expect(provider).to receive(:faraday).at_least(:once).and_return(faraday)
       expect(provider).to receive(:get_url).and_return 'http://example.com/source.tgz'
       expect(provider).to receive(:version).and_return 'v1.3.0'
-      expect(provider.context).to receive(:shell).with('curl https://build-output.heroku.com/streams/01234567-89ab-cdef-0123-456789abcdef')
+      expect(provider.context).to receive(:shell).with("curl https://build-output.heroku.com/streams/01234567-89ab-cdef-0123-456789abcdef -H 'Accept: application/vnd.heroku+json; version=3'")
       provider.trigger_build
       expect(provider.build_id).to eq('01234567-89ab-cdef-0123-456789abcdef')
     end


### PR DESCRIPTION
We missed these in the previous PR #642.