### PR TITLE
Stop using heroku build result endpoint

### DIFF
--- a/lib/dpl/provider/heroku/api.rb
+++ b/lib/dpl/provider/heroku/api.rb
@@ -52,16 +52,18 @@ module DPL
 
         def verify_build
           loop do
-            response = faraday.get("/apps/#{option(:app)}/builds/#{build_id}/result")
-            exit_code = JSON.parse(response.body)['exit_code']
-            if exit_code.nil?
+            response = faraday.get("/apps/#{option(:app)}/builds/#{build_id}")
+            body = JSON.parse(response.body)
+
+            case body['status']
+            when 'pending'
               log "heroku build still pending"
               sleep 5
               next
-            elsif exit_code == 0
+            when 'succeeded'
               break
             else
-              error "deploy failed, build exited with code #{exit_code}"
+              error "deploy failed"
             end
           end
         end

--- a/spec/provider/heroku_spec.rb
+++ b/spec/provider/heroku_spec.rb
@@ -11,7 +11,7 @@ RSpec.shared_context 'with faraday' do
         stub.get("/account") {|env| [200, response_headers, account_response_body]}
         stub.get("/apps/example") {|env| [200, response_headers, app_response_body]}
         stub.post("/apps/example/builds") {|env| [201, response_headers, builds_response_body]}
-        stub.get("/apps/example/builds/01234567-89ab-cdef-0123-456789abcdef/result") {|env| [200, response_headers, build_result_response_body]}
+        stub.get("/apps/example/builds/01234567-89ab-cdef-0123-456789abcdef") {|env| [200, response_headers, build_response_body]}
         stub.post("/sources") {|env| [201, response_headers, source_response_body] }
         stub.post("/apps/example/dynos") {|env| [201, response_headers, dynos_create_response_body]}
         stub.delete("/apps/example/dynos") {|env| [202, response_headers, '{}'] }
@@ -163,53 +163,27 @@ RSpec.shared_context 'with faraday' do
     }'
   }
 
-  let(:build_result_response_body) {
+  let(:build_response_body) {
   '{
-      "build": {
-      "id": "01234567-89ab-cdef-0123-456789abcdef",
-      "status": "succeeded",
-      "output_stream_url": "https://build-output.heroku.com/streams/01234567-89ab-cdef-0123-456789abcdef"
-    },
-    "exit_code": 0,
-    "lines": [
-      {
-        "line": "-----> Ruby app detected\n",
-        "stream": "STDOUT"
-      }
-    ]
+    "id": "01234567-89ab-cdef-0123-456789abcdef",
+    "status": "succeeded",
+    "output_stream_url": "https://build-output.heroku.com/streams/01234567-89ab-cdef-0123-456789abcdef"
   }'
   }
 
-  let(:build_result_response_body_failure) {
+  let(:build_response_body_failure) {
     '{
-        "build": {
-        "id": "01234567-89ab-cdef-0123-456789abcdef",
-        "status": "failed",
-        "output_stream_url": "https://build-output.heroku.com/streams/01234567-89ab-cdef-0123-456789abcdef"
-      },
-      "exit_code": 1,
-      "lines": [
-        {
-          "line": "-----> Ruby app detected\n",
-          "stream": "STDOUT"
-        }
-      ]
+      "id": "01234567-89ab-cdef-0123-456789abcdef",
+      "status": "failed",
+      "output_stream_url": "https://build-output.heroku.com/streams/01234567-89ab-cdef-0123-456789abcdef"
     }'
   }
 
-  let(:build_result_response_body_in_progress) {
+  let(:build_response_body_in_progress) {
     '{
-        "build": {
-        "id": "01234567-89ab-cdef-0123-456789abcdef",
-        "status": "failed",
-        "output_stream_url": "https://build-output.heroku.com/streams/01234567-89ab-cdef-0123-456789abcdef"
-      },
-      "lines": [
-        {
-          "line": "-----> Ruby app detected\n",
-          "stream": "STDOUT"
-        }
-      ]
+      "id": "01234567-89ab-cdef-0123-456789abcdef",
+      "status": "pending",
+      "output_stream_url": "https://build-output.heroku.com/streams/01234567-89ab-cdef-0123-456789abcdef"
     }'
   }
 end
@@ -298,8 +272,8 @@ describe DPL::Provider::Heroku, :api do
       example do
         expect(provider).to receive(:faraday).at_least(:once).and_return(faraday)
         expect(provider).to receive(:build_id).at_least(:once).and_return('01234567-89ab-cdef-0123-456789abcdef')
-        stubs.get("/apps/example/builds/01234567-89ab-cdef-0123-456789abcdef/result") {|env| [200, response_headers, build_result_response_body_failure]}
-        expect{ provider.verify_build }.to raise_error("deploy failed, build exited with code 1")
+        stubs.get("/apps/example/builds/01234567-89ab-cdef-0123-456789abcdef") {|env| [200, response_headers, build_response_body_failure]}
+        expect{ provider.verify_build }.to raise_error("deploy failed")
       end
     end
 
@@ -307,7 +281,7 @@ describe DPL::Provider::Heroku, :api do
       example do
         expect(provider).to receive(:faraday).at_least(:once).and_return(faraday)
         expect(provider).to receive(:build_id).at_least(:once).and_return('01234567-89ab-cdef-0123-456789abcdef')
-        stubs.get("/apps/example/builds/01234567-89ab-cdef-0123-456789abcdef/result") {|env| [200, response_headers, build_result_response_body_in_progress]}
+        stubs.get("/apps/example/builds/01234567-89ab-cdef-0123-456789abcdef") {|env| [200, response_headers, build_response_body_in_progress]}
         expect(provider).to receive(:sleep).with(5).and_return(true)
         expect{ provider.verify_build }.not_to raise_error
       end


### PR DESCRIPTION
This endpoint has been deprecated for years, and we are looking into removing it.
As such, it is currently browned out and will be permanently removed in 2 weeks.
See https://devcenter.heroku.com/changelog-items/1486

This PR stops using that endpoint, to use the standard build one.