### PR TITLE
Read .ebignore when choosing files to include in archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,13 @@ For example: `--endpoint=https://nyc3.digitaloceanspaces.com`
  * **bucket_path**: Location within Bucket to upload app to.
  * **only_create_app_version**: only create the app version, don't actually deploy it.
 
+If `.ebignore` file exists, the files matching the patterns in this file will be
+ignored during the application upload.
+Similarly, if `.ebignore` does not exist but `.gitignore` does, the files matching
+the standard `.gitignore` rules will be excluded from the upload.
+See [AWS CLI documentation](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/eb-cli3-configuration.html)
+for more information.
+
 #### Environment variables:
 
  * **ELASTIC_BEANSTALK_ENV**: Elastic Beanstalk environment name which will be updated. Is only used if `env` option is omitted.

--- a/lib/dpl/provider/elastic_beanstalk.rb
+++ b/lib/dpl/provider/elastic_beanstalk.rb
@@ -106,7 +106,14 @@ module DPL
       end
 
       def files_to_pack
-        `git ls-files -z`.split("\x0")
+        exclude_flag = ''
+        if File.exist? '.ebignore'
+          exclude_flag = ' --exclude-from=.ebignore'
+        elsif File.exist? '.gitignore'
+          exclude_flag = ' --exclude-standard'
+        end
+
+        `git ls-files #{exclude_flag} -z`.split("\x0")
       end
 
       def create_zip


### PR DESCRIPTION
Resolves https://github.com/travis-ci/dpl/issues/411.

1. If `.ebignore` exists, read that file, and that file only, to choose files to include.
1. If `.ebignore` does not exist, but `.gitignore` does, then use the standard rules to choose files. (See https://git-scm.com/docs/git-ls-files#_exclude_patterns)

The latter is a departure from the current behavior, and may require some care.
