### PR TITLE
Configurable timeouts for packgecloud provider

### DIFF
--- a/lib/dpl/provider/packagecloud.rb
+++ b/lib/dpl/provider/packagecloud.rb
@@ -6,9 +6,9 @@ module DPL
       def check_auth
         setup_auth
         timeout_options = {
-          connect_timeout: option(:connect_timeout) || 60,
-          read_timeout: option(:read_timeout) || 60,
-          write_timeout: option(:write_timeout) || 180
+          connect_timeout: options(:connect_timeout) || 60,
+          read_timeout: options(:read_timeout) || 60,
+          write_timeout: options(:write_timeout) || 180
         }
         connection = ::Packagecloud::Connection.new("https", "packagecloud.io", "443", timeout_options)
         begin

--- a/lib/dpl/provider/packagecloud.rb
+++ b/lib/dpl/provider/packagecloud.rb
@@ -6,9 +6,9 @@ module DPL
       def check_auth
         setup_auth
         timeout_options = {
-          connect_timeout: options[:connect_timeout] || 60,
-          read_timeout: options[:read_timeout] || 60,
-          write_timeout: options[:write_timeout] || 180
+          connect_timeout: (options[:connect_timeout] || 60).to_i,
+          read_timeout:    (options[:read_timeout] || 60).to_i,
+          write_timeout:   (options[:write_timeout] || 180.to_i)
         }
         connection = ::Packagecloud::Connection.new("https", "packagecloud.io", "443", timeout_options)
         begin

--- a/lib/dpl/provider/packagecloud.rb
+++ b/lib/dpl/provider/packagecloud.rb
@@ -6,9 +6,9 @@ module DPL
       def check_auth
         setup_auth
         timeout_options = {
-          connect_timeout: options(:connect_timeout) || 60,
-          read_timeout: options(:read_timeout) || 60,
-          write_timeout: options(:write_timeout) || 180
+          connect_timeout: options[:connect_timeout] || 60,
+          read_timeout: options[:read_timeout] || 60,
+          write_timeout: options[:write_timeout] || 180
         }
         connection = ::Packagecloud::Connection.new("https", "packagecloud.io", "443", timeout_options)
         begin

--- a/lib/dpl/provider/packagecloud.rb
+++ b/lib/dpl/provider/packagecloud.rb
@@ -5,8 +5,15 @@ module DPL
     class Packagecloud < Provider
       def check_auth
         setup_auth
+        timeout_options = {
+          connect_timeout: option(:connect_timeout) || 60,
+          read_timeout: option(:read_timeout) || 60,
+          write_timeout: option(:write_timeout) || 180
+        }
+        connection = ::Packagecloud::Connection.new("https", "packagecloud.io", "443", timeout_options)
         begin
-          @client = ::Packagecloud::Client.new(@creds, "travis-ci")
+          log "Timeout configuration: #{timeout_options.inspect}"
+          @client = ::Packagecloud::Client.new(@creds, "travis-ci dpl #{DPL::VERSION}", connection)
         rescue ::Packagecloud::UnauthenticatedException
           error "Could not authenticate to https://packagecloud.io, please check credentials"
         end


### PR DESCRIPTION
We received reports from some of our users that their uploads would occasionally take too long and time out. 

This patch allows the user to configure the read, connect, and write timeouts used in `packagecloud` provider. 

Also, it now passes the `DPL::VERSION` along in the user agent.

Link to working build here: https://travis-ci.org/computology/node-test-package

Let me know if there is anything else I need to do to get this merged. Thanks in advance!

