### PR TITLE
Allowed .jar files to be copied to lambda function

### DIFF
--- a/README.md
+++ b/README.md
@@ -706,7 +706,7 @@ For accounts using two factor authentication, you have to use an oauth token as 
  * **handler_name**: Required. The function that Lambda calls to begin execution. For NodeJS, it is exported function for the module.
  * **dot_match**: Optional. When `true`, the zipped archive will include the hidden `.*` files. Defaults to `false`.
  * **module_name**: Optional. The name of the module that exports the handler. Defaults to `index`.
- * **zip**: Optional. Either a path to an existing packaged (zipped) Lambda, a directory to package, or a single file to package. Defaults to `Dir.pwd`.
+ * **zip**: Optional. Either a path to an existing packaged (zipped or jar file) Lambda, a directory to package, or a single file to package. Defaults to `Dir.pwd`.
  * **description**: Optional. The description of the Lambda being created / updated. Defaults to "Deploy build #{context.env['TRAVIS_BUILD_NUMBER']} to AWS Lambda via Travis CI"
  * **timeout**: Optional. The function execution time at which Lambda should terminate the function. Defaults to 3 (seconds).
  * **memory_size**: Optional. The amount of memory in MB to allocate to this Lambda. Defaults to 128.

--- a/lib/dpl/provider/lambda.rb
+++ b/lib/dpl/provider/lambda.rb
@@ -132,8 +132,9 @@ module DPL
       end
 
       def zip_file(dest_file_path, target_file_path)
-        if File.extname(target_file_path) == '.zip'
-          # Just copy it to the destination right away, since it is already a zip.
+        # Test .zip or .jar file extensions.
+        if %w[.zip .jar].include?(File.extname(target_file_path))
+          # Just copy it to the destination right away, since it is already a zip or jar.
           FileUtils.cp(target_file_path, dest_file_path)
           dest_file_path
         else

--- a/spec/provider/lambda_spec.rb
+++ b/spec/provider/lambda_spec.rb
@@ -305,6 +305,20 @@ describe DPL::Provider::Lambda do
         provider.zip_file(dest, target)
       end
     end
+
+    context 'when zip is an existing jar file' do
+      dir = '/some/target'
+      target = File.join(dir, 'file.js')
+
+      before do
+        expect(File).to receive(:extname).with(target).and_return('.jar')
+        expect(FileUtils).to receive(:cp).with(target, dest)
+      end
+
+      example do
+        provider.zip_file(dest, target)
+      end
+    end
   end
 
   describe '#zip_directory' do


### PR DESCRIPTION
Extended the file ext test in `zip_file()` to include .Jar file extensions with .zip file extensions to be copied to Lambda.
Added tests for the new condition

Fixes #838