### PR TITLE
[WIP] Add auth_method option for NPM deployment

### DIFF
--- a/lib/dpl/provider/npm.rb
+++ b/lib/dpl/provider/npm.rb
@@ -49,7 +49,8 @@ module DPL
 
       def npmrc_file_content
         log "NPM version: #{npm_version}"
-        if npm_version =~ /^1/
+        
+        if npm_version =~ /^1/ || option(:auth_method) == "auth"
           "_auth = ${NPM_API_KEY}\nemail = #{option(:email)}"
         else
           "//#{package_registry}/:_authToken=${NPM_API_KEY}"

--- a/lib/dpl/provider/npm.rb
+++ b/lib/dpl/provider/npm.rb
@@ -49,8 +49,8 @@ module DPL
 
       def npmrc_file_content
         log "NPM version: #{npm_version}"
-        
-        if npm_version =~ /^1/ || option(:auth_method) == "auth"
+
+        if npm_version =~ /^1/ || options[:auth_method] == "auth"
           "_auth = ${NPM_API_KEY}\nemail = #{option(:email)}"
         else
           "//#{package_registry}/:_authToken=${NPM_API_KEY}"


### PR DESCRIPTION
I learnt from a Support request that some private registries need a specific authentication method, and our approach to check npm's version to use `_auth` or `_authToken`  does not apply in these cases.

For example, to authenticate with Nexus, you need to use the __auth_ method in your .npmrc file no matter what npm version you have.

This PR aims to make possible to specify an authentication method (`auth` or `authtoken` - maybe there's a better naming for these?) so that folks that need to deploy to Nexus, or somewhere else that works similarly, can do it.

Tests and docs will be coming soon -