### PR TITLE
Allow providing AWS credentials via environment variables in the AWS Lambda provider

### DIFF
--- a/lib/dpl/provider/lambda.rb
+++ b/lib/dpl/provider/lambda.rb
@@ -12,10 +12,18 @@ module DPL
         @lambda ||= ::Aws::Lambda::Client.new(lambda_options)
       end
 
+      def access_key_id
+        options[:access_key_id] || context.env['AWS_ACCESS_KEY_ID'] || raise(Error, "missing access_key_id")
+      end
+
+      def secret_access_key
+        options[:secret_access_key] || context.env['AWS_SECRET_ACCESS_KEY'] || raise(Error, "missing secret_access_key")
+      end
+
       def lambda_options
         {
             region:      options[:region] || 'us-east-1',
-            credentials: ::Aws::Credentials.new(option(:access_key_id), option(:secret_access_key))
+            credentials: ::Aws::Credentials.new(access_key_id, secret_access_key)
         }
       end
 
@@ -158,7 +166,7 @@ module DPL
       end
 
       def check_auth
-        log "Using Access Key: #{option(:access_key_id)[-4..-1].rjust(20, '*')}"
+        log "Using Access Key: #{access_key_id[-4..-1].rjust(20, '*')}"
       end
 
       def output_file_path


### PR DESCRIPTION
Resolves #745, making the Lambda provider consistent with other dpl AWS offerings. This code is lifted from the [S3](https://github.com/travis-ci/dpl/blob/e6a53d8f4cb4ce76b1ce3a301af348b3f8ee8547/lib/dpl/provider/s3.rb#L21-L34) provider. I'll admit these are the first lines of Ruby I've ever written - do let me know if there are any improvements to be made!

As changes to Travis environment variables do not require making commits, this modification will allow me to rotate AWS credentials for all my repositories via the Travis API much more easily.

In accordance with the contributing guidelines, I tried using this branch for deployment of one of my own projects, and it [succeeded](https://travis-ci.org/gebn/commute-weather/builds/343432756).