### PR TITLE
[Scalingo] Make the app option mandatory

### DIFF
--- a/README.md
+++ b/README.md
@@ -718,12 +718,12 @@ For accounts using two factor authentication, you have to use an oauth token as 
  * **security_group_ids**: Optional. List of security group IDs to be added to the function. Needs the `ec2:DescribeSecurityGroups` and `ec2:DescribeVpcs` permission for the user of the access/secret key to work.
  * **dead_letter_arn**: Optional. ARN to an SNS or SQS resource used for the dead letter queue. [More about DLQs here](https://docs.aws.amazon
  .com/lambda/latest/dg/dlq.html).
- * **tracing_mode**: Optional. "Active" or "PassThrough" only. Default is "PassThrough".  Needs the `xray:PutTraceSegments` and `xray:PutTelemetryRecords` on the role for this to work. [More on 
+ * **tracing_mode**: Optional. "Active" or "PassThrough" only. Default is "PassThrough".  Needs the `xray:PutTraceSegments` and `xray:PutTelemetryRecords` on the role for this to work. [More on
  Active Tracing here](https://docs.aws.amazon.com/lambda/latest/dg/lambda-x-ray.html).
  * **environment_variables**: Optional. List of Environment Variables to add to the function, needs to be in the format of `KEY=VALUE`. Can be encrypted for added security.
  * **kms_key_arn**: Optional. KMS key ARN to use to encrypt `environment_variables`.
  * **function_tags**: Optional. List of tags to add to the function, needs to be in the format of `KEY=VALUE`. Can be encrypted for added security.
- 
+
  For a list of all [permissions for Lambda, please refer to the documentation](https://docs.aws.amazon.com/lambda/latest/dg/lambda-api-permissions-ref.html).
 
 #### Examples:
@@ -822,16 +822,15 @@ and your testers can start testing your app.
 ### Scalingo:
 
 #### Options:
-* **api_key**: scalingo API Key. Not necessary if username and password are used.
-* **username**: scalingo username. Not necessary if api_key is used.
-* **password**: scalingo password. Not necessary if api_key is used.
-* **remote**: Remote url or git remote name of your git repository. By default remote name is "scalingo".
+* **api_key**: Scalingo API Key. Not necessary if username and password are used.
+* **username**: Scalingo username. Not necessary if api_key is used.
+* **password**: Scalingo password. Not necessary if api_key is used.
 * **branch**: Branch of your git repository. By default branch name is "master".
-* **app**: Only necessary if your repository does not contain the appropriate remote. Specifying the app will add a remote to your local repository: `git remote add <remote> git@scalingo.com:<app>.git`
+* **app**: Only necessary if your git repository does not already contain the appropriate remote. Specifying the app will push with: `git push git@scalingo.com:<app>.git <branch>`.
 
 #### Use:
 
-You can connect to Scalingo using your username/password or your api key.
+You can connect to Scalingo using your username/password or your API key.
 It needs [Scalingo CLI](http://cli.scalingo.com/) which will be [downloaded here](http://cli.scalingo.com/).
 Then, it will push your project to Scalingo and deploy it automatically.
 
@@ -842,8 +841,8 @@ Note: You only need to connect once to Scalingo CLI, credentials are stored loca
     dpl --provider=scalingo --api_key="aaAAbbBB0011223344"
     dpl --provider=scalingo --username=<username> --password=<password>
 
-    dpl --provider=scalingo --api_key="aaAAbbBB0011223344" --remote="scalingo-staging"
-    dpl --provider=scalingo --api_key="aaAAbbBB0011223344" --remote="scalingo-staging" --branch="master"
+    dpl --provider=scalingo --api_key="aaAAbbBB0011223344" --app="my-app"
+    dpl --provider=scalingo --api_key="aaAAbbBB0011223344" --app="my-app-staging" --branch="staging"
 
     dpl --provider=scalingo
 

--- a/lib/dpl/provider/scalingo.rb
+++ b/lib/dpl/provider/scalingo.rb
@@ -27,37 +27,7 @@ module DPL
 
       def check_auth
         if @options[:api_key]
-          unless context.shell 'mkdir -p ~/.config/scalingo'
-            error "Couldn't create authentication file."
-          end
-          url = URI.parse('http://api.scalingo.com/v1/users/self')
-          http = Net::HTTP.new(url.host, url.port)
-          request = Net::HTTP::Get.new(url.request_uri)
-          request.basic_auth('', @options[:api_key])
-          request['Accept'] = 'application/json'
-          request['Content-type'] = 'application/json'
-          response = http.request(request)
-          data = {}
-          if File.exist?("#{Dir.home}/.config/scalingo/auth")
-            data = JSON.parse(File.read("#{Dir.home}/.config/scalingo/auth"))
-          end
-          begin
-            user = JSON.parse(response.body)
-          rescue
-            error 'Invalid API token.'
-          end
-          data['auth_config_data'] = {}
-          data['auth_config_data']['api.scalingo.com'] = {}
-          data['auth_config_data']['api.scalingo.com']['id'] = user['user']['id']
-          data['auth_config_data']['api.scalingo.com']['last_name'] = user['user']['last_name']
-          data['auth_config_data']['api.scalingo.com']['username'] = user['user']['username']
-          data['auth_config_data']['api.scalingo.com']['email'] = user['user']['email']
-          data['auth_config_data']['api.scalingo.com']['first_name'] = user['user']['first_name']
-          data['auth_config_data']['api.scalingo.com']['auth_token'] = @options[:api_key]
-          data['last_update'] = DateTime.now
-          File.open("#{Dir.home}/.config/scalingo/auth", 'w+') do |f|
-            f.write(data.to_json)
-          end
+          context.shell "timeout 2 ./scalingo login --api-key #{@options[:api_key]} 2> /dev/null > /dev/null"
         elsif @options[:username] && @options[:password]
           context.shell "echo -e \"#{@options[:username]}\n#{@options[:password]}\" | timeout 2 ./scalingo login 2> /dev/null > /dev/null"
         end

--- a/spec/provider/scalingo_spec.rb
+++ b/spec/provider/scalingo_spec.rb
@@ -4,7 +4,7 @@ require 'dpl/provider/scalingo'
 describe DPL::Provider::Scalingo do
 
   subject :provider do
-    described_class.new(DummyContext.new, :username => 'travis', :password => 'secret', :remote => 'scalingo', :branch => 'master')
+    described_class.new(DummyContext.new, :username => 'travis', :password => 'secret', :app => 'scalingo-app', :branch => 'master')
   end
 
   describe "#install_deploy_dependencies" do
@@ -55,10 +55,9 @@ describe DPL::Provider::Scalingo do
   describe "#push_app" do
     example do
       expect(provider.context).to receive(:shell).with(
-        'git push scalingo master -f'
+        'git push --force git@scalingo.com:scalingo-app.git master'
       ).and_return(true)
       provider.push_app
     end
   end
-
 end


### PR DESCRIPTION
For the Scalingo provider, we would like to make the `app` option mandatory to make it less error prone.

Working build:
https://travis-ci.org/EtienneM/sample-ruby-sinatra/builds/307954609