### PR TITLE
Pin `aws-sdk` to < 3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,16 +33,16 @@ group :rubygems do
 end
 
 group :sss do
-  gem 'aws-sdk', '~> 2.6.32'
+  gem 'aws-sdk', '~> 2.6.32', '< 3.0'
   gem 'mime-types'
 end
 
 group :code_deploy do
-  gem 'aws-sdk', '~> 2.6.32'
+  gem 'aws-sdk', '~> 2.6.32', '< 3.0'
 end
 
 group :lambda do
-  gem 'aws-sdk', '~> 2.6.32'
+  gem 'aws-sdk', '~> 2.6.32', '< 3.0'
   gem 'rubyzip', '~> 1.1'
 end
 
@@ -63,7 +63,7 @@ group :gcs do
 end
 
 group :elastic_beanstalk do
-  gem 'aws-sdk', '~> 2.6.32'
+  gem 'aws-sdk', '~> 2.6.32', '< 3.0'
   gem 'rubyzip', '~> 1.1'
 end
 
@@ -96,5 +96,5 @@ group :deis do
 end
 
 group :opsworks do
-  gem 'aws-sdk', '~> 2.6.32'
+  gem 'aws-sdk', '~> 2.6.32', '< 3.0'
 end

--- a/lib/dpl/provider/code_deploy.rb
+++ b/lib/dpl/provider/code_deploy.rb
@@ -3,7 +3,7 @@ require 'json'
 module DPL
   class Provider
     class CodeDeploy < Provider
-      requires 'aws-sdk', pre: true, version: '~> 2.8.5'
+      requires 'aws-sdk', pre: true, version: '< 3.0'
 
       def code_deploy
         @code_deploy ||= Aws::CodeDeploy::Client.new(code_deploy_options)

--- a/lib/dpl/provider/elastic_beanstalk.rb
+++ b/lib/dpl/provider/elastic_beanstalk.rb
@@ -5,7 +5,7 @@ module DPL
     class ElasticBeanstalk < Provider
       experimental 'AWS Elastic Beanstalk'
 
-      requires 'aws-sdk'
+      requires 'aws-sdk', version: '< 3.0'
       requires 'rubyzip', :load => 'zip'
 
       DEFAULT_REGION = 'us-east-1'

--- a/lib/dpl/provider/lambda.rb
+++ b/lib/dpl/provider/lambda.rb
@@ -5,7 +5,7 @@ require 'fileutils'
 module DPL
   class Provider
     class Lambda < Provider
-      requires 'aws-sdk'
+      requires 'aws-sdk', version: '< 3.0'
       requires 'rubyzip', load: 'zip'
 
       def lambda

--- a/lib/dpl/provider/ops_works.rb
+++ b/lib/dpl/provider/ops_works.rb
@@ -3,7 +3,7 @@ require 'timeout'
 module DPL
   class Provider
     class OpsWorks < Provider
-      requires 'aws-sdk', version: '~> 2'
+      requires 'aws-sdk', version: '< 3.0'
       experimental 'AWS OpsWorks'
 
       def opsworks

--- a/lib/dpl/provider/s3.rb
+++ b/lib/dpl/provider/s3.rb
@@ -3,7 +3,7 @@ require 'json'
 module DPL
   class Provider
     class S3 < Provider
-      requires 'aws-sdk', version: '>= 2.0.22'
+      requires 'aws-sdk', version: '< 3.0'
       requires 'mime-types', version: '~> 2.0'
 
       def api


### PR DESCRIPTION
[`aws-sdk` 3.0](https://rubygems.org/gems/aws-sdk/versions/3.0.0) was released earlier today, and this results in problems if multiple different AWS deployments are configured (most notably CodeDeploy, which _requires_ S3).

The manifestation is such that `gem` waits for user input that never comes, to confirm whether or not `aws.rb` should be overwritten: https://travis-ci.org/BanzaiMan/travis_production_test/builds/269741234#L571-L573

This PR fixes this issue by specifying `< 3` in the `gem install -v` command. Here, we will assume that the previous `~> 2.*` strings are no longer necessary, since sufficient time has passed and it is not longer a concern to drop it. (`gem install -v` cannot take multiple such specifications)