### PR TITLE
Integrate TravisBuddy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,4 +33,8 @@ deploy:
     ruby: 2.2.6
 
 notifications:
-  webhooks: "http://requestb.in/1guaq7t1"
+  webhooks:
+      urls:
+        - https://www.travisbuddy.com/
+        - http://requestb.in/1guaq7t1
+


### PR DESCRIPTION
TravisBuddy will comment on pull requests in your public repository everytime a test failed in one of them. The comment will include only the part of the build log that applies to your testing framework, so your contirbutors won't have to enter Travis's website and search the long and annoying build log for the reason the tests failed.

Here's an example: https://github.com/bluzi/static-server/pull/1