### PR TITLE
Fix GitHub deployment failure when overwriting assets

### DIFF
--- a/lib/dpl/provider/releases.rb
+++ b/lib/dpl/provider/releases.rb
@@ -36,9 +36,9 @@ module DPL
           }
         }
         if options[:user] and options[:password]
-          @api ||= Octokit::Client.new(:login => options[:user], :password => options[:password], :connection_options => connection_options)
+          @api ||= Octokit::Client.new(:login => options[:user], :password => options[:password], :auto_paginate => true, :connection_options => connection_options)
         else
-          @api ||= Octokit::Client.new(:access_token => option(:api_key), :connection_options => connection_options)
+          @api ||= Octokit::Client.new(:access_token => option(:api_key), :auto_paginate => true, :connection_options => connection_options)
         end
       end
 
@@ -116,7 +116,7 @@ module DPL
           next unless File.file?(file)
           existing_url = nil
           filename = Pathname.new(file).basename.to_s
-          api.release(release_url).rels[:assets].get.data.each do |existing_file|
+          api.release_assets(release_url).each do |existing_file|
             if existing_file.name == filename
               existing_url = existing_file.url
             end

--- a/spec/provider/releases_spec.rb
+++ b/spec/provider/releases_spec.rb
@@ -30,7 +30,7 @@ describe DPL::Provider::Releases do
   describe "#api" do
     example "With API key" do
       api = double(:api)
-      expect(::Octokit::Client).to receive(:new).with(:access_token => '0123445789qwertyuiop0123445789qwertyuiop', :connection_options=>{:request=>{:timeout=>180, :open_timeout=>180}}).and_return(api)
+      expect(::Octokit::Client).to receive(:new).with(:access_token => '0123445789qwertyuiop0123445789qwertyuiop', :auto_paginate => true, :connection_options=>{:request=>{:timeout=>180, :open_timeout=>180}}).and_return(api)
       expect(provider.api).to eq(api)
     end
 
@@ -39,7 +39,7 @@ describe DPL::Provider::Releases do
       provider.options.update(:user => 'foo')
       provider.options.update(:password => 'bar')
 
-      expect(::Octokit::Client).to receive(:new).with(:login => 'foo', :password  => 'bar', :connection_options=>{:request=>{:timeout=>180, :open_timeout=>180}}).and_return(api)
+      expect(::Octokit::Client).to receive(:new).with(:login => 'foo', :password  => 'bar', :auto_paginate => true, :connection_options=>{:request=>{:timeout=>180, :open_timeout=>180}}).and_return(api)
       expect(provider.api).to eq(api)
     end
   end
@@ -169,10 +169,7 @@ describe DPL::Provider::Releases do
         allow(release.rels[:self]).to receive(:href)
       end
 
-      allow(provider.api).to receive(:release)
-      allow(provider.api.release).to receive(:rels).and_return({:assets => nil})
-      allow(provider.api.release.rels[:assets]).to receive(:get).and_return({:data => [""]})
-      allow(provider.api.release.rels[:assets].get).to receive(:data).and_return([])
+      allow(provider.api).to receive(:release_assets).and_return([])
 
       expect(provider.api).to receive(:upload_asset).with(anything, "test/foo.bar", {:name=>"foo.bar", :content_type=>"application/octet-stream"})
       expect(provider.api).to receive(:upload_asset).with(anything, "bar.txt", {:name=>"bar.txt", :content_type=>"text/plain"})
@@ -197,10 +194,7 @@ describe DPL::Provider::Releases do
         allow(release.rels[:self]).to receive(:href)
       end
 
-      allow(provider.api).to receive(:release)
-      allow(provider.api.release).to receive(:rels).and_return({:assets => nil})
-      allow(provider.api.release.rels[:assets]).to receive(:get).and_return({:data => [""]})
-      allow(provider.api.release.rels[:assets].get).to receive(:data).and_return([double(:name => "foo.bar", :url => 'foo-bar-url'), double(:name => "foo.foo", :url => 'foo-foo-url')])
+      allow(provider.api).to receive(:release_assets).and_return([double(:name => "foo.bar", :url => 'foo-bar-url'), double(:name => "foo.foo", :url => 'foo-foo-url')])
 
       expect(provider.api).to receive(:upload_asset).with(anything, "bar.txt", {:name=>"bar.txt", :content_type=>"text/plain"})
       expect(provider).to receive(:log).with("foo.bar already exists, skipping.")
@@ -225,10 +219,7 @@ describe DPL::Provider::Releases do
         allow(release.rels[:self]).to receive(:href)
       end
 
-      allow(provider.api).to receive(:release)
-      allow(provider.api.release).to receive(:rels).and_return({:assets => nil})
-      allow(provider.api.release.rels[:assets]).to receive(:get).and_return({:data => [""]})
-      allow(provider.api.release.rels[:assets].get).to receive(:data).and_return([double(:name => "exists.txt", :url => "release-url")])
+      allow(provider.api).to receive(:release_assets).and_return([double(:name => "exists.txt", :url => "release-url")])
 
       expect(provider.api).to receive(:delete_release_asset).with("release-url").and_return(true)
       expect(provider.api).to receive(:upload_asset).with(anything, "exists.txt", {:name=>"exists.txt", :content_type=>"text/plain"})
