### PR TITLE
Update AWS SDK for Elastic Beanstalk to V3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,3 +53,8 @@ before_script:
 
 script:
   - rake
+
+deploy:
+  provider: elasticbeanstalk
+  edge:
+    branch: eb-updates

--- a/dpl-elastic_beanstalk.gemspec
+++ b/dpl-elastic_beanstalk.gemspec
@@ -1,3 +1,8 @@
 require './gemspec_helper'
 
-gemspec_for 'elastic_beanstalk', [['aws-sdk', '~> 2.0'], ['rubyzip']]
+gemspec_for 'elastic_beanstalk', [
+  ['aws-sdk-core', '~> 3.0'],
+  ['aws-sdk-s3', '~> 1.0'],
+  ['aws-sdk-elasticbeanstalk', '~> 1.0'],
+  ['rubyzip']
+]

--- a/lib/dpl/provider/elastic_beanstalk.rb
+++ b/lib/dpl/provider/elastic_beanstalk.rb
@@ -1,6 +1,8 @@
 require 'time'
-require 'aws-sdk'
 require 'zip'
+require 'aws-sdk-core'
+require 'aws-sdk-s3'
+require 'aws-sdk-elasticbeanstalk'
 
 module DPL
   class Provider

--- a/spec/provider/elastic_beanstalk_spec.rb
+++ b/spec/provider/elastic_beanstalk_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
-require 'aws-sdk'
 require 'dpl/provider'
 require 'dpl/provider/elastic_beanstalk'
+require 'aws-sdk-s3'
 
 describe DPL::Provider::ElasticBeanstalk do
 
@@ -16,22 +16,23 @@ describe DPL::Provider::ElasticBeanstalk do
   let(:wait_until_deployed) { nil }
 
   let(:bucket_mock) do
-    dbl = double("bucket mock", write: nil)
-    allow(dbl).to receive(:objects).and_return(double("Hash", :[] => dbl))
-    dbl
+    instance_double(Aws::S3::Bucket)
   end
 
   let(:s3_mock) do
-    hash_dbl = double("Hash", :[] => bucket_mock, :map => [])
-    double("Aws::S3", bucket: hash_dbl, config: hash_dbl)
+    instance_double(Aws::S3::Resource)
   end
 
   let(:io_double) do
-    double('IO', open: Object.new)
+    double(IO, open: Object.new)
   end
 
-  let(:s3_obj_double) do
-    double("Aws::S3::Object", put: Object.new)
+  let(:s3_obj_mock) do
+    instance_double(Aws::S3::Object, put: Object.new)
+  end
+
+  let(:file_mock) do
+    instance_double(File)
   end
 
   subject :provider do
@@ -62,16 +63,18 @@ describe DPL::Provider::ElasticBeanstalk do
     let(:app_version) { Object.new }
 
     before :each do
-      allow(io_double).to receive(:open)
-      allow(s3_obj_double).to receive(:put).with(anything).and_return(Object.new)
+      allow(s3_obj_mock).to receive(:put).with(anything).and_return(Object.new)
       allow(s3_mock).to receive(:bucket).with(bucket_name).and_return(bucket_mock)
-      expect(Pathname).to receive(:new).and_return(io_double)
+
+      allow(Pathname).to receive(:new).and_return(io_double)
+      allow(io_double).to receive(:open).and_return(file_mock)
+      expect(s3_obj_mock).to receive(:put).with(body: file_mock)
     end
 
     example 'bucket exists already' do
       allow(s3_mock).to receive(:bucket).with(bucket_name).and_return(bucket_mock)
       allow(bucket_mock).to receive(:exists?).and_return(true)
-      allow(bucket_mock).to receive(:object).with("some/app/file.zip").and_return(s3_obj_double)
+      allow(bucket_mock).to receive(:object).with("some/app/file.zip").and_return(s3_obj_mock)
 
       expect(provider).to receive(:s3).and_return(s3_mock).twice
       expect(provider).not_to receive(:create_bucket)
@@ -79,7 +82,7 @@ describe DPL::Provider::ElasticBeanstalk do
       expect(provider).to receive(:archive_name).and_return('file.zip')
       expect(provider).to receive(:upload).with('file.zip', '/path/to/file.zip').and_call_original
       expect(provider).to receive(:sleep).with(5)
-      expect(provider).to receive(:create_app_version).with(s3_obj_double).and_return(app_version)
+      expect(provider).to receive(:create_app_version).with(s3_obj_mock).and_return(app_version)
       expect(provider).to receive(:update_app).with(app_version)
 
       provider.push_app
@@ -88,7 +91,7 @@ describe DPL::Provider::ElasticBeanstalk do
     example 'bucket doesnt exist yet' do
       allow(s3_mock).to receive(:bucket).with(bucket_name).and_return(bucket_mock)
       allow(bucket_mock).to receive(:exists?).and_return(false)
-      allow(bucket_mock).to receive(:object).with("some/app/file.zip").and_return(s3_obj_double)
+      allow(bucket_mock).to receive(:object).with("some/app/file.zip").and_return(s3_obj_mock)
 
       expect(provider).to receive(:s3).and_return(s3_mock).twice
       expect(provider).to receive(:create_bucket)
@@ -96,7 +99,7 @@ describe DPL::Provider::ElasticBeanstalk do
       expect(provider).to receive(:archive_name).and_return('file.zip')
       expect(provider).to receive(:upload).with('file.zip', '/path/to/file.zip').and_call_original
       expect(provider).to receive(:sleep).with(5)
