### PR TITLE
Fix GAE deployable files to accept more than one

### DIFF
--- a/README.md
+++ b/README.md
@@ -866,11 +866,11 @@ In order to use this provider, please make sure you have the [App Engine Admin A
 
 * **project**: [Project ID](https://developers.google.com/console/help/new/#projectnumber) used to identify the project on Google Cloud.
 * **keyfile**: Path to the JSON file containing your [Service Account](https://developers.google.com/console/help/new/#serviceaccounts) credentials in [JSON Web Token](https://tools.ietf.org/html/rfc7519) format. To be obtained via the [Google Developers Console](https://console.developers.google.com/project/_/apiui/credential). Defaults to `"service-account.json"`. Note that this file should be handled with care as it contains authorization keys.
-* **config**: Path to your module configuration file. Defaults to `"app.yaml"`. This file is runtime dependent ([Go](https://cloud.google.com/appengine/docs/go/config/appconfig), [Java](https://cloud.google.com/appengine/docs/java/configyaml/appconfig_yaml), [PHP](https://developers.google.com/console/help/new/#projectnumber), [Python](https://cloud.google.com/appengine/docs/python/config/appconfig))
-* **version**: The version of the app that will be created or replaced by this deployment. If you do not specify a version, one will be generated for you. See [`gcloud preview app deploy`](https://cloud.google.com/sdk/gcloud/reference/preview/app/deploy)
-* **no_promote**: Flag to not promote the deployed version. See [`gcloud preview app deploy`](https://cloud.google.com/sdk/gcloud/reference/preview/app/deploy)
+* **config**: Path to your deployable service files. Defaults to `"app.yaml"`. See [`gcloud app deploy`](https://cloud.google.com/sdk/gcloud/reference/app/deploy) for a list of different deployable file types.
+* **version**: The version of the app that will be created or replaced by this deployment. If you do not specify a version, one will be generated for you. See [`gcloud app deploy`](https://cloud.google.com/sdk/gcloud/reference/app/deploy)
+* **no_promote**: Flag to not promote the deployed version. See [`gcloud app deploy`](https://cloud.google.com/sdk/gcloud/reference/app/deploy)
 * **verbosity**: Let's you adjust the verbosity when invoking `"gcloud"`. Defaults to `"warning"`. See [`gcloud`](https://cloud.google.com/sdk/gcloud/reference/).
-* **no_stop_previous_version**: Flag to prevent your deployment from stopping the previously promoted version. This is from the future, so might not work (yet). See [`gcloud preview app deploy`](https://cloud.google.com/sdk/gcloud/reference/preview/app/deploy)
+* **no_stop_previous_version**: Flag to prevent your deployment from stopping the previously promoted version. This is from the future, so might not work (yet). See [`gcloud app deploy`](https://cloud.google.com/sdk/gcloud/reference/app/deploy)
 
 #### Environment variables:
 

--- a/lib/dpl/provider/gae.rb
+++ b/lib/dpl/provider/gae.rb
@@ -82,7 +82,9 @@ module DPL
         command << ' --quiet'
         command << " --verbosity \"#{verbosity}\""
         command << " --project \"#{project}\""
-        command << " app deploy \"#{config}\""
+        command << " app deploy"
+        command << " \"#{config}\"" if config.kind_of?(String)
+        config.each { |c| command << " \"#{c}\"" } if config.kind_of?(Array)
         command << " --version \"#{version}\"" unless version.to_s.empty?
         command << " --#{no_promote ? 'no-' : ''}promote"
         command << ' --no-stop-previous-version' unless no_stop_previous_version.to_s.empty?


### PR DESCRIPTION
Per Google Cloud's `gcloud` documentation[0], the `app deploy` subcommand accepts multiple types of deployable files at once. Previously, the string value was only added to the command string. This made deploying with multiple files fail as Ruby fetched the string value of the Array type instead.

Now, the value is only appended to the command string directly if the value type is a string. If the value type is an Array, each value is appended onto the string separately.

`travis.yml` examples:
```
deploy:
 provider: gae
 project: example-1
 keyfile: example-key.json
 config:
  - server/app.yaml
  - server/dos.yaml
  - server/cron.yaml

(or)

deploy:
 provider: gae
 project: example-1
 keyfile: example-key.json
 config: server/app.yaml

```

This fixes #829.

--
0: https://cloud.google.com/sdk/gcloud/reference/app/deploy