### PR TITLE
Drop verification of existing firebase-tools installation

### DIFF
--- a/lib/dpl/provider/firebase.rb
+++ b/lib/dpl/provider/firebase.rb
@@ -1,7 +1,7 @@
 module DPL
   class Provider
     class Firebase < Provider
-      npm_g 'firebase-tools@^3.0', 'firebase'
+      npm_g 'firebase-tools@^3.0'
 
       def check_auth
         raise Error, "must supply token option or FIREBASE_TOKEN environment variable" if !options[:token] && !context.env['FIREBASE_TOKEN']


### PR DESCRIPTION
This prevents https://github.com/travis-ci/travis-ci/issues/8637 from happening.

The check uses the PATH, which in case of node.js projects includes `node_modules/.bin`. If the firebase-tools package has been installed locally, the check will pass because they are stored in said folder, so the tools will not get installed globally. The problem is that when the deploy is run, `node_modules/.bin` isn't in the PATH so it results in 'sh: 1: firebase: not found' when deploying.