### PR TITLE
PyPI: Add skip_existing option

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ This _overrides_ the `gemspec` option.
   that supports this option. See https://github.com/travis-ci/dpl/issues/660
   for details.
 * **docs_dir**: Optional. A path to the directory to upload documentation from. Defaults to 'build/docs'
+* **skip_existing**: Optional. When set to `true`, the deployment will not fail if a file with the same name already exists on the server. It won't be uploaded and will not overwrite the existing file. Defaults to `false`.
 
 #### Environment variables:
 

--- a/lib/dpl/provider/pypi.rb
+++ b/lib/dpl/provider/pypi.rb
@@ -32,6 +32,12 @@ module DPL
           (options.has_key?(:skip_upload_docs) && options[:skip_upload_docs])
       end
 
+      def pypi_skip_existing_option
+          if options.fetch(:skip_existing, false)
+            ' --skip-existing'
+          end
+      end
+
       def install_deploy_dependencies
         unless context.shell "wget -O - https://bootstrap.pypa.io/get-pip.py | python - --no-setuptools --no-wheel && " \
                              "pip install --upgrade setuptools twine wheel"
@@ -89,7 +95,7 @@ module DPL
 
       def push_app
         context.shell "python setup.py #{pypi_distributions}"
-        unless context.shell "twine upload -r pypi dist/*"
+        unless context.shell "twine upload#{pypi_skip_existing_option} -r pypi dist/*"
           error 'PyPI upload failed.'
         end
         context.shell "rm -rf dist/*"

--- a/spec/provider/pypi_spec.rb
+++ b/spec/provider/pypi_spec.rb
@@ -56,6 +56,24 @@ describe DPL::Provider::PyPI do
       provider.push_app
     end
 
+    example "with :skip_existing option being false" do
+      provider.options.update(:skip_existing => false)
+      expect(provider.context).to receive(:shell).with("python setup.py sdist").and_return(true)
+      expect(provider.context).to receive(:shell).with("twine upload -r pypi dist/*").and_return(true)
+      expect(provider.context).to receive(:shell).with("rm -rf dist/*").and_return(true)
+      expect(provider.context).not_to receive(:shell).with("python setup.py upload_docs  -r https://upload.pypi.org/legacy/")
+      provider.push_app
+    end
+
+    example "with :skip_existing option being true" do
+      provider.options.update(:skip_existing => true)
+      expect(provider.context).to receive(:shell).with("python setup.py sdist").and_return(true)
+      expect(provider.context).to receive(:shell).with("twine upload --skip-existing -r pypi dist/*").and_return(true)
+      expect(provider.context).to receive(:shell).with("rm -rf dist/*").and_return(true)
+      expect(provider.context).not_to receive(:shell).with("python setup.py upload_docs  -r https://upload.pypi.org/legacy/")
+      provider.push_app
+    end
+
     example "with :skip_upload_docs option" do
       provider.options.update(:skip_upload_docs => true)
       expect(provider.context).to receive(:shell).with("python setup.py sdist").and_return(true)


### PR DESCRIPTION
This allows deployment not to fail if a file is already present on the PyPI server.

This fixes travis-ci/travis-ci#7851

You can find 3 builds using this commit:
Option not set, deployment fails because of existing files on the server (same behavior as before): https://travis-ci.org/mayeut/gcovr/builds/339567990
Option set to false, deployment fails because of existing files on the server: https://travis-ci.org/mayeut/gcovr/builds/339578927
Option set to true, deployment succeeds, skipping existing files on the server: https://travis-ci.org/mayeut/gcovr/builds/339580501