### PR TITLE
Preserve history when deploying to gh-pages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,7 +519,8 @@ You first need to create an [Atlas account](https://atlas.hashicorp.com/account/
 * **github-token**: GitHub oauth token with `repo` permission.
 * **deploy-key**: A base64-encoded [GitHub deploy
   key](https://developer.github.com/v3/guides/managing-deploy-keys/#deploy-keys)
-  with write access to the **repo** repository.
+  with write access to the **repo** repository. Note that RSA keys are too long
+  to fit into a secure variable, but ECDSA-521 fits.
 * **repo**: Repo slug, defaults to current one.
 * **target-branch**: Branch to push force to, defaults to gh-pages.
 * **local-dir**: Directory to push to GitHub Pages, defaults to current.

--- a/README.md
+++ b/README.md
@@ -518,13 +518,16 @@ You first need to create an [Atlas account](https://atlas.hashicorp.com/account/
 
 * **github-token**: GitHub oauth token with `repo` permission.
 * **deploy-key**: Filename of an encrypted
-  [GitHub deploy key](https://developer.github.com/v3/guides/managing-deploy-keys/#deploy-keys)
-  with write access to the **repo** repository, encrypted with `travis
-  encrypt-file`.
-* **deploy-key-key**: The key produced by `travis encrypt-file`, usually of the
-  form `$encrypted_<hex-digits>_key`.
-* **deploy-key-iv**: The IV produced by `travis encrypt-file`, usually of the
-  form `$encrypted_<hex-digits>_iv`.
+  [GitHub deploy key](https://developer.github.com/v3/guides/managing-deploy-keys/#deploy-keys) with
+  write access to the **repo** repository, encrypted using
+  [`openssl aes-256-cbc -k`](https://docs.travis-ci.com/user/encrypting-files/#Using-OpenSSL). For
+  example, if your deploy key is in `deploy_key`, its encryption key is in `$DEPLOY_KEY_KEY`, and
+  you want to encrypt it to `deploy_key.enc`, you can use: `openssl aes-256-cbc -k "$DEPLOY_KEY_KEY"
+  -in deploy_key -out deploy_key.enc`.
+* **deploy-key-key**: The decryption key for the deploy-key file. This can be created with `openssl
+  rand -base64 32` and saved securely into Travis CI using `travis encrypt DEPLOY_KEY_KEY=<the
+  key> --add`. Be sure to pick an [encrypted variable](https://docs.travis-ci.com/user/encryption-keys/)
+  name that you're not yet using.
 * **repo**: Repo slug, defaults to current one.
 * **target-branch**: Branch to push force to, defaults to gh-pages.
 * **local-dir**: Directory to push to GitHub Pages, defaults to current.
@@ -536,6 +539,10 @@ You first need to create an [Atlas account](https://atlas.hashicorp.com/account/
 #### Examples:
 
     dpl --provider=pages --github-token=<api-key> --local-dir=build
+    DEPLOY_KEY_KEY=$(openssl rand -base64 32)
+    travis encrypt DEPLOY_KEY_KEY=$DEPLOY_KEY_KEY --add
+    openssl aes-256-cbc -k $DEPLOY_KEY_KEY -in deploy_key -out deploy_key.enc
+    dpl --provider=pages --deploy-key=deploy_key.enc --deploy-key-key=$DEPLOY_KEY_KEY --local-dir=build
 
 ### GitHub Releases:
 

--- a/README.md
+++ b/README.md
@@ -517,6 +517,14 @@ You first need to create an [Atlas account](https://atlas.hashicorp.com/account/
 #### Options:
 
 * **github-token**: GitHub oauth token with `repo` permission.
+* **deploy-key**: Filename of an encrypted
+  [GitHub deploy key](https://developer.github.com/v3/guides/managing-deploy-keys/#deploy-keys)
+  with write access to the **repo** repository, encrypted with `travis
+  encrypt-file`.
+* **deploy-key-key**: The key produced by `travis encrypt-file`, usually of the
+  form `$encrypted_<hex-digits>_key`.
+* **deploy-key-iv**: The IV produced by `travis encrypt-file`, usually of the
+  form `$encrypted_<hex-digits>_iv`.
 * **repo**: Repo slug, defaults to current one.
 * **target-branch**: Branch to push force to, defaults to gh-pages.
 * **local-dir**: Directory to push to GitHub Pages, defaults to current.

--- a/README.md
+++ b/README.md
@@ -517,17 +517,9 @@ You first need to create an [Atlas account](https://atlas.hashicorp.com/account/
 #### Options:
 
 * **github-token**: GitHub oauth token with `repo` permission.
-* **deploy-key**: Filename of an encrypted
-  [GitHub deploy key](https://developer.github.com/v3/guides/managing-deploy-keys/#deploy-keys) with
-  write access to the **repo** repository, encrypted using
-  [`openssl aes-256-cbc -k`](https://docs.travis-ci.com/user/encrypting-files/#Using-OpenSSL). For
-  example, if your deploy key is in `deploy_key`, its encryption key is in `$DEPLOY_KEY_KEY`, and
-  you want to encrypt it to `deploy_key.enc`, you can use: `openssl aes-256-cbc -k "$DEPLOY_KEY_KEY"
-  -in deploy_key -out deploy_key.enc`.
-* **deploy-key-key**: The decryption key for the deploy-key file. This can be created with `openssl
-  rand -base64 32` and saved securely into Travis CI using `travis encrypt DEPLOY_KEY_KEY=<the
-  key> --add`. Be sure to pick an [encrypted variable](https://docs.travis-ci.com/user/encryption-keys/)
-  name that you're not yet using.
+* **deploy-key**: A base64-encoded [GitHub deploy
+  key](https://developer.github.com/v3/guides/managing-deploy-keys/#deploy-keys)
+  with write access to the **repo** repository.
 * **repo**: Repo slug, defaults to current one.
 * **target-branch**: Branch to push force to, defaults to gh-pages.
 * **local-dir**: Directory to push to GitHub Pages, defaults to current.
@@ -539,10 +531,8 @@ You first need to create an [Atlas account](https://atlas.hashicorp.com/account/
 #### Examples:
 
     dpl --provider=pages --github-token=<api-key> --local-dir=build
-    DEPLOY_KEY_KEY=$(openssl rand -base64 32)
-    travis encrypt DEPLOY_KEY_KEY=$DEPLOY_KEY_KEY --add
-    openssl aes-256-cbc -k $DEPLOY_KEY_KEY -in deploy_key -out deploy_key.enc
-    dpl --provider=pages --deploy-key=deploy_key.enc --deploy-key-key=$DEPLOY_KEY_KEY --local-dir=build
+    travis encrypt DEPLOY_KEY="$(cat deploy_key|base64)"
+    dpl --provider=pages --deploy-key="$DEPLOY_KEY" --local-dir=build
 
 ### GitHub Releases:
 

--- a/lib/dpl/provider/pages.rb
+++ b/lib/dpl/provider/pages.rb
@@ -84,9 +84,12 @@ module DPL
       end
 
       def github_deploy
-        context.shell "touch \"deployed at `date` by #{@gh_name}\""
         context.shell "echo '#{@gh_fqdn}' > CNAME" if @gh_fqdn
         context.shell 'git add .'
+        if context.shell "git diff --cached --quiet"
+          log "No changes; skipping deploy."
+          return true
+        end
         context.shell "FILES=\"`git commit -m 'Deploy #{@project_name} to #{@gh_ref}:#{@target_branch}' | tail`\"; echo \"$FILES\"; echo \"$FILES\" | [ `wc -l` -lt 10 ] || echo '...'"
         # The following line will fail if another deploy happened concurrently.
         # We'd rather have the deploy for the later revision succeed, but that

--- a/lib/dpl/provider/pages.rb
+++ b/lib/dpl/provider/pages.rb
@@ -1,3 +1,5 @@
+require "base64"
+
 module DPL
   class Provider
     class Pages < Provider
@@ -6,8 +8,7 @@ module DPL
       Options:
         - repo [optional, for pushed to other repos]
         - github-token [this or deploy-key required]
-        - deploy-key [this or github-token required; deploy key encrypted with `openssl aes-256-cbc -k`]
-        - deploy-key-key [required if deploy-key is present]
+        - deploy-key [this or github-token required]
         - github-url [optional, defaults to github.com]
         - target-branch [optional, defaults to gh-pages]
         - local-dir [optional, defaults to `pwd`]
@@ -35,9 +36,6 @@ module DPL
         unless @gh_token || @gh_deploy_key
           raise(Error, "must specify github-token or deploy-key")
         end
-        if @gh_deploy_key
-          @gh_deploy_key_key = option(:deploy_key_key)
-        end
 
         @gh_email = options[:email] || 'deploy@travis-ci.org'
         @gh_name = "#{options[:name] || 'Deployment Bot'} (from Travis CI)"
@@ -58,8 +56,8 @@ module DPL
 
       def needs_key?
         # Provider's generic support for keys is about provisioning and
-        # deprovisioning them, while this provider needs to install an encrypted
-        # key provided by the caller.
+        # deprovisioning them, while this provider needs to install a key
+        # provided by the caller.
         false
       end
 
@@ -84,9 +82,10 @@ module DPL
       def push_app
         Dir.mktmpdir {|gitdir|
           if @gh_deploy_key
-            # Decrypt the key and install it.
-            context.shell "openssl aes-256-cbc -k '#{@gh_deploy_key_key}' -in '#{@gh_deploy_key}' -out #{gitdir}/deploykey -d"
-            File.chmod(0600, "#{gitdir}/deploykey")
+            # Install the key.
+            File.open("#{gitdir}/deploykey", "w", 0600) {|file|
+              file.write Base64.decode64(@gh_deploy_key)
+            }
             setup_git_ssh("#{gitdir}/git-ssh", "#{gitdir}/deploykey")
           end
           Dir.mktmpdir {|tmpdir|

--- a/lib/dpl/provider/pages.rb
+++ b/lib/dpl/provider/pages.rb
@@ -6,9 +6,8 @@ module DPL
       Options:
         - repo [optional, for pushed to other repos]
         - github-token [this or deploy-key required]
-        - deploy-key [this or github-token required; deploy key encrypted with `travis encrypt-file`]
+        - deploy-key [this or github-token required; deploy key encrypted with `openssl aes-256-cbc -k`]
         - deploy-key-key [required if deploy-key is present]
-        - deploy-key-iv [required if deploy-key is present]
         - github-url [optional, defaults to github.com]
         - target-branch [optional, defaults to gh-pages]
         - local-dir [optional, defaults to `pwd`]
@@ -38,7 +37,6 @@ module DPL
         end
         if @gh_deploy_key
           @gh_deploy_key_key = option(:deploy_key_key)
-          @gh_deploy_key_iv = option(:deploy_key_iv)
         end
 
         @gh_email = options[:email] || 'deploy@travis-ci.org'
@@ -86,8 +84,8 @@ module DPL
       def push_app
         Dir.mktmpdir {|gitdir|
           if @gh_deploy_key
-            # Decrypt a key encrypted by `travis encrypt-file`, and install it.
-            context.shell "openssl aes-256-cbc -K #{@gh_deploy_key_key} -iv #{@gh_deploy_key_iv} -in #{@gh_deploy_key} -out #{gitdir}/deploykey -d"
+            # Decrypt the key and install it.
+            context.shell "openssl aes-256-cbc -k '#{@gh_deploy_key_key}' -in '#{@gh_deploy_key}' -out #{gitdir}/deploykey -d"
             File.chmod(0600, "#{gitdir}/deploykey")
             setup_git_ssh("#{gitdir}/git-ssh", "#{gitdir}/deploykey")
           end

--- a/lib/dpl/provider/pages.rb
+++ b/lib/dpl/provider/pages.rb
@@ -33,9 +33,6 @@ module DPL
         @gh_url = options[:github_url] || 'github.com'
         @gh_token = options[:github_token]
         @gh_deploy_key = options[:deploy_key]
-        unless @gh_token || @gh_deploy_key
-          raise(Error, "must specify github-token or deploy-key")
-        end
 
         @gh_email = options[:email] || 'deploy@travis-ci.org'
         @gh_name = "#{options[:name] || 'Deployment Bot'} (from Travis CI)"
@@ -52,6 +49,9 @@ module DPL
       end
 
       def check_auth
+        unless @gh_token || @gh_deploy_key
+          error "must specify github-token or deploy-key"
+        end
       end
 
       def needs_key?


### PR DESCRIPTION
Fixes #704.

This change sits on top of #695, which is mostly reviewed.

@webknjaz, does this look reasonable to you?

Test deploys:
* https://travis-ci.org/jyasskin/testing/builds/304151299 testing a deploy with no existing gh-pages branch.
* https://travis-ci.org/jyasskin/testing/builds/304151521 testing a deploy with an existing gh-pages branch
* https://travis-ci.org/jyasskin/testing/builds/304151699 testing that a no-op deploy is skipped.

You can see the resulting gh-pages branch at https://github.com/jyasskin/testing/commits/gh-pages.