### PR TITLE
Truncate output of git commit in pages provider

### DIFF
--- a/lib/dpl/provider/pages.rb
+++ b/lib/dpl/provider/pages.rb
@@ -59,7 +59,7 @@ module DPL
         context.shell "git config user.name '#{@gh_name}'"
         context.shell "echo '#{@gh_fqdn}' > CNAME" if @gh_fqdn
         context.shell 'git add .'
-        context.shell "git commit -m 'Deploy #{@project_name} to #{@gh_ref}:#{@target_branch}'"
+        context.shell "FILES=\"`git commit -m 'Deploy #{@project_name} to #{@gh_ref}:#{@target_branch}' | tail`\"; echo \"$FILES\"; echo \"$FILES\" | [ `wc -l` -lt 10 ] || echo '...'"
         context.shell "git push --force --quiet 'https://#{@gh_token}@#{@gh_ref}' master:#{@target_branch} > /dev/null 2>&1"
       end
 


### PR DESCRIPTION
Prevents build/deploy errors when more than 10k files are `git commit`'d and the build log grows too large.