### PR TITLE
Enable gh-pages to retain deploy branch history

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,6 +519,8 @@ You first need to create an [Atlas account](https://atlas.hashicorp.com/account/
 * **github-token**: GitHub oauth token with `repo` permission.
 * **repo**: Repo slug, defaults to current one.
 * **target-branch**: Branch to push force to, defaults to gh-pages.
+* **keep-history**: Optional, create incremental commit instead of doing push force, defaults to false.
+* **verbose**: Optional, be verbose about internal steps, defaults to false.
 * **local-dir**: Directory to push to GitHub Pages, defaults to current.
 * **fqdn**: Optional, no default, sets a main domain for your website.
 * **project-name**: Defaults to fqdn or repo slug, used for metadata.

--- a/README.md
+++ b/README.md
@@ -521,12 +521,13 @@ You first need to create an [Atlas account](https://atlas.hashicorp.com/account/
 * **target-branch**: Branch to push force to, defaults to gh-pages.
 * **keep-history**: Optional, create incremental commit instead of doing push force, defaults to false.
 * **allow-empty-commit**: Optional, defaults to false. Enabled if only keep-history is true.
+* **committer-from-gh**: Optional, defaults to false. Allows to use token's owner name and email for commit. Overrides `email` and `name` options.
 * **verbose**: Optional, be verbose about internal steps, defaults to false.
 * **local-dir**: Directory to push to GitHub Pages, defaults to current.
 * **fqdn**: Optional, no default, sets a main domain for your website.
 * **project-name**: Defaults to fqdn or repo slug, used for metadata.
-* **email**: Optional, comitter info, defaults to deploy@travis-ci.org.
-* **name**: Optional, comitter, defaults to Deployment Bot.
+* **email**: Optional, committer info, defaults to deploy@travis-ci.org.
+* **name**: Optional, committer, defaults to Deployment Bot.
 
 #### Examples:
 

--- a/README.md
+++ b/README.md
@@ -520,6 +520,7 @@ You first need to create an [Atlas account](https://atlas.hashicorp.com/account/
 * **repo**: Repo slug, defaults to current one.
 * **target-branch**: Branch to push force to, defaults to gh-pages.
 * **keep-history**: Optional, create incremental commit instead of doing push force, defaults to false.
+* **allow-empty-commit**: Optional, defaults to false. Enabled if only keep-history is true.
 * **verbose**: Optional, be verbose about internal steps, defaults to false.
 * **local-dir**: Directory to push to GitHub Pages, defaults to current.
 * **fqdn**: Optional, no default, sets a main domain for your website.

--- a/lib/dpl/provider/pages.rb
+++ b/lib/dpl/provider/pages.rb
@@ -25,7 +25,7 @@ module DPL
       def initialize(context, options)
         super
 
-        @build_dir = options[:local_dir] || '.'
+        @build_dir = File.join(Dir.pwd, options[:local_dir] || '.')
         @project_name = options[:project_name] || fqdn || slug
         @target_branch = options[:target_branch] || 'gh-pages'
 
@@ -94,7 +94,7 @@ module DPL
 
       def github_init(target_dir)
         FileUtils.cd(target_dir, :verbose => true) do
-          print_step "Creating a brand new local repo from scratch in dir #{`pwd`}..."
+          print_step "Creating a brand new local repo from scratch in dir #{Dir.pwd}..."
           context.shell "git init" or raise 'Could not create new git repo'
           print_step 'Repo created successfully'
           context.shell "git checkout --orphan '#{@target_branch}'" or raise 'Could not create an orphan git branch'
@@ -103,13 +103,13 @@ module DPL
       end
 
       def github_configure
-        print_step "Configuring git committer to be #{@gh_name} <#{@gh_email}> (workdir: #{`pwd`})"
+        print_step "Configuring git committer to be #{@gh_name} <#{@gh_email}> (workdir: #{Dir.pwd})"
         context.shell "git config user.email '#{@gh_email}'"
         context.shell "git config user.name '#{@gh_name}'"
       end
 
       def github_commit
-        print_step "Preparing to deploy #{@target_branch} branch to gh-pages (workdir: #{`pwd`})"
+        print_step "Preparing to deploy #{@target_branch} branch to gh-pages (workdir: #{Dir.pwd})"
         context.shell "touch \"deployed at `date` by #{@gh_name}\""
         context.shell "echo '#{@gh_fqdn}' > CNAME" if @gh_fqdn
         context.shell 'git add -A .'
@@ -118,7 +118,7 @@ module DPL
       end
 
       def github_deploy
-        print_step "Doing the git push (workdir: #{`pwd`})..."
+        print_step "Doing the git push (workdir: #{Dir.pwd})..."
         unless context.shell "git push#{@git_push_opts} --quiet '#{@gh_remote_url}' '#{@target_branch}':'#{@target_branch}' &>/dev/null"
           error "Couldn't push the build to #{@gh_ref}:#{@target_branch}"
         end
@@ -135,7 +135,7 @@ module DPL
             github_pull_or_init(workdir)
 
             FileUtils.cd(workdir, :verbose => true) do
-              print_step "Copying #{@build_dir} contents to #{workdir} (workdir: #{`pwd`})..."
+              print_step "Copying #{@build_dir} contents to #{workdir} (workdir: #{Dir.pwd})..."
               context.shell "rsync -r --exclude .git --delete '#{@build_dir}/' '#{workdir}'" or error "Could not copy #{@build_dir}."
 
               github_configure

--- a/lib/dpl/provider/pages.rb
+++ b/lib/dpl/provider/pages.rb
@@ -123,7 +123,9 @@ module DPL
 
       def github_deploy
         print_step "Doing the git push..."
-        context.shell "git push#{@git_push_opts} --quiet '#{@gh_remote_url}' '#{@target_branch}':'#{@target_branch}' &>/dev/null"
+        unless context.shell "git push#{@git_push_opts} --quiet '#{@gh_remote_url}' '#{@target_branch}':'#{@target_branch}' &>/dev/null"
+          error "Couldn't push the build to #{@gh_ref}:#{@target_branch}"
+        end
       end
 
       def prepare_dir_tree(dir)
@@ -175,9 +177,7 @@ module DPL
               end
               github_configure
               github_commit
-              unless github_deploy
-                error "Couldn't push the build to #{@gh_ref}:#{@target_branch}"
-              end
+              github_deploy
               context.shell "git status" if @verbose
             end
         end

--- a/lib/dpl/provider/pages.rb
+++ b/lib/dpl/provider/pages.rb
@@ -84,7 +84,7 @@ module DPL
         end
 
         print_step "Trying to clone a single branch #{@target_branch} from existing repo..."
-        unless context.shell "git clone --quiet --branch='#{@target_branch}' --depth=1 '#{@gh_remote_url}' '#{target_dir}' &>/dev/null"
+        unless context.shell "git clone --quiet --branch='#{@target_branch}' --depth=1 '#{@gh_remote_url}' '#{target_dir}' > /dev/null 2>&1"
           # if such branch doesn't exist at remote, init it from scratch
           print_step "Cloning #{@target_branch} branch failed"
           Dir.mkdir(target_dir)  # Restore dir destroyed by failed `git clone`
@@ -119,7 +119,7 @@ module DPL
 
       def github_deploy
         print_step "Doing the git push (workdir: #{Dir.pwd})..."
-        unless context.shell "git push#{@git_push_opts} --quiet '#{@gh_remote_url}' '#{@target_branch}':'#{@target_branch}' &>/dev/null"
+        unless context.shell "git push#{@git_push_opts} --quiet '#{@gh_remote_url}' '#{@target_branch}':'#{@target_branch}' > /dev/null 2>&1"
           error "Couldn't push the build to #{@gh_ref}:#{@target_branch}"
         end
       end

--- a/lib/dpl/provider/pages.rb
+++ b/lib/dpl/provider/pages.rb
@@ -8,6 +8,8 @@ module DPL
         - github-token [required]
         - github-url [optional, defaults to github.com]
         - target-branch [optional, defaults to gh-pages]
+        - keep-history [optional, defaults to false]
+        - verbose [optional, defaults to false]
         - local-dir [optional, defaults to `pwd`]
         - fqdn [optional]
         - project-name [optional, defaults to fqdn or repo slug]
@@ -29,11 +31,15 @@ module DPL
         @gh_fqdn = fqdn
         @gh_url = options[:github_url] || 'github.com'
         @gh_token = option(:github_token)
+        @keep_history = !!keep_history
+        @verbose = !!verbose
 
         @gh_email = options[:email] || 'deploy@travis-ci.org'
         @gh_name = "#{options[:name] || 'Deployment Bot'} (from Travis CI)"
 
         @gh_ref = "#{@gh_url}/#{slug}.git"
+        @gh_remote_url = "https://#{@gh_token}@#{@gh_ref}"
+        @git_push_opts = @keep_history ? '' : ' --force'
       end
 
       def fqdn
@@ -44,6 +50,15 @@ module DPL
         options.fetch(:repo) { context.env['TRAVIS_REPO_SLUG'] }
       end
 
+      def keep_history
+        options.fetch(:keep_history, false)
+      end
+
+      def verbose
+        # Achtung! Never verbosify git, since it may expose user's token.
+        options.fetch(:verbose, false)
+      end
+
       def check_auth
       end
 
@@ -51,27 +66,115 @@ module DPL
         false
       end
 
-      def github_deploy
-        context.shell 'rm -rf .git > /dev/null 2>&1'
-        context.shell "touch \"deployed at `date` by #{@gh_name}\""
-        context.shell 'git init' or raise 'Could not create new git repo'
+      def print_step(msg)
+        log msg if @verbose
+      end
+
+      def github_pull(target_dir)
+        print_step "Trying to clone a single branch #{@target_branch} from existing repo..."
+        unless context.shell "git clone --quiet --branch='#{@target_branch}' --depth=1 '#{@gh_remote_url}' '#{target_dir}' &>/dev/null"
+          # if such branch doesn't exist at remote, do normal clone and create
+          # a new orphan branch
+          print_step "Cloning #{@target_branch} branch failed"
+          print_step 'Trying to clone the whole repo...'
+          context.shell "git clone --quiet '#{@gh_remote_url}' '#{target_dir}' &>/dev/null" or raise "It looks the repo doesn't exist on remote or is inaccessible"
+          FileUtils.cd(target_dir, :verbose => @verbose) do
+            print_step "Assuming #{@target_branch} branch doesn't exist, thus creating orphan one"
+            context.shell "git checkout --orphan '#{@target_branch}'"
+          end
+        end
+      end
+
+      def github_clean
+        print_step 'Purging every existing file from repo...'
+        context.shell "git ls-files -z 2>/dev/null | xargs -0 rm -f 2>/dev/null"  # remove all committed files from the repo
+        print_step 'Cleaning up all folders from repo...'
+        context.shell "git ls-tree --name-only -d -r -z HEAD 2>/dev/null | sort -rz | xargs -0 rmdir 2>/dev/null"  # remove all directories from the repo
+      end
+
+      def github_init
+        print_step 'Creating a brand new local repo from scratch...'
+        context.shell "git init" or raise 'Could not create new git repo'
+        print_step 'Repo created successfully'
+        context.shell "git checkout --orphan '#{@target_branch}'" or raise 'Could not create an orphan git branch'
+        print_step "An orphan branch #{@target_branch} created successfully"
+      end
+
+      def github_configure
+        print_step "Configuring git committer to be #{@gh_name} <#{@gh_email}>"
         context.shell "git config user.email '#{@gh_email}'"
         context.shell "git config user.name '#{@gh_name}'"
+      end
+
+      def github_commit
+        print_step "Preparing to deploy #{@target_branch} branch to gh-pages"
+        context.shell "touch \"deployed at `date` by #{@gh_name}\""
         context.shell "echo '#{@gh_fqdn}' > CNAME" if @gh_fqdn
-        context.shell 'git add .'
+        context.shell 'git add -A .'
         context.shell "FILES=\"`git commit -m 'Deploy #{@project_name} to #{@gh_ref}:#{@target_branch}' | tail`\"; echo \"$FILES\"; echo \"$FILES\" | [ `wc -l` -lt 10 ] || echo '...'"
-        context.shell "git push --force --quiet 'https://#{@gh_token}@#{@gh_ref}' master:#{@target_branch} > /dev/null 2>&1"
+      end
+
+      def github_deploy
+        print_step "Doing the git push..."
+        context.shell "git push#{@git_push_opts} --quiet '#{@gh_remote_url}' '#{@target_branch}':'#{@target_branch}' &>/dev/null"
+      end
+
+      def prepare_dir_tree(dir)
+            build = "#{dir}/build"
+            work = "#{dir}/work"
+
+            Dir.mkdir(build)
+            print_step "Created a temporary build directory #{build}"
+
+            Dir.mkdir(work)
+            print_step "Created a temporary working directory #{work}"
+
+            return build, work
+      end
+
+      def prepare_build_dir(build, tmp)
+            FileUtils.cp_r("#{build}/.", tmp)
+            print_step "Copied over build contents to #{tmp}"
+            FileUtils.cd(tmp, :verbose => @verbose) do
+                FileUtils.rm_r '.git', :force => true, :verbose => @verbose # cleanup garbage
+                print_step "Cleaned up .git artifacts"
+            end
       end
 
       def push_app
-        Dir.mktmpdir {|tmpdir|
-            FileUtils.cp_r("#{@build_dir}/.", tmpdir)
-            FileUtils.cd(tmpdir, :verbose => true) do
+        print_step "Starting deployment of #{@target_branch} branch to GitHub Pages..."
+        print_step "The deployment is configured to preserve the target branch if it exists on remote" if @keep_history
+        Dir.mktmpdir do |tmpdir|
+            print_step "Created a temporary directory #{tmpdir}"
+
+            tmp_build_dir, tmp_work_dir = prepare_dir_tree(tmpdir)
+
+            prepare_build_dir(@build_dir, tmp_build_dir)
+
+            if @keep_history
+              github_pull(tmp_work_dir)
+              FileUtils.cd(tmp_work_dir, :verbose => @verbose) do
+                github_clean
+              end
+            end
+
+            print_step "Copying #{@build_dir} contents to #{tmp_work_dir}..."
+            FileUtils.cp_r("#{tmp_build_dir}/.", tmp_work_dir)
+
+            print_step "Entering #{tmp_work_dir}..."
+            FileUtils.cd(tmp_work_dir, :verbose => @verbose) do
+              unless @keep_history
+                github_init
+              end
+              github_configure
+              github_commit
               unless github_deploy
                 error "Couldn't push the build to #{@gh_ref}:#{@target_branch}"
               end
+              context.shell "git status" if @verbose
             end
-        }
+        end
+        print_step "App has been pushed"
       end
 
     end

--- a/lib/dpl/provider/pages.rb
+++ b/lib/dpl/provider/pages.rb
@@ -118,7 +118,8 @@ module DPL
         context.shell "touch \"deployed at `date` by #{@gh_name}\""
         context.shell "echo '#{@gh_fqdn}' > CNAME" if @gh_fqdn
         context.shell 'git add -A .'
-        context.shell "FILES=\"`git commit#{@git_commit_opts} -m 'Deploy #{@project_name} to #{@gh_ref}:#{@target_branch}' | tail`\"; echo \"$FILES\"; echo \"$FILES\" | [ `wc -l` -lt 10 ] || echo '...'"
+        context.shell "git commit#{@git_commit_opts} -qm 'Deploy #{@project_name} to #{@gh_ref}:#{@target_branch}'"
+        context.shell 'git show --stat-count=10 HEAD'
       end
 
       def github_deploy

--- a/lib/dpl/provider/pages.rb
+++ b/lib/dpl/provider/pages.rb
@@ -9,6 +9,7 @@ module DPL
         - github-url [optional, defaults to github.com]
         - target-branch [optional, defaults to gh-pages]
         - keep-history [optional, defaults to false]
+        - allow-empty-commit [optional, defaults to false]
         - verbose [optional, defaults to false]
         - local-dir [optional, defaults to `pwd`]
         - fqdn [optional]
@@ -32,6 +33,7 @@ module DPL
         @gh_url = options[:github_url] || 'github.com'
         @gh_token = option(:github_token)
         @keep_history = !!keep_history
+        @allow_empty_commit = !!allow_empty_commit
         @verbose = !!verbose
 
         @gh_email = options[:email] || 'deploy@travis-ci.org'
@@ -40,6 +42,7 @@ module DPL
         @gh_ref = "#{@gh_url}/#{slug}.git"
         @gh_remote_url = "https://#{@gh_token}@#{@gh_ref}"
         @git_push_opts = @keep_history ? '' : ' --force'
+        @git_commit_opts = (@allow_empty_commit and @keep_history) ? ' --allow-empty' : ''
       end
 
       def fqdn
@@ -52,6 +55,10 @@ module DPL
 
       def keep_history
         options.fetch(:keep_history, false)
+      end
+
+      def allow_empty_commit
+        options.fetch(:allow_empty_commit, false)
       end
 
       def verbose
@@ -111,7 +118,7 @@ module DPL
         context.shell "touch \"deployed at `date` by #{@gh_name}\""
         context.shell "echo '#{@gh_fqdn}' > CNAME" if @gh_fqdn
         context.shell 'git add -A .'
-        context.shell "FILES=\"`git commit -m 'Deploy #{@project_name} to #{@gh_ref}:#{@target_branch}' | tail`\"; echo \"$FILES\"; echo \"$FILES\" | [ `wc -l` -lt 10 ] || echo '...'"
+        context.shell "FILES=\"`git commit#{@git_commit_opts} -m 'Deploy #{@project_name} to #{@gh_ref}:#{@target_branch}' | tail`\"; echo \"$FILES\"; echo \"$FILES\" | [ `wc -l` -lt 10 ] || echo '...'"
       end
 
       def github_deploy


### PR DESCRIPTION
Closes travis-ci/travis-ci#7562
Resolves #704 

This duplicates efforts of #715, but a bit differently. I wrote it a long time ago, but was unsure whether it's ready. Now I think it's better to present this code to public at least.

The design of this feature is also based on my analysis of [some npm packages](https://www.npmjs.com/search?q=gh-pages) providing similar behavior.

@jyasskin please check it out.


-------------
#### UPD:

##### Test run:
https://travis-ci.org/webknjaz/dpl-gh-pages/builds/323649670
(It's got checks for non-existing branch on remote, for enabled and for disabled force push, for `committer-from-gh` option, and check for invalid token — that's why it's errored in the end and it's okay)

##### Command-line options added (some as minor semi-related improvements):
* **keep-history**: Optional, create incremental commit instead of doing push force, defaults to false.
* **allow-empty-commit**: Optional, defaults to false. Enabled if only keep-history is true.
* **committer-from-gh**: Optional, defaults to false. Allows to use token's owner name and email for commit. Overrides `email` and `name` options.
* **verbose**: Optional, be verbose about internal steps, defaults to false.

##### Decisions made:
- **keep-history** must be switchable, because force pushes may help eliminate repo growth in case of lots of blobs (https://github.com/travis-ci/dpl/pull/719/files#r155931757).
- **allow-empty-commit** must be switchable, because of my personal wish to support different cases I saw in similar solutions/tutorials and I think we shouldn't be breaking possible preferences regarding this as build indicator.
- **committer-from-gh**: I added this, because it became possible after introducing auth_check improvement adding an API client. And I think it might be handy.
- I reused existing **verbose** flag to add switchable logging of what's happening during script run, because logs are the best cure from debugging.
- I've added auth_check to give end-users better clue on what's wrong with their token and as a side-effect I've logging the token user's name/handle.
- I'm maintaining repo copy in subfolder as advised @jyasskin, because some of `git clone` removing destination folder on fail and we don't want to lose ownership over tmpdir (which is controlled by the OS).
- This provider supports cases of pre-existing branch as well of non-existent. It creates an orphan branch if creating it, and it is not switchable. If anyone would need non-orphan it should be easy to extend this behavior.
- I've replaced a dirty hack of trimming of commit command output using just git.
- `git add -A .` will still have explicit `-A`, because different versions may have different defaults, which would lead to flakiness (https://github.com/travis-ci/dpl/pull/719/files#r155342614).

##### Side-effect finding:
- It's better not to use `&>` shell stream redirection syntax when spawning commands from within Ruby script: it's broken (#730).
  