### PR TITLE
crates.io provider for publishing Rust packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Dpl supports the following providers:
 * [BitBalloon](#bitballoon)
 * [Bluemix Cloud Foundry](#bluemix-cloud-foundry)
 * [Boxfuse](#boxfuse)
+* [cargo](#cargo)
 * [Catalyze](#catalyze)
 * [Chef Supermarket](#chef-supermarket)
 * [Cloud 66](#cloud-66)
@@ -490,6 +491,16 @@ You first need to create an [Atlas account](https://atlas.hashicorp.com/account/
 #### Examples:
 
     dpl --provider=cloudfoundry --username=<username> --password=<password> --organization=<organization> --api=<api> --space=<space> --skip-ssl-validation
+
+### cargo:
+
+#### Options:
+
+* **token**: Your cargo registry API token, for crates.io generate at <https://crates.io/me>
+
+#### Examples:
+
+    dpl --provider=cargo --token=<token>
 
 ### Rackspace Cloud Files:
 

--- a/dpl-cargo.gemspec
+++ b/dpl-cargo.gemspec
@@ -1,0 +1,3 @@
+require './gemspec_helper'
+
+gemspec_for 'cargo'

--- a/lib/dpl/provider.rb
+++ b/lib/dpl/provider.rb
@@ -25,6 +25,7 @@ module DPL
       'CloudFiles'          => 'cloud_files',
       'CloudFoundry'        => 'cloud_foundry',
       'CodeDeploy'          => 'code_deploy',
+      'Cargo'               => 'cargo',
       'Deis'                => 'deis',
       'Divshot'             => 'divshot',
       'ElasticBeanstalk'    => 'elastic_beanstalk',

--- a/lib/dpl/provider/cargo.rb
+++ b/lib/dpl/provider/cargo.rb
@@ -1,0 +1,22 @@
+require 'json'
+require 'uri'
+
+module DPL
+  class Provider
+    class Cargo < Provider
+      def needs_key?
+        false
+      end
+
+      def check_auth
+        option(:token)
+      end
+
+      def push_app
+        if ! context.shell "cargo publish --token #{option(:token)}"
+          raise Error, "Publish failed"
+        end
+      end
+    end
+  end
+end

--- a/spec/provider/cargo_spec.rb
+++ b/spec/provider/cargo_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+require 'dpl/provider/cargo'
+
+describe DPL::Provider::Cargo do
+  context 'when token is not provided' do
+    subject :provider do
+      described_class.new(DummyContext.new, {})
+    end
+
+    describe "#check_auth" do
+      example do
+        expect { provider.check_auth }.to raise_error(DPL::Error, 'missing token')
+      end
+    end
+  end
+
+  context 'when token is provided' do
+    subject :provider do
+      described_class.new(DummyContext.new, token: "TEST_TOKEN")
+    end
+
+    describe "#check_auth" do
+      example do
+        expect { provider.check_auth }.not_to raise_error
+      end
+    end
+
+    context 'when publish fails' do
+      describe "#push_app" do
+        example do
+          expect(provider.context).to receive(:shell).with("cargo publish --token TEST_TOKEN") { false }
+          expect { provider.push_app }.to raise_error('Publish failed')
+        end
+      end
+    end
+
+    context 'when publish succeeds' do
+      describe "#push_app" do
+        example do
+          expect(provider.context).to receive(:shell).with("cargo publish --token TEST_TOKEN") { true }
+          provider.push_app
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Example job: https://travis-ci.com/Nemo157/nemo157-rs/jobs/130213124

This is a trivial first integration. It would be possible to add more options like which registry to push to, but those can be left to a future PR.