### PR TITLE
Handle "true"/"false" in GitHub Releases flag

### DIFF
--- a/lib/dpl/provider/releases.rb
+++ b/lib/dpl/provider/releases.rb
@@ -82,6 +82,8 @@ module DPL
         tag_matched = false
         release_url = nil
 
+        booleanize!(options)
+
         if options[:release_number]
           tag_matched = true
           release_url = "https://api.github.com/repos/" + slug + "/releases/" + options[:release_number]
@@ -129,6 +131,19 @@ module DPL
           content_type = "application/octet-stream"
         end
         api.upload_asset(release_url, file, {:name => filename, :content_type => content_type})
+      end
+
+      def booleanize!(opts)
+        opts.transform_values! do |val|
+          case val.to_s.downcase
+          when 'true'
+            true
+          when 'false'
+            false
+          else
+            val
+          end
+        end
       end
     end
   end

--- a/lib/dpl/provider/releases.rb
+++ b/lib/dpl/provider/releases.rb
@@ -134,14 +134,15 @@ module DPL
       end
 
       def booleanize!(opts)
-        opts.transform_values! do |val|
-          case val.to_s.downcase
+        opts.map do |k,v|
+          opts[k] =
+          case v.to_s.downcase
           when 'true'
             true
           when 'false'
             false
           else
-            val
+            v
           end
         end
       end

--- a/spec/provider/releases_spec.rb
+++ b/spec/provider/releases_spec.rb
@@ -307,5 +307,25 @@ describe DPL::Provider::Releases do
 
       provider.push_app
     end
+
+    example "When prerelease is 'true'" do
+      allow_message_expectations_on_nil
+
+      provider.options.update(:file => ["bar.txt"])
+      provider.options.update(:release_number => "1234")
+      provider.options.update(:prerelease => 'true')
+      allow(provider).to receive(:slug).and_return("foo/bar")
+      expect(File).to receive(:file?).with("bar.txt").and_return(true)
+
+      allow(provider.api).to receive(:release)
+      allow(provider.api.release).to receive(:rels).and_return({:assets => nil})
+      allow(provider.api.release.rels[:assets]).to receive(:get).and_return({:data => nil})
+      allow(provider.api.release.rels[:assets].get).to receive(:data).and_return([])
+
+      expect(provider.api).to receive(:upload_asset).with("https://api.github.com/repos/foo/bar/releases/1234", "bar.txt", {:name=>"bar.txt", :content_type=>"text/plain"})
+      expect(provider.api).to receive(:update_release).with(anything, hash_including(:prerelease => true))
+
+      provider.push_app
+    end
   end
 end


### PR DESCRIPTION
These are passed on to Octokit, so the values should be booleans,
not strings.

Resolves #613.