### PR TITLE
Deis/Hephy: Simplify CLI install URL logic

### DIFF
--- a/lib/dpl/provider/deis.rb
+++ b/lib/dpl/provider/deis.rb
@@ -3,22 +3,11 @@ module DPL
     class Deis < Provider
       
       def install_deploy_dependencies
-        install_url = determine_install_url
         context.shell "curl -sSL #{install_url} | bash -x -s #{option(:cli_version)}"
       end
 
-      #Default to installing the default v1 client. Otherwise determine if this is a v2 client
-      def determine_install_url
-         if option(:cli_version).nil?
-           return "https://raw.githubusercontent.com/teamhephy/workflow-cli/master/install-v2.sh"
-         else
-           version_arg = Gem::Version.new(option(:cli_version).gsub(/^v?V?/,''))
-           if version_arg >= Gem::Version.new('2.0.0')
-             return "https://raw.githubusercontent.com/teamhephy/workflow-cli/master/install-v2.sh"
-           else
-             return "https://raw.githubusercontent.com/teamhephy/workflow-cli/master/install-v2.sh"
-           end
-         end
+      def install_url
+        return "https://raw.githubusercontent.com/teamhephy/workflow-cli/master/install-v2.sh"
       end
 
       def needs_key?

--- a/lib/dpl/provider/hephy.rb
+++ b/lib/dpl/provider/hephy.rb
@@ -3,22 +3,11 @@ module DPL
     class Hephy < Provider
       
       def install_deploy_dependencies
-        install_url = determine_install_url
         context.shell "curl -sSL #{install_url} | bash -x -s #{option(:cli_version)}"
       end
 
-      #Default to installing the default v1 client. Otherwise determine if this is a v2 client
-      def determine_install_url
-         if option(:cli_version).nil?
-           return "https://raw.githubusercontent.com/teamhephy/workflow-cli/master/install-v2.sh"
-         else
-           version_arg = Gem::Version.new(option(:cli_version).gsub(/^v?V?/,''))
-           if version_arg >= Gem::Version.new('2.0.0')
-             return "https://raw.githubusercontent.com/teamhephy/workflow-cli/master/install-v2.sh"
-           else
-             return "https://raw.githubusercontent.com/teamhephy/workflow-cli/master/install-v2.sh"
-           end
-         end
+      def install_url
+        return "https://raw.githubusercontent.com/teamhephy/workflow-cli/master/install-v2.sh"
       end
 
       def needs_key?


### PR DESCRIPTION
v2 is the only version of the install script being used since cutting over to the Hephy fork of Deis. This change simplifies the URL logic to return the single URL available. I left the `cli_version` option in case any future logic wants to make use of it, even though this was the only code in the provider using it.