### PR TITLE
Define Aws constants up front

### DIFF
--- a/lib/dpl/provider/s3.rb
+++ b/lib/dpl/provider/s3.rb
@@ -2,6 +2,8 @@ require 'json'
 require 'aws-sdk'
 require 'mime-types'
 
+Aws.eager_autoload!
+
 module DPL
   class Provider
     class S3 < Provider


### PR DESCRIPTION
Aws and multithreading may not play well at all times.

See https://aws.amazon.com/blogs/developer/threading-with-the-aws-sdk-for-ruby/
for more details.

Resolves #788.