@@ -256,10 +247,7 @@ describe DPL::Provider::Releases do
       allow(provider.api.create_release).to receive(:rels).and_return({:self => nil})
       allow(provider.api.create_release.rels[:slef]).to receive(:href)
 
-      allow(provider.api).to receive(:release)
-      allow(provider.api.release).to receive(:rels).and_return({:assets => nil})
-      allow(provider.api.release.rels[:assets]).to receive(:get).and_return({:data => nil})
-      allow(provider.api.release.rels[:assets].get).to receive(:data).and_return([])
+      allow(provider.api).to receive(:release_assets).and_return([])
 
       expect(provider.api).to receive(:upload_asset).with(anything, "test/foo.bar", {:name=>"foo.bar", :content_type=>"application/octet-stream"})
       expect(provider.api).to receive(:upload_asset).with(anything, "bar.txt", {:name=>"bar.txt", :content_type=>"text/plain"})
@@ -277,10 +265,7 @@ describe DPL::Provider::Releases do
       allow(provider).to receive(:slug).and_return("foo/bar")
       expect(File).to receive(:file?).with("bar.txt").and_return(true)
 
-      allow(provider.api).to receive(:release)
-      allow(provider.api.release).to receive(:rels).and_return({:assets => nil})
-      allow(provider.api.release.rels[:assets]).to receive(:get).and_return({:data => nil})
-      allow(provider.api.release.rels[:assets].get).to receive(:data).and_return([])
+      allow(provider.api).to receive(:release_assets).and_return([])
 
       expect(provider.api).to receive(:upload_asset).with("https://api.github.com/repos/foo/bar/releases/1234", "bar.txt", {:name=>"bar.txt", :content_type=>"text/plain"})
       expect(provider.api).to receive(:update_release).with(anything, hash_including(:draft => false))
@@ -297,10 +282,7 @@ describe DPL::Provider::Releases do
       allow(provider).to receive(:slug).and_return("foo/bar")
       expect(File).to receive(:file?).with("bar.txt").and_return(true)
 
-      allow(provider.api).to receive(:release)
-      allow(provider.api.release).to receive(:rels).and_return({:assets => nil})
-      allow(provider.api.release.rels[:assets]).to receive(:get).and_return({:data => nil})
-      allow(provider.api.release.rels[:assets].get).to receive(:data).and_return([])
+      allow(provider.api).to receive(:release_assets).and_return([])
 
       expect(provider.api).to receive(:upload_asset).with("https://api.github.com/repos/foo/bar/releases/1234", "bar.txt", {:name=>"bar.txt", :content_type=>"text/plain"})
       expect(provider.api).to receive(:update_release).with(anything, hash_including(:draft => true))
@@ -317,10 +299,7 @@ describe DPL::Provider::Releases do
       allow(provider).to receive(:slug).and_return("foo/bar")
       expect(File).to receive(:file?).with("bar.txt").and_return(true)
 
-      allow(provider.api).to receive(:release)
-      allow(provider.api.release).to receive(:rels).and_return({:assets => nil})
-      allow(provider.api.release.rels[:assets]).to receive(:get).and_return({:data => nil})
-      allow(provider.api.release.rels[:assets].get).to receive(:data).and_return([])
+      allow(provider.api).to receive(:release_assets).and_return([])
 
       expect(provider.api).to receive(:upload_asset).with("https://api.github.com/repos/foo/bar/releases/1234", "bar.txt", {:name=>"bar.txt", :content_type=>"text/plain"})
       expect(provider.api).to receive(:update_release).with(anything, hash_including(:prerelease => true))
@@ -338,10 +317,7 @@ describe DPL::Provider::Releases do
       allow(provider).to receive(:slug).and_return("foo/bar")
       expect(File).to receive(:file?).with("bar.txt").and_return(true)
 
-      allow(provider.api).to receive(:release)
-      allow(provider.api.release).to receive(:rels).and_return({:assets => nil})
-      allow(provider.api.release.rels[:assets]).to receive(:get).and_return({:data => nil})
-      allow(provider.api.release.rels[:assets].get).to receive(:data).and_return([])
+      allow(provider.api).to receive(:release_assets).and_return([])
 
       expect(provider.api).to receive(:upload_asset).with("https://api.github.com/repos/foo/bar/releases/1234", "bar.txt", {:name=>"bar.txt", :content_type=>"text/plain"})
       expect(provider.api).to receive(:update_release).with(anything, hash_including(:prerelease => true, :name => 'true'))


### PR DESCRIPTION
The overwrite logic for GitHub Releases first checks to see if an asset with the given name already exists, and if so deletes it to make way for the new upload.  If, for some reason, a match is overlooked, the asset
is not deleted, and the upload errors with 422 Validation Failed, code "already_exists" and field "name".

The "some reason" in this case was that only the first page of assets are returned in-line with the releases() call.  Using release_assets() directly will trigger the paginate logic in Octokit and fix the problem.

Here is an example of a build [failing to find and delete](https://travis-ci.org/djpohly/PKGBUILD/builds/414689202#L561) an existing asset from a release, and a build using the PR branch which [successfully overwrites assets](https://travis-ci.org/djpohly/PKGBUILD/builds/414690940#L560) beyond the first page.