### PR TITLE
Opsworks: Update application source setting after successful deploy

### DIFF
--- a/lib/dpl/provider/ops_works.rb
+++ b/lib/dpl/provider/ops_works.rb
@@ -101,9 +101,22 @@ module DPL
         print "\n"
         if deployment[:status] == 'successful'
           log "Deployment successful."
+          return unless options[:update_app_on_success]
+          update_app
         else
           error "Deployment failed."
         end
+      end
+
+      def update_app
+        update_config = {
+          app_id: option(:app_id),
+          app_source: {
+            revision: current_sha,
+          }
+        }
+        opsworks.update_app(update_config)
+        log "Application Source branch/revision setting updated."
       end
 
       def wait_until_deployed(deployment_id)


### PR DESCRIPTION
Adding new option to also have the application source updated.

Problem: travis only creates deployment but this won't update the settings where one would see the current deployed version. Setting the flag `update-app-on-success` to `true` updates the settings after the deployment was successful.

```yml
deploy:
  provider: opsworks
    access_key_id: abcdefg
    secret_access_key: ultrA-5ecr3t
    app-id: 11223344-5566-7788-9900-aabbccddeeff
    on:
      branch: master
    wait-until-deployed: true
    update-app-on-success: true
```

An opsworks-user with the permission to deploy and to update-app is required.

See successful run here: https://travis-ci.com/easybib/bib-cd/builds/68564088