### PR TITLE
Fix CodeDeploy provider when key isn't authorized to run `head_object`

### DIFF
--- a/lib/dpl/provider/code_deploy.rb
+++ b/lib/dpl/provider/code_deploy.rb
@@ -48,7 +48,7 @@ module DPL
           bucket: option(:bucket),
           key: s3_key
         })
-      rescue Aws::S3::Errors
+      rescue Aws::Errors::ServiceError
         {}
       end
 

--- a/lib/dpl/provider/code_deploy.rb
+++ b/lib/dpl/provider/code_deploy.rb
@@ -75,15 +75,17 @@ module DPL
 
       def push_app
         rev = revision()
-        if rev[:s3_location]
-          rev_info = rev[:s3_location]
+        rev_info = rev[:s3_location]
+
+        if rev_info && rev_info[:version]
           log "Registering app revision with version=#{rev_info[:version]}, etag=#{rev_info[:e_tag]}"
+          code_deploy.register_application_revision({
+            revision:               rev,
+            application_name:       options[:application] || option(:application_name),
+            description:            options[:description] || default_description
+          })
         end
-        code_deploy.register_application_revision({
-          revision:               rev,
-          application_name:       options[:application] || option(:application_name),
-          description:            options[:description] || default_description
-        })
+
         data = code_deploy.create_deployment({
           revision:               revision,
           application_name:       options[:application]      || option(:application_name),

--- a/lib/dpl/provider/code_deploy.rb
+++ b/lib/dpl/provider/code_deploy.rb
@@ -53,14 +53,20 @@ module DPL
       end
 
       def s3_revision
-        {
+        info = {
           revision_type: 'S3',
           s3_location: {
             bucket:      option(:bucket),
             bundle_type: bundle_type,
             key:         s3_key,
-          }.merge( revision_version_info )
+          }
         }
+        unless revision_version_info.empty?
+          info[:s3_location][:version] = revision_version_info[:version_id]
+          info[:s3_location][:e_tag]   = revision_version_info[:etag]
+        end
+
+        info
       end
 
       def github_revision

--- a/lib/dpl/provider/code_deploy.rb
+++ b/lib/dpl/provider/code_deploy.rb
@@ -44,23 +44,22 @@ module DPL
       end
 
       def revision_version_info
-        s3obj = s3api.head_object({
+        s3api.head_object({
           bucket: option(:bucket),
           key: s3_key
         })
+      rescue Aws::S3::Errors
+        {}
       end
 
       def s3_revision
-        s3info = revision_version_info
         {
           revision_type: 'S3',
           s3_location: {
             bucket:      option(:bucket),
             bundle_type: bundle_type,
             key:         s3_key,
-            version:     s3info[:version_id],
-            e_tag:       s3info[:etag]
-          }
+          }.merge( revision_version_info )
         }
       end
 

--- a/spec/provider/code_deploy_spec.rb
+++ b/spec/provider/code_deploy_spec.rb
@@ -164,9 +164,9 @@ describe DPL::Provider::CodeDeploy do
     key = "/some/key.#{bundle_type}"
 
     before(:each) do
-      head_data = provider.s3api.stub_data(:head_object, {
+      head_data = provider.s3api.stub(:head_object).and_return({
         version_id: 'object_version_id',
-        etag: 'etag'
+        e_tag: 'etag'
       })
       provider.s3api.stub_responses(:head_object, head_data)
       expect(provider).to receive(:option).with(:bucket).and_return(bucket).twice
@@ -175,16 +175,13 @@ describe DPL::Provider::CodeDeploy do
     end
 
     example do
-      expect(provider.s3_revision).to eq({
-        revision_type: 'S3',
-        s3_location: {
+      expect(provider.s3_revision[:s3_location]).to include(
           bucket: bucket,
           bundle_type: bundle_type,
           key: key,
-          version: 'object_version_id',
+          version_id: 'object_version_id',
           e_tag: 'etag'
-        }
-      })
+        )
     end
   end
 

--- a/spec/provider/code_deploy_spec.rb
+++ b/spec/provider/code_deploy_spec.rb
@@ -166,12 +166,12 @@ describe DPL::Provider::CodeDeploy do
     before(:each) do
       head_data = provider.s3api.stub(:head_object).and_return({
         version_id: 'object_version_id',
-        e_tag: 'etag'
+        etag: 'etag'
       })
       provider.s3api.stub_responses(:head_object, head_data)
-      expect(provider).to receive(:option).with(:bucket).and_return(bucket).twice
+      expect(provider).to receive(:option).at_least(1).times.with(:bucket).and_return(bucket)
       expect(provider).to receive(:bundle_type).and_return(bundle_type)
-      expect(provider).to receive(:s3_key).and_return(key).twice
+      expect(provider).to receive(:s3_key).at_least(1).times.and_return(key)
     end
 
     example do
@@ -179,7 +179,7 @@ describe DPL::Provider::CodeDeploy do
           bucket: bucket,
           bundle_type: bundle_type,
           key: key,
-          version_id: 'object_version_id',
+          version: 'object_version_id',
           e_tag: 'etag'
         )
     end


### PR DESCRIPTION
It is possible to deploy CodeDeploy app without authorization to run `head_object`. When we encounter such an error, we should move on and fall back to the default behavior.

This resolves https://github.com/travis-ci/dpl/issues/741.