### PR TITLE
Raise an error if Firebase deployment fails.

### DIFF
--- a/lib/dpl/provider/firebase.rb
+++ b/lib/dpl/provider/firebase.rb
@@ -20,7 +20,7 @@ module DPL
         command << " --project #{options[:project]}" if options[:project]
         command << " --message '#{options[:message]}'" if options[:message]
         command << " --token '#{options[:token]}'" if options[:token]
-        context.shell command
+        context.shell command or raise Error, "Firebase deployment failed"
       end
     end
   end

--- a/spec/provider/firebase_spec.rb
+++ b/spec/provider/firebase_spec.rb
@@ -36,7 +36,8 @@ describe DPL::Provider::Firebase do
       expect(provider.context).to receive(:shell).with("firebase deploy --non-interactive --token 'abc123'").and_return(true)
       provider.push_app
     end
-    it 'fails when cabal complains' do
+
+    it 'should report an error when deployment fails' do
       expect(provider.context).to receive(:shell).with("firebase deploy --non-interactive --token 'abc123'").and_return(false)
       expect {
         provider.push_app

--- a/spec/provider/firebase_spec.rb
+++ b/spec/provider/firebase_spec.rb
@@ -22,19 +22,25 @@ describe DPL::Provider::Firebase do
   describe "#push_app" do
     it 'should include the project specified' do
       provider.options.update(:project => 'myapp-dev')
-      expect(provider.context).to receive(:shell).with("firebase deploy --non-interactive --project myapp-dev --token 'abc123'")
+      expect(provider.context).to receive(:shell).with("firebase deploy --non-interactive --project myapp-dev --token 'abc123'").and_return(true)
       provider.push_app
     end
 
     it 'should include the message specified' do
       provider.options.update(:message => 'test message')
-      expect(provider.context).to receive(:shell).with("firebase deploy --non-interactive --message 'test message' --token 'abc123'")
+      expect(provider.context).to receive(:shell).with("firebase deploy --non-interactive --message 'test message' --token 'abc123'").and_return(true)
       provider.push_app
     end
 
     it 'should default to no project override' do
-      expect(provider.context).to receive(:shell).with("firebase deploy --non-interactive --token 'abc123'")
+      expect(provider.context).to receive(:shell).with("firebase deploy --non-interactive --token 'abc123'").and_return(true)
       provider.push_app
+    end
+    it 'fails when cabal complains' do
+      expect(provider.context).to receive(:shell).with("firebase deploy --non-interactive --token 'abc123'").and_return(false)
+      expect {
+        provider.push_app
+      }.to raise_error(DPL::Error)
     end
   end
 end


### PR DESCRIPTION
Currently, the build passes even though deployment failed:
https://travis-ci.org/SamirTalwar/friendlychat-web/builds/418938360

With this fix, the build fails when there is a deployment failure:
https://travis-ci.org/SamirTalwar/friendlychat-web/builds/418939206