### PR TITLE
[Elastic Beanstalk] Set zip file comment to the current SHA

### DIFF
--- a/lib/dpl/provider/elastic_beanstalk.rb
+++ b/lib/dpl/provider/elastic_beanstalk.rb
@@ -114,6 +114,7 @@ module DPL
         zipfile_name = File.join(directory, archive_name)
 
         Zip::File.open(zipfile_name, Zip::File::CREATE) do |zipfile|
+          zipfile.comment = sha
           files_to_pack.each do |file|
             relative_archive_path = File.join(directory, '/')
             zipfile.add(file.sub(relative_archive_path, ''), file)

--- a/spec/provider/elastic_beanstalk_spec.rb
+++ b/spec/provider/elastic_beanstalk_spec.rb
@@ -206,4 +206,24 @@ describe DPL::Provider::ElasticBeanstalk do
 
     end
   end
+
+  describe '#create_zip' do
+    let(:dummy_sha) { SecureRandom.hex(40) }
+    let(:mock_zip_file) { double(Zip::File) }
+
+    before do
+      allow(Zip::File).to receive(:new).and_return(mock_zip_file)
+      allow(mock_zip_file).to receive(:add)
+      allow(mock_zip_file).to receive(:comment=)
+      allow(mock_zip_file).to receive(:close)
+    end
+
+    it "sets the zip file's comment to the current SHA" do
+      allow(provider).to receive(:sha).and_return(dummy_sha)
+
+      provider.send(:create_zip)
+
+      expect(mock_zip_file).to have_received(:comment=).with(dummy_sha)
+    end
+  end
 end


### PR DESCRIPTION
To find out which revision was (or currently is) deployed on an
AWS Elastic Beanstalk instance, many people like to use

BUILD_VERSION=$(unzip -z /opt/elasticbeanstalk/deploy/appsource/source_bundle | tail -n 1)

Even though this is not officially documented behavior of awsebcli,
this "trick" can be found in many places on the internet, e.g.

https://forums.aws.amazon.com/thread.jspa?threadID=173263
https://stackoverflow.com/a/21166754

This commit makes dpl mimic this behavior of awsebcli
by setting the zip file comment to the current commit SHA.