### PR TITLE
Pin down aws-sdk to latest released version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,16 +33,16 @@ group :rubygems do
 end
 
 group :sss do
-  gem 'aws-sdk', '~> 2.10.39', '< 2.10.97'
+  gem 'aws-sdk', '= 2.10.97'
   gem 'mime-types'
 end
 
 group :code_deploy do
-  gem 'aws-sdk', '~> 2.10.39', '< 2.10.97'
+  gem 'aws-sdk', '= 2.10.97'
 end
 
 group :lambda do
-  gem 'aws-sdk', '~> 2.10.39', '< 2.10.97'
+  gem 'aws-sdk', '= 2.10.97'
   gem 'rubyzip', '~> 1.1'
 end
 
@@ -63,7 +63,7 @@ group :gcs do
 end
 
 group :elastic_beanstalk do
-  gem 'aws-sdk', '~> 2.10.39', '< 2.10.97'
+  gem 'aws-sdk', '= 2.10.97'
   gem 'rubyzip', '~> 1.1'
 end
 
@@ -96,5 +96,5 @@ group :deis do
 end
 
 group :opsworks do
-  gem 'aws-sdk', '~> 2.10.39', '< 2.10.97'
+  gem 'aws-sdk', '= 2.10.97'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -33,16 +33,16 @@ group :rubygems do
 end
 
 group :sss do
-  gem 'aws-sdk', '~> 2.10.39', '< 3.0'
+  gem 'aws-sdk', '~> 2.10.39', '< 2.10.97'
   gem 'mime-types'
 end
 
 group :code_deploy do
-  gem 'aws-sdk', '~> 2.10.39', '< 3.0'
+  gem 'aws-sdk', '~> 2.10.39', '< 2.10.97'
 end
 
 group :lambda do
-  gem 'aws-sdk', '~> 2.10.39', '< 3.0'
+  gem 'aws-sdk', '~> 2.10.39', '< 2.10.97'
   gem 'rubyzip', '~> 1.1'
 end
 
@@ -63,7 +63,7 @@ group :gcs do
 end
 
 group :elastic_beanstalk do
-  gem 'aws-sdk', '~> 2.10.39', '< 3.0'
+  gem 'aws-sdk', '~> 2.10.39', '< 2.10.97'
   gem 'rubyzip', '~> 1.1'
 end
 
@@ -96,5 +96,5 @@ group :deis do
 end
 
 group :opsworks do
-  gem 'aws-sdk', '~> 2.10.39', '< 3.0'
+  gem 'aws-sdk', '~> 2.10.39', '< 2.10.97'
 end


### PR DESCRIPTION
This is needed such that we can protect our customers from having failing deployment when there's a delay between the release of the aws-sdk gem and the aws-sdk-resources gem. It happened a coupe of time now.