-      expect(provider).to receive(:create_app_version).with(s3_obj_double).and_return(app_version)
+      expect(provider).to receive(:create_app_version).with(s3_obj_mock).and_return(app_version)
       expect(provider).to receive(:update_app).with(app_version)
 
       provider.push_app
@@ -109,14 +112,14 @@ describe DPL::Provider::ElasticBeanstalk do
         allow(s3_mock).to receive(:bucket).with(bucket_name).and_return(bucket_mock)
         allow(bucket_mock).to receive(:exists?).and_return(false)
         allow(bucket_mock).to receive(:create)
-        allow(bucket_mock).to receive(:object).with("some/app/file.zip").and_return(s3_obj_double)
+        allow(bucket_mock).to receive(:object).with("some/app/file.zip").and_return(s3_obj_mock)
 
         expect(provider).to receive(:s3).and_return(s3_mock).at_least(3).times
         expect(provider).to receive(:create_zip).and_return('/path/to/file.zip')
         expect(provider).to receive(:archive_name).and_return('file.zip')
         expect(provider).to receive(:upload).with('file.zip', '/path/to/file.zip').and_call_original
         expect(provider).to receive(:sleep).with(5)
-        expect(provider).to receive(:create_app_version).with(s3_obj_double).and_return(app_version)
+        expect(provider).to receive(:create_app_version).with(s3_obj_mock).and_return(app_version)
         expect(provider).not_to receive(:update_app).with(app_version)
 
         provider.push_app
@@ -126,7 +129,7 @@ describe DPL::Provider::ElasticBeanstalk do
     context 'When the bucket_path option is not set' do
       example 'Does not prepend bucket_path to the s3 bucket' do
         allow(s3_mock).to receive(:bucket).with(bucket_name).and_return(bucket_mock)
-        allow(bucket_mock).to receive(:object).with("file.zip").and_return(s3_obj_double)
+        allow(bucket_mock).to receive(:object).with("file.zip").and_return(s3_obj_mock)
         allow(bucket_mock).to receive(:exists?).and_return(false)
         allow(bucket_mock).to receive(:create)
 
@@ -136,7 +139,7 @@ describe DPL::Provider::ElasticBeanstalk do
         expect(provider_without_bucket_path).to receive(:bucket_path).and_return(nil)
         expect(provider_without_bucket_path).to receive(:upload).with('file.zip', '/path/to/file.zip').and_call_original
         expect(provider_without_bucket_path).to receive(:sleep).with(5)
-        expect(provider_without_bucket_path).to receive(:create_app_version).with(s3_obj_double).and_return(app_version)
+        expect(provider_without_bucket_path).to receive(:create_app_version).with(s3_obj_mock).and_return(app_version)
         expect(provider_without_bucket_path).to receive(:update_app).with(app_version)
 
         provider_without_bucket_path.push_app
@@ -149,14 +152,14 @@ describe DPL::Provider::ElasticBeanstalk do
       example 'Waits until deployment completes' do
         allow(bucket_mock).to receive(:exists?).and_return(false)
         allow(bucket_mock).to receive(:create)
-        allow(bucket_mock).to receive(:object).with("some/app/file.zip").and_return(s3_obj_double)
+        allow(bucket_mock).to receive(:object).with("some/app/file.zip").and_return(s3_obj_mock)
 
         expect(provider).to receive(:s3).and_return(s3_mock).at_least(3).times
         expect(provider).to receive(:create_zip).and_return('/path/to/file.zip')
         expect(provider).to receive(:archive_name).and_return('file.zip')
         expect(provider).to receive(:upload).with('file.zip', '/path/to/file.zip').and_call_original
         expect(provider).to receive(:sleep).with(5)
-        expect(provider).to receive(:create_app_version).with(s3_obj_double).and_return(app_version)
+        expect(provider).to receive(:create_app_version).with(s3_obj_mock).and_return(app_version)
         expect(provider).to receive(:update_app).with(app_version)
         expect(provider).to receive(:wait_until_deployed)
 
@@ -166,13 +169,13 @@ describe DPL::Provider::ElasticBeanstalk do
 
     context "when zip_file option is given" do
       before :each do
-        allow(bucket_mock).to receive(:object).with("some/app/file.zip").and_return(s3_obj_double)
+        allow(bucket_mock).to receive(:object).with("some/app/file.zip").and_return(s3_obj_mock)
         allow(bucket_mock).to receive(:exists?).and_return(false)
         allow(bucket_mock).to receive(:create)
         expect(provider).to receive(:s3).and_return(s3_mock).at_least(3).times
         expect(provider).to receive(:archive_name).and_return('file.zip')
         expect(provider).to receive(:sleep).with(5)
-        expect(provider).to receive(:create_app_version).with(s3_obj_double).and_return(app_version)
+        expect(provider).to receive(:create_app_version).with(s3_obj_mock).and_return(app_version)
         expect(provider).to receive(:update_app).with(app_version)
       end
 


### PR DESCRIPTION
This upgrades the AWS SDK for the Elastic Beanstalk provider from v2 to v3. The new version is backwards compatible. The only difference is that the `aws-sdk` gem is split into multiple sub-gems, one per service (see the [announcing blog post at the time](https://aws.amazon.com/blogs/developer/upgrading-from-version-2-to-version-3-of-the-aws-sdk-for-ruby-2/)).

I also refactored the corresponding spec a bit, by using verifying doubles.