### PR TITLE
Allow a user to set a EB version label in the travis YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,7 +365,7 @@ It is possible to set file-specific `Cache-Control` and `Expires` headers using 
  * **region**: AWS Region the Elastic Beanstalk app is running in. Defaults to 'us-east-1'. Please be aware that this must match the region of the elastic beanstalk app.
  * **app**: Elastic Beanstalk application name.
  * **env**: Elastic Beanstalk environment name which will be updated.
- * **label**: Label name of the new version. _**Note:**_ This need to be a dynamic
+ * **label**: Label name of the new version. Another option than using `ELASTIC_BEANSTALK_LABEL`
  * **zip_file**: The zip file that you want to deploy. _**Note:**_ you also need to use the `skip_cleanup` or the zip file you are trying to upload will be removed during cleanup.
  * **bucket_name**: Bucket name to upload app to.
  * **bucket_path**: Location within Bucket to upload app to.

--- a/README.md
+++ b/README.md
@@ -365,6 +365,7 @@ It is possible to set file-specific `Cache-Control` and `Expires` headers using 
  * **region**: AWS Region the Elastic Beanstalk app is running in. Defaults to 'us-east-1'. Please be aware that this must match the region of the elastic beanstalk app.
  * **app**: Elastic Beanstalk application name.
  * **env**: Elastic Beanstalk environment name which will be updated.
+ * **label**: Label name of the new version. _**Note:**_ This need to be a dynamic
  * **zip_file**: The zip file that you want to deploy. _**Note:**_ you also need to use the `skip_cleanup` or the zip file you are trying to upload will be removed during cleanup.
  * **bucket_name**: Bucket name to upload app to.
  * **bucket_path**: Location within Bucket to upload app to.

--- a/lib/dpl/provider/elastic_beanstalk.rb
+++ b/lib/dpl/provider/elastic_beanstalk.rb
@@ -66,7 +66,7 @@ module DPL
       end
 
       def version_label
-        context.env['ELASTIC_BEANSTALK_LABEL'] || "travis-#{sha}-#{Time.now.to_i}"
+        options[:label] || context.env['ELASTIC_BEANSTALK_LABEL'] || "travis-#{sha}-#{Time.now.to_i}"
       end
 
       def version_description


### PR DESCRIPTION
Allow a user to set the EB version label using a YAML property vs ENV variable.

Relates to #862 