### PR TITLE
Skip upload_docs by default for PyPI provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ For authentication you can also use Travis CI secure environment variable:
 * **password**: PyPI Password.
 * **server**: Optional. Only required if you want to release to a different index. Follows the form of 'https://mypackageindex.com/index'. Defaults to 'https://pypi.python.org/pypi'.
 * **distributions**: Optional. A space-separated list of distributions to be uploaded to PyPI. Defaults to 'sdist'.
-* **skip_upload_docs**: Optional. When set to `true`, documentation is not uploaded. Defaults to `false`.
+* **skip_upload_docs**: Optional. When set to `false`, documentation is uploaded. Defaults to `true`.
 * **docs_dir**: Optional. A path to the directory to upload documentation from. Defaults to 'build/docs'
 
 #### Environment variables:

--- a/README.md
+++ b/README.md
@@ -279,9 +279,13 @@ For authentication you can also use Travis CI secure environment variable:
 
 * **user**: PyPI Username.
 * **password**: PyPI Password.
-* **server**: Optional. Only required if you want to release to a different index. Follows the form of 'https://mypackageindex.com/index'. Defaults to 'https://pypi.python.org/pypi'.
+* **server**: Optional. Only required if you want to release to a different index. Follows the form of 'https://mypackageindex.com/index'. Defaults to 'https://upload.pypi.org/legacy/'.
 * **distributions**: Optional. A space-separated list of distributions to be uploaded to PyPI. Defaults to 'sdist'.
 * **skip_upload_docs**: Optional. When set to `false`, documentation is uploaded. Defaults to `true`.
+  Note that upload.pypi.org does not support document uploading. If you set
+  this option to `false`, your deployment fails, unless you specify the server
+  that supports this option. See https://github.com/travis-ci/dpl/issues/660
+  for details.
 * **docs_dir**: Optional. A path to the directory to upload documentation from. Defaults to 'build/docs'
 
 #### Environment variables:

--- a/lib/dpl/provider/pypi.rb
+++ b/lib/dpl/provider/pypi.rb
@@ -27,6 +27,11 @@ module DPL
         end
       end
 
+      def skip_upload_docs?
+        ! options.has_key?(:skip_upload_docs) ||
+          (options.has_key?(:skip_upload_docs) && options[:skip_upload_docs])
+      end
+
       def self.install_setuptools
         shell 'wget https://bootstrap.pypa.io/ez_setup.py -O - | sudo python'
         shell 'rm -f setuptools-*.zip'
@@ -96,7 +101,7 @@ module DPL
         context.shell "python setup.py #{pypi_distributions}"
         context.shell "twine upload -r pypi dist/*"
         context.shell "rm -rf dist/*"
-        unless options[:skip_upload_docs]
+        unless skip_upload_docs?
           log "Uploading documentation (skip with \"skip_upload_docs: true\")"
           context.shell "python setup.py upload_docs #{pypi_docs_dir_option} -r #{pypi_server}"
         end

--- a/spec/provider/pypi_spec.rb
+++ b/spec/provider/pypi_spec.rb
@@ -32,7 +32,7 @@ describe DPL::Provider::PyPI do
       expect(provider.context).to receive(:shell).with("python setup.py sdist")
       expect(provider.context).to receive(:shell).with("twine upload -r pypi dist/*")
       expect(provider.context).to receive(:shell).with("rm -rf dist/*")
-      expect(provider.context).to receive(:shell).with("python setup.py upload_docs  -r https://upload.pypi.org/legacy/")
+      expect(provider.context).not_to receive(:shell).with("python setup.py upload_docs  -r https://upload.pypi.org/legacy/")
       provider.push_app
     end
 
@@ -41,7 +41,7 @@ describe DPL::Provider::PyPI do
       expect(provider.context).to receive(:shell).with("python setup.py sdist bdist")
       expect(provider.context).to receive(:shell).with("twine upload -r pypi dist/*")
       expect(provider.context).to receive(:shell).with("rm -rf dist/*")
-      expect(provider.context).to receive(:shell).with("python setup.py upload_docs  -r https://upload.pypi.org/legacy/")
+      expect(provider.context).not_to receive(:shell).with("python setup.py upload_docs  -r https://upload.pypi.org/legacy/")
       provider.push_app
     end
 
@@ -50,16 +50,7 @@ describe DPL::Provider::PyPI do
       expect(provider.context).to receive(:shell).with("python setup.py sdist")
       expect(provider.context).to receive(:shell).with("twine upload -r pypi dist/*")
       expect(provider.context).to receive(:shell).with("rm -rf dist/*")
-      expect(provider.context).to receive(:shell).with("python setup.py upload_docs  -r http://blah.com")
-      provider.push_app
-    end
-
-    example "with :docs_dir option" do
-      provider.options.update(:docs_dir => 'some/dir')
-      expect(provider.context).to receive(:shell).with("python setup.py sdist")
-      expect(provider.context).to receive(:shell).with("twine upload -r pypi dist/*")
-      expect(provider.context).to receive(:shell).with("rm -rf dist/*")
-      expect(provider.context).to receive(:shell).with("python setup.py upload_docs --upload-dir some/dir -r https://upload.pypi.org/legacy/")
+      expect(provider.context).not_to receive(:shell).with("python setup.py upload_docs  -r http://blah.com")
       provider.push_app
     end
 
@@ -68,8 +59,33 @@ describe DPL::Provider::PyPI do
       expect(provider.context).to receive(:shell).with("python setup.py sdist")
       expect(provider.context).to receive(:shell).with("twine upload -r pypi dist/*")
       expect(provider.context).to receive(:shell).with("rm -rf dist/*")
+      expect(provider.context).not_to receive(:shell).with("python setup.py upload_docs -r https://upload.pypi.org/legacy/")
       provider.push_app
     end
+
+    context "with :skip_upload_docs option being false" do
+      before :each do
+        provider.options.update(:skip_upload_docs => false)
+      end
+
+      it "runs upload_docs" do
+        expect(provider.context).to receive(:shell).with("python setup.py sdist")
+        expect(provider.context).to receive(:shell).with("twine upload -r pypi dist/*")
+        expect(provider.context).to receive(:shell).with("rm -rf dist/*")
+        expect(provider.context).to receive(:shell).with("python setup.py upload_docs  -r https://upload.pypi.org/legacy/")
+        provider.push_app
+      end
+
+      example "with :docs_dir option" do
+        provider.options.update(:docs_dir => 'some/dir')
+        expect(provider.context).to receive(:shell).with("python setup.py sdist")
+        expect(provider.context).to receive(:shell).with("twine upload -r pypi dist/*")
+        expect(provider.context).to receive(:shell).with("rm -rf dist/*")
+        expect(provider.context).to receive(:shell).with("python setup.py upload_docs --upload-dir some/dir -r https://upload.pypi.org/legacy/")
+        provider.push_app
+      end
+    end
+
   end
 
   describe "#write_servers" do


### PR DESCRIPTION
https://github.com/travis-ci/dpl/issues/660 points to the change in default behavior. We should recognize this change, and change the default.

I think this is less risky than usual, since the default now leads to deployment failure.

This resolves #665.