### PR TITLE
Add support for message in Firebase provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -877,10 +877,11 @@ In order to use this provider, please make sure you have the [App Engine Admin A
 
 * **token**: Your Firebase CI access token (generate with `firebase login:ci`)
 * **project**: Deploy to a different Firebase project than specified in your `firebase.json` (e.g. `myapp-staging`)
+* **message**: Optional. The message describing this deploy.
 
 #### Examples:
 
-    dpl --provider=firebase --token=<token> --project=<project>
+    dpl --provider=firebase --token=<token> --project=<project> --message=<message>
 
 
 

--- a/lib/dpl/provider/firebase.rb
+++ b/lib/dpl/provider/firebase.rb
@@ -18,7 +18,7 @@ module DPL
       def push_app
         command = "firebase deploy --non-interactive"
         command << " --project #{options[:project]}" if options[:project]
-        command << " --message #{options[:message]}" if options[:message]
+        command << " --message '#{options[:message]}'" if options[:message]
         command << " --token '#{options[:token]}'" if options[:token]
         context.shell command
       end

--- a/lib/dpl/provider/firebase.rb
+++ b/lib/dpl/provider/firebase.rb
@@ -18,6 +18,7 @@ module DPL
       def push_app
         command = "firebase deploy --non-interactive"
         command << " --project #{options[:project]}" if options[:project]
+        command << " --message #{options[:message]}" if options[:message]
         command << " --token '#{options[:token]}'" if options[:token]
         context.shell command
       end

--- a/spec/provider/firebase_spec.rb
+++ b/spec/provider/firebase_spec.rb
@@ -27,8 +27,8 @@ describe DPL::Provider::Firebase do
     end
 
     it 'should include the message specified' do
-      provider.options.update(:message => 'test-message')
-      expect(provider.context).to receive(:shell).with("firebase deploy --non-interactive --message test-message --token 'abc123'")
+      provider.options.update(:message => 'test message')
+      expect(provider.context).to receive(:shell).with("firebase deploy --non-interactive --message 'test message' --token 'abc123'")
       provider.push_app
     end
 

--- a/spec/provider/firebase_spec.rb
+++ b/spec/provider/firebase_spec.rb
@@ -26,6 +26,12 @@ describe DPL::Provider::Firebase do
       provider.push_app
     end
 
+    it 'should include the message specified' do
+      provider.options.update(:message => 'test-message')
+      expect(provider.context).to receive(:shell).with("firebase deploy --non-interactive --message test-message --token 'abc123'")
+      provider.push_app
+    end
+
     it 'should default to no project override' do
       expect(provider.context).to receive(:shell).with("firebase deploy --non-interactive --token 'abc123'")
       provider.push_app


### PR DESCRIPTION
Adds support for adding optional messages when deploying with the Firebase provider.

Please take a look at `spec/provider/firebase_spec.rb` as I'm not totally sure how the test should be.

Fixes travis-ci/travis-ci#7872