### PR TITLE
pip install --ignore-installed

### DIFF
--- a/lib/dpl/provider/pypi.rb
+++ b/lib/dpl/provider/pypi.rb
@@ -34,7 +34,7 @@ module DPL
 
       def install_deploy_dependencies
         unless context.shell "wget -O - https://bootstrap.pypa.io/get-pip.py | python - --no-setuptools --no-wheel && " \
-                             "pip install --upgrade setuptools twine wheel"
+                             "pip install --upgrade --ignore-installed setuptools twine wheel"
           error "Couldn't install pip, setuptools, twine or wheel."
         end
       end

--- a/spec/provider/pypi_spec.rb
+++ b/spec/provider/pypi_spec.rb
@@ -9,7 +9,7 @@ describe DPL::Provider::PyPI do
   describe "#install_deploy_dependencies" do
     example do
       expect(provider.context).to receive(:shell).with(
-        "wget -O - https://bootstrap.pypa.io/get-pip.py | python - --no-setuptools --no-wheel && pip install --upgrade setuptools twine wheel"
+        "wget -O - https://bootstrap.pypa.io/get-pip.py | python - --no-setuptools --no-wheel && pip install --upgrade --ignore-installed setuptools twine wheel"
       ).and_return(true)
       provider.install_deploy_dependencies
     end


### PR DESCRIPTION
It seems, based on https://github.com/pypa/pip/issues/2751, that there's a problem with pip and how it can fail when .pth files are incorrect.

This addition allows PyPi deployments to move on when it encounters a .pth file it doesn't understand. It's hopefully a temporary fix, but the issue with pip has been known and unfixed for a while now.