### PR TITLE
Relax chef gem constraint for chef-supermarket provider

### DIFF
--- a/lib/dpl/provider/chef_supermarket.rb
+++ b/lib/dpl/provider/chef_supermarket.rb
@@ -5,10 +5,16 @@ module DPL
       # Most of the code is inspired by:
       # https://github.com/opscode/chef/blob/11.16.4/lib/chef/knife/cookbook_site_share.rb
 
-      # Compatibility with ruby 1.9
-      requires 'rack', version: '< 2.0'
-      requires 'mime-types', version: '~> 1.16'
-      requires 'chef', version: '< 12.0'
+      case RUBY_VERSION
+      when /^1\.[0-9](\..*)?$/
+         requires 'rack', version: '< 2.0'
+         requires 'mime-types', version: '~> 1.16'
+         requires 'chef', version: '< 12.0'
+      when /^2.[0-2](\..*)?$/
+        requires 'chef', version: '~> 12.0'
+      else
+        requires 'chef'
+      end
       requires 'chef', load: 'chef/config'
       requires 'chef', load: 'chef/cookbook_loader'
       requires 'chef', load: 'chef/cookbook_uploader'
@@ -41,7 +47,7 @@ module DPL
         # So we assume cookbook path is '..'
         cl = ::Chef::CookbookLoader.new '..'
         @cookbook = cl[cookbook_name]
-        ::Chef::CookbookUploader.new(cookbook, '..').validate_cookbooks
+        ::Chef::CookbookUploader.new(cookbook).validate_cookbooks
       end
 
       def push_app


### PR DESCRIPTION
dpl is now running with ruby 2.2.7 so we don't have to restrain
chef version too much

Also fix compatibility with recent chef version.