### PR TITLE
Pin aws-sdk to '~> 2.0'

### DIFF
--- a/lib/dpl/provider/code_deploy.rb
+++ b/lib/dpl/provider/code_deploy.rb
@@ -3,7 +3,7 @@ require 'json'
 module DPL
   class Provider
     class CodeDeploy < Provider
-      requires 'aws-sdk', pre: true, version: '< 3.0'
+      requires 'aws-sdk', pre: true, version: '~> 2.0'
 
       def code_deploy
         @code_deploy ||= Aws::CodeDeploy::Client.new(code_deploy_options)

--- a/lib/dpl/provider/elastic_beanstalk.rb
+++ b/lib/dpl/provider/elastic_beanstalk.rb
@@ -5,7 +5,7 @@ module DPL
     class ElasticBeanstalk < Provider
       experimental 'AWS Elastic Beanstalk'
 
-      requires 'aws-sdk', version: '< 3.0'
+      requires 'aws-sdk', version: '~> 2.0'
       requires 'rubyzip', :load => 'zip'
 
       DEFAULT_REGION = 'us-east-1'

--- a/lib/dpl/provider/lambda.rb
+++ b/lib/dpl/provider/lambda.rb
@@ -5,7 +5,7 @@ require 'fileutils'
 module DPL
   class Provider
     class Lambda < Provider
-      requires 'aws-sdk', version: '< 3.0'
+      requires 'aws-sdk', version: '~> 2.0'
       requires 'rubyzip', load: 'zip'
 
       def lambda

--- a/lib/dpl/provider/ops_works.rb
+++ b/lib/dpl/provider/ops_works.rb
@@ -3,7 +3,7 @@ require 'timeout'
 module DPL
   class Provider
     class OpsWorks < Provider
-      requires 'aws-sdk', version: '< 3.0'
+      requires 'aws-sdk', version: '~> 2.0'
       experimental 'AWS OpsWorks'
 
       def opsworks

--- a/lib/dpl/provider/s3.rb
+++ b/lib/dpl/provider/s3.rb
@@ -3,7 +3,7 @@ require 'json'
 module DPL
   class Provider
     class S3 < Provider
-      requires 'aws-sdk', version: '< 3.0'
+      requires 'aws-sdk', version: '~> 2.0'
       requires 'mime-types', version: '~> 2.0'
 
       def api


### PR DESCRIPTION
Previous '< 3.0' was too lax, resulting in some cases installation
of '1.x'

Resolves https://github.com/travis-ci/dpl/issues/685.