### PR TITLE
PyPI: Drop using deprecated ez_setup.py in favor of get-pip.py.

### DIFF
--- a/lib/dpl/provider/pypi.rb
+++ b/lib/dpl/provider/pypi.rb
@@ -32,21 +32,15 @@ module DPL
           (options.has_key?(:skip_upload_docs) && options[:skip_upload_docs])
       end
 
-      def self.install_setuptools
-        shell 'wget https://bootstrap.pypa.io/ez_setup.py -O - | sudo python'
-        shell 'rm -f setuptools-*.zip'
+      def self.install_pip
+        shell 'wget https://bootstrap.pypa.io/get-pip.py -O - | sudo python'
       end
 
       def self.install_twine
         shell("pip install twine", retry: true) if `which twine`.chop.empty?
       end
 
-      def initialize(*args)
-        super(*args)
-        self.class.pip 'wheel' if pypi_distributions.to_s.include? 'bdist_wheel'
-      end
-
-      install_setuptools
+      install_pip
       install_twine
 
       def config

--- a/spec/provider/pypi_spec.rb
+++ b/spec/provider/pypi_spec.rb
@@ -13,13 +13,6 @@ describe DPL::Provider::PyPI do
     end
   end
 
-  describe "#initialize" do
-    example "with :distributions option containing 'bdist_wheel'" do
-      expect(described_class).to receive(:pip).with("wheel")
-      described_class.new(DummyContext.new, :user => 'foo', :password => 'bar', :distributions => 'bdist_wheel sdist')
-    end
-  end
-
   describe "#check_auth" do
     example do
       expect(provider).to receive(:log).with("Authenticated as foo")


### PR DESCRIPTION
Fix #603.

This also removes installing wheel conditionally since get-pip.py will
install wheel automatically (see https://pip.pypa.io/en/stable/installing/).

More info about the deprecation of ez_setup.py: https://github.com/pypa/setuptools/issues/581