### PR TITLE
Add support for aws lambda event source

### DIFF
--- a/README.md
+++ b/README.md
@@ -720,6 +720,9 @@ For accounts using two factor authentication, you have to use an oauth token as 
  * **environment_variables**: Optional. List of Environment Variables to add to the function, needs to be in the format of `KEY=VALUE`. Can be encrypted for added security.
  * **kms_key_arn**: Optional. KMS key ARN to use to encrypt `environment_variables`.
  * **function_tags**: Optional. List of tags to add to the function, needs to be in the format of `KEY=VALUE`. Can be encrypted for added security.
+ * **event_source_arn**: Optional. The ARN of the resource which is to be used as the event source. Current support is only for `LATEST`  as the event source starting position. [More about Event Sources here](https://docs.aws.amazon.com/lambda/latest/dg/invoking-lambda-function.html).
+ * **event_source_enabled**: Optional. If `false` the event source will not trigger the lambda. Default is `true`.
+ * **event_source_batch_size**: Optional. The number of batches to retrieve off the event source. Defaults to 1.
 
  For a list of all [permissions for Lambda, please refer to the documentation](https://docs.aws.amazon.com/lambda/latest/dg/lambda-api-permissions-ref.html).
 
@@ -744,6 +747,16 @@ Deploy contents of a specific directory using specific module name:
         --zip="${TRAVIS_BUILD_DIR}/dist"  \
         --module_name="copy" \
         --handler_name="handler";
+```
+Deploy lambda with a event source using default settings:
+```
+    dpl --provider="lambda" \
+        --access_key_id="${AWS_ACCESS_KEY}" \
+        --secret_access_key="${AWS_SECRET_KEY}" \
+        --function_name="test-lambda" \
+        --role="${AWS_LAMBDA_ROLE}" \
+        --handler_name="handler" \
+        --event_source_arn="arn:aws:dynamodb:us-west-2:000000000000:table/test-table";
 ```
 
 ### Launchpad:

--- a/README.md
+++ b/README.md
@@ -712,17 +712,19 @@ For accounts using two factor authentication, you have to use an oauth token as 
  * **memory_size**: Optional. The amount of memory in MB to allocate to this Lambda. Defaults to 128.
  * **runtime**: Optional. The Lambda runtime to use. Defaults to `node`.
  * **publish**: If `true`, a [new version](http://docs.aws.amazon.com/lambda/latest/dg/versioning-intro.html#versioning-intro-publish-version) of the Lambda function will be created instead of replacing the code of the existing one.
- * **subnet_ids**: Optional. List of subnet IDs to be added to the function. Needs the `ec2:DescribeSubnets` and `ec2:DescribeVpcs` permission for the user of the access/secret key to work.
- * **security_group_ids**: Optional. List of security group IDs to be added to the function. Needs the `ec2:DescribeSecurityGroups` and `ec2:DescribeVpcs` permission for the user of the access/secret key to work.
+ * **subnet_ids**: Optional. List of subnet IDs to be added to the function. Needs the `ec2:DescribeSubnets` and `ec2:DescribeVpcs` permission for the user of the access/secret key to work. If set, then security_group_ids must be provided.
+ * **security_group_ids**: Optional. List of security group IDs to be added to the function. Needs the `ec2:DescribeSecurityGroups` and `ec2:DescribeVpcs` permission for the user of the access/secret key to work. If set, then subnet_ids must be provided.
  * **dead_letter_arn**: Optional. ARN to an SNS or SQS resource used for the dead letter queue. [More about DLQs here](https://docs.aws.amazon.com/lambda/latest/dg/dlq.html).
  * **tracing_mode**: Optional. "Active" or "PassThrough" only. Default is "PassThrough".  Needs the `xray:PutTraceSegments` and `xray:PutTelemetryRecords` on the role for this to work. [More on
  Active Tracing here](https://docs.aws.amazon.com/lambda/latest/dg/lambda-x-ray.html).
  * **environment_variables**: Optional. List of Environment Variables to add to the function, needs to be in the format of `KEY=VALUE`. Can be encrypted for added security.
  * **kms_key_arn**: Optional. KMS key ARN to use to encrypt `environment_variables`.
  * **function_tags**: Optional. List of tags to add to the function, needs to be in the format of `KEY=VALUE`. Can be encrypted for added security.
- * **event_source_arn**: Optional. The ARN of the resource which is to be used as the event source. Current support is only for `LATEST`  as the event source starting position. [More about Event Sources here](https://docs.aws.amazon.com/lambda/latest/dg/invoking-lambda-function.html).
+ * **event_source_arn**: Optional. The ARN of the resource which is to be used as the event source. [More about Event Sources here](https://docs.aws.amazon.com/lambda/latest/dg/invoking-lambda-function.html).
  * **event_source_enabled**: Optional. If `false` the event source will not trigger the lambda. Default is `true`.
- * **event_source_batch_size**: Optional. The number of batches to retrieve off the event source. Defaults to 1.
+ * **batch_size**: Optional. The number of batches to retrieve off the event source. Defaults to 1.
+ * **starting_position**: Optional. The position in the DynamoDB or Kinesis stream where AWS Lambda should start reading. Allowed values are `LATEST`, `TRIM_HORIZON` and `AT_TIMESTAMP`
+ * **starting_position_timestamp**: Optional. The timestamp in ISO8601 of the data record from which to start reading. Used with starting_position `AT_TIMESTAMP`.
 
  For a list of all [permissions for Lambda, please refer to the documentation](https://docs.aws.amazon.com/lambda/latest/dg/lambda-api-permissions-ref.html).
 

--- a/lib/dpl/provider/lambda.rb
+++ b/lib/dpl/provider/lambda.rb
@@ -176,7 +176,7 @@ module DPL
           response = lambda.update_event_source_mapping({
             uuid:           event_source_list.uuid,
             function_name:  function_name,
-            batch_size:     options[:event_source_batch_size]   || default_batch_size,
+            batch_size:     batch_size,
             enabled:        event_source_enabled
           })
           log "Updated configuration of event source id #{event_source_list.uuid}."
@@ -185,8 +185,9 @@ module DPL
             event_source_arn:             options[:event_source_arn],
             function_name:                function_name,
             enabled:                      event_source_enabled,
-            batch_size:                   options[:event_source_batch_size]         || default_batch_size,
-            starting_position:            default_event_source_starting_position
+            batch_size:                   batch_size,
+            starting_position:            starting_position,
+            starting_position_timestamp:  starting_position_timestamp,
           })
           log "Created event source #{response.uuid} for function #{function_name}."
         end
@@ -211,7 +212,7 @@ module DPL
       def environment_variables
         options[:environment_variables] ? { :variables => split_string_array_to_hash(options[:environment_variables]) } : nil
       end
-
+      
       def dead_letter_arn
         options[:dead_letter_arn] ? { :target_arn => options[:dead_letter_arn]} : nil
       end
@@ -227,7 +228,19 @@ module DPL
       def function_tags
         options[:function_tags] ? split_string_array_to_hash(options[:function_tags]) : nil
       end
-
+      
+      def batch_size
+        options[:batch_size] ? options[:batch_size] : 1
+      end
+      
+      def starting_position
+        options[:starting_position] ? options[:starting_position] : nil
+      end
+      
+      def starting_position_timestamp
+        options[:starting_position_timestamp] ? Time.parse(options[:starting_position_timestamp]) : nil
+      end
+      
       def default_runtime
         'nodejs'
       end
@@ -246,14 +259,6 @@ module DPL
 
       def default_module_name
         'index'
-      end
-
-      def default_batch_size
-        1
-      end
-      
-      def default_event_source_starting_position
-        'LATEST'
       end
 
       def publish

--- a/spec/provider/lambda_spec.rb
+++ b/spec/provider/lambda_spec.rb
@@ -431,18 +431,6 @@ describe DPL::Provider::Lambda do
     end
   end
   
-  describe '#default_batch_size' do
-    example do
-      expect(provider.default_batch_size).to eq(1)
-    end
-  end
-
-  describe '#default_event_source_starting_position' do
-    example do
-      expect(provider.default_event_source_starting_position).to eq('LATEST')
-    end
-  end
-  
   describe '#event_source_enabled' do
     context 'is default turned on' do
       example do


### PR DESCRIPTION
Resolves #543 - Added the ability to create and update lambda function event sources.

The following builds show the functionality working:
- `Create Event Source` https://travis-ci.com/bhavikkumar/lambda-travis-ci/builds/77953875
- `Update Event Source` https://travis-ci.com/bhavikkumar/lambda-travis-ci/builds/77954754