### PR TITLE
Pin net-ssh-gateway to ~> 1.3.0

### DIFF
--- a/lib/dpl/provider/openshift.rb
+++ b/lib/dpl/provider/openshift.rb
@@ -3,6 +3,7 @@ module DPL
     class Openshift < Provider
       requires 'httpclient', version: '~> 2.4.0'
       requires 'net-ssh',    load: 'net/ssh',    version: '~> 2.9.2' # Anything higher requires Ruby 2.x
+      requires 'net-ssh-gateway', load: 'net/ssh/gateway',    version: '~> 1.3.0' # 2.0.0 requires net-ssh 4.0.0
       requires 'rhc'
 
       def initialize(context, options)


### PR DESCRIPTION
More recent versions require net-ssh 4.0.0, which is not compatible
with Ruby 1.9.x.

Resolves https://github.com/travis-ci/dpl/issues/595.