### PR TITLE
Provider for deploying to AWS ECR 

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Dpl supports the following providers:
 * [Cloud 66](#cloud-66)
 * [Cloud Foundry](#cloud-foundry)
 * [Deis](#deis)
+* [ECR](#ecr)
 * [Engine Yard](#engine-yard)
 * [Firebase](#firebase)
 * [Github Pages](#github-pages)
@@ -219,6 +220,21 @@ For authentication you can also use Travis CI secure environment variable:
 
 #### Examples:
     dpl --provider=nodejitsu --username=<username> --api-key=<api-key>
+
+### Ecr
+
+#### Options
+
+- **source**: You can use the repository id (e.g. `1f47fade220d`) or the repository name and optional tag (`mysql:5.6`).
+- **target**: One or more partial repository names to push to ECR (i.e. a YAML string or a list). Note that you enter `ze-image:latest` to push to `<account-id>.dkr.ecr.<region>.amazonaws.com/ze-image:latest`; the provider abstracts away the need to tell the Docker daemon which registry to push to.
+- **aws_region**: One or more regions to push the image to (i.e. a YAML list or a string). Overrides `AWS_REGION` environment variable.
+- **aws_account_id**: If the repository is owned by a different account than the IAM user, specify it here. Overrides `AWS_ACCOUNT_ID`.
+- **aws_access_key_id**: The access key to use when authenticating. Overrides `AWS_ACCESS_KEY_ID`.
+- **aws_secret_access_key**: The secret to use when authenticating. Overrides `AWS_SECRET_ACCESS_KEY`.
+
+#### Examples
+
+    dpl --provider=ecr --source=<local-image> --aws_region=eu-west-1 --target=<ecr-repo> --aws-access-key-id=<access-key> --aws-secret-access-key=<secret>
 
 ### Engine Yard:
 

--- a/dpl-ecr.gemspec
+++ b/dpl-ecr.gemspec
@@ -1,0 +1,3 @@
+require './gemspec_helper'
+
+gemspec_for 'ecr', [['aws-sdk', '~> 2.0'], ['docker-api', '~> 1.34']]

--- a/lib/dpl/provider.rb
+++ b/lib/dpl/provider.rb
@@ -27,6 +27,7 @@ module DPL
       'CodeDeploy'          => 'code_deploy',
       'Cargo'               => 'cargo',
       'Deis'                => 'deis',
+      'Ecr'                 => 'ecr',
       'ElasticBeanstalk'    => 'elastic_beanstalk',
       'EngineYard'          => 'engine_yard',
       'Firebase'            => 'firebase',

--- a/lib/dpl/provider/ecr.rb
+++ b/lib/dpl/provider/ecr.rb
@@ -1,0 +1,85 @@
+require 'aws-sdk'
+require 'docker-api'
+require 'net/http'
+
+module DPL
+  class Provider
+    class Ecr < Provider
+      def needs_key?
+        false
+      end
+
+      def validate
+        issues = []
+        issues << 'source or target option missing' unless ([:source, :target] - options.keys).empty?
+        issues << 'aws_region option or env AWS_REGION missing' if aws_regions.empty?
+        issues << 'aws_access_key_id option or env AWS_ACCESS_KEY_ID missing' unless options[:aws_access_key_id] || ENV['AWS_ACCESS_KEY_ID']
+        raise DPL::Error, "dpl-ecr failed validation: #{issues.join(', ')}" unless issues.empty?
+      end
+
+      def check_auth
+        validate
+        aws_regions.each do |aws_region|
+          auth_region(aws_region)
+        end
+      end
+
+      def check_app
+        image
+      rescue Docker::Error::NotFoundError
+        raise DPL::Error, "No such image #{options[:source]} in local Docker repo"
+      end
+
+      def push_app
+        aws_regions.product([*options[:target]]).each do |aws_region, repo_tag|
+          push_image(aws_region, repo_tag)
+        end
+      end
+
+      def endpoints
+        @endpoints ||= {}
+      end
+
+      private
+
+      def aws_credentials
+        options.select {|k, v| [:aws_access_key_id, :aws_secret_access_key].include?(k) }
+      end
+
+      def registry_ids
+        if (aws_account_id = options.fetch(:aws_account_id, ENV['AWS_ACCOUNT_ID']))
+          {registry_ids: [aws_account_id]}
+        else
+          {}
+        end
+      end
+
+      def aws_regions
+        [*options.fetch(:aws_region, ENV['AWS_REGION'] || ENV['AWS_DEFAULT_REGION'])]
+      end
+
+      def auth_region(aws_region)
+        ecr_client = Aws::ECR::Client.new(region: aws_region, **aws_credentials)
+        auth_response = ecr_client.get_authorization_token(**registry_ids)
+        registry_auth = auth_response.authorization_data[0]
+        username, password = Base64.decode64(registry_auth.authorization_token).split(':')
+        Docker.authenticate!(
+          username: username,
+          password: password,
+          serveraddress: registry_auth.proxy_endpoint,
+        )
+        endpoints[aws_region] = registry_auth.proxy_endpoint
+      end
+
+      def image
+        @image ||= Docker::Image.get(options[:source])
+      end
+
+      def push_image(aws_region, repo_tag)
+        endpoint = endpoints[aws_region].sub(/^https?:\/\//, '')
+        repo_tag = "#{endpoint}/#{repo_tag}"
+        image.push(nil, repo_tag: repo_tag)
+      end
+    end
+  end
+end

--- a/lib/dpl/provider/ecr.rb
+++ b/lib/dpl/provider/ecr.rb
@@ -81,8 +81,9 @@ module DPL
 
       def push_image(aws_region, repo_tag)
         endpoint = endpoints[aws_region].sub(/^https?:\/\//, '')
-        repo_tag = "#{endpoint}/#{repo_tag}"
-        image.push(nil, repo_tag: repo_tag, &method(:present_progress))
+        repo, tag = repo_tag.split(':')
+        image.tag(repo: "#{endpoint}/#{repo}", tag: tag, force: true)
+        image.push(nil, repo_tag: "#{endpoint}/#{repo_tag}", &method(:present_progress))
         log("Pushed image #{image.id} to #{repo_tag}")
       end
 

--- a/spec/provider/ecr_spec.rb
+++ b/spec/provider/ecr_spec.rb
@@ -29,6 +29,7 @@ describe DPL::Provider::Ecr do
   let(:image) do
     double(:image, id: 'ze-id').tap do |i|
       allow(i).to receive(:push)
+      allow(i).to receive(:tag)
     end
   end
 
@@ -232,6 +233,7 @@ describe DPL::Provider::Ecr do
     context 'with minimal options' do
       it 'pushes the image to ecr' do
         provider.push_app
+        expect(image).to have_received(:tag).with(repo: 'north-endpoint/target/repo', tag: nil, force: true)
         expect(image).to have_received(:push).with(nil, repo_tag: 'north-endpoint/target/repo')
       end
     end
@@ -243,7 +245,9 @@ describe DPL::Provider::Ecr do
 
       it 'pushes the image to both registries', :aggregate_failures do
         provider.push_app
+        expect(image).to have_received(:tag).with(repo: 'central-endpoint/target/repo', tag: nil, force: true)
         expect(image).to have_received(:push).with(nil, repo_tag: 'central-endpoint/target/repo')
+        expect(image).to have_received(:tag).with(repo: 'south-endpoint/target/repo', tag: nil, force: true)
         expect(image).to have_received(:push).with(nil, repo_tag: 'south-endpoint/target/repo')
       end
     end
@@ -255,7 +259,9 @@ describe DPL::Provider::Ecr do
 
       it 'pushes the image with both tags', :aggregate_failures do
         provider.push_app
+        expect(image).to have_received(:tag).with(repo: 'north-endpoint/target/repo', tag: '1.0', force: true)
         expect(image).to have_received(:push).with(nil, repo_tag: 'north-endpoint/target/repo:1.0')
+        expect(image).to have_received(:tag).with(repo: 'north-endpoint/target/repo', tag: 'latest', force: true)
         expect(image).to have_received(:push).with(nil, repo_tag: 'north-endpoint/target/repo:latest')
       end
     end

--- a/spec/provider/ecr_spec.rb
+++ b/spec/provider/ecr_spec.rb
@@ -27,7 +27,7 @@ describe DPL::Provider::Ecr do
   end
 
   let(:image) do
-    double(:image).tap do |i|
+    double(:image, id: 'ze-id').tap do |i|
       allow(i).to receive(:push)
     end
   end
@@ -39,7 +39,9 @@ describe DPL::Provider::Ecr do
   end
 
   subject :provider do
-    described_class.new(DummyContext.new, **options)
+    described_class.new(DummyContext.new, **options).tap do |p|
+      allow(p).to receive(:log)
+    end
   end
 
   around do |example|

--- a/spec/provider/ecr_spec.rb
+++ b/spec/provider/ecr_spec.rb
@@ -1,0 +1,261 @@
+require 'base64'
+require 'spec_helper'
+require 'dpl/provider/ecr'
+
+describe DPL::Provider::Ecr do
+  let :options do
+    {
+      source: 'source/repo',
+      target: 'target/repo'
+    }
+  end
+
+  let :ecr_authorization do
+    double(:ecr_authorization, authorization_data: [
+      double(:registry_auth,
+        authorization_token: Base64.encode64('ze-username:ze-token'),
+        expires_at: Time.at(1234567890),
+        proxy_endpoint: 'https://ze-endpoint',
+      )
+    ])
+  end
+
+  let :ecr_client do
+    double(:ecr_client).tap do |c|
+      allow(c).to receive(:get_authorization_token).and_return(ecr_authorization)
+    end
+  end
+
+  let(:image) do
+    double(:image).tap do |i|
+      allow(i).to receive(:push)
+    end
+  end
+
+  before do
+    allow(Docker).to receive(:authenticate!).and_return(true)
+    allow(Docker::Image).to receive(:get).and_return(image)
+    allow(Aws::ECR::Client).to receive(:new).and_return(ecr_client)
+  end
+
+  subject :provider do
+    described_class.new(DummyContext.new, **options)
+  end
+
+  around do |example|
+    @old_env = ENV.to_h.dup
+    example.run
+    ENV.clear.update(@old_env)
+  end
+
+  describe '#validate' do
+    let :options do
+      super().merge(
+        aws_region: 'rp-north-1',
+        aws_account_id: '54321',
+        aws_access_key_id: 'ANOTHERACCESSKEY',
+        aws_secret_access_key: 'evenmoresecret',
+      )
+    end
+
+    context 'with no source option' do
+      let(:options) { super().reject{|k, _| k == :source } }
+
+      it 'raises an error' do
+        expect { provider.validate }.to raise_error(/source.*missing/im)
+      end
+    end
+
+    context 'with no target option' do
+      let(:options) { super().reject{|k, _| k == :target } }
+
+      it 'raises an error' do
+        expect { provider.validate }.to raise_error(/target.*missing/im)
+      end
+    end
+
+    context 'with no region option' do
+      let(:options) { super().reject{|k, _| k == :aws_region } }
+
+      it 'raises an error' do
+        expect { provider.validate }.to raise_error(/aws_region.*missing/im)
+      end
+
+      context 'and environment variable AWS_REGION' do
+        before { ENV['AWS_REGION'] = 'rp-east-1' }
+
+        it 'does not raise an error' do
+          provider.validate
+        end
+      end
+    end
+
+    context 'with no access key option' do
+      let(:options) { super().reject{|k, _| k == :aws_access_key_id } }
+
+      it 'raises an error' do
+        expect { provider.validate }.to raise_error(/aws_access_key_id.*missing/im)
+      end
+
+      context 'and environment variable AWS_ACCESS_KEY_ID' do
+        before { ENV['AWS_ACCESS_KEY_ID'] = 'SOMEACCESSKEY' }
+
+        it 'does not raise an error' do
+          provider.validate
+        end
+      end
+    end
+  end
+
+  describe '#check_auth' do
+    before do
+      ENV['AWS_ACCESS_KEY_ID'] = 'SOMEACCESSKEY'
+      ENV['AWS_SECRET_ACCESS_KEY'] = 'verysecret'
+      ENV['AWS_DEFAULT_REGION'] = 'rp-north-1'
+    end
+
+    context 'with minimal options' do
+      it 'infers the rest from environment variables' do
+        provider.check_auth
+        expect(ecr_client).to have_received(:get_authorization_token).with({})
+      end
+
+      it 'uses the credentials to authenticate with the ECR registry' do
+        provider.check_auth
+        expect(Docker).to have_received(:authenticate!)
+          .with(
+            username: 'ze-username',
+            password: 'ze-token',
+            serveraddress: 'https://ze-endpoint'
+          )
+      end
+
+      it 'remembers the endpoint' do
+        provider.check_auth
+        expect(provider.endpoints).to include('rp-north-1' => 'https://ze-endpoint')
+      end
+    end
+
+    context 'with AWS_ACCOUNT_ID environment variable' do
+      before do
+        ENV['AWS_ACCOUNT_ID'] = '12345'
+      end
+
+      it 'passes that account id as registry id' do
+        provider.check_auth
+        expect(ecr_client).to have_received(:get_authorization_token).with(registry_ids: ['12345'])
+      end
+    end
+
+    context 'with AWS_REGION environment variable' do
+      before do
+        ENV['AWS_REGION'] = 'rp-west-1'
+      end
+
+      it 'prefers AWS_REGION to AWS_DEFAULT_REGION' do
+        provider.check_auth
+        expect(Aws::ECR::Client).to have_received(:new).with(hash_including(region: 'rp-west-1'))
+      end
+    end
+
+    context 'with explicitly configured aws credentials' do
+      let :options do
+        super().merge(
+          aws_account_id: '54321',
+          aws_access_key_id: 'ANOTHERACCESSKEY',
+          aws_secret_access_key: 'evenmoresecret',
+        )
+      end
+
+      it 'overrides credentials from environment variables' do
+        provider.check_auth
+        expect(Aws::ECR::Client).to have_received(:new).with(
+          region: 'rp-north-1',
+          aws_access_key_id: 'ANOTHERACCESSKEY',
+          aws_secret_access_key: 'evenmoresecret',
+        )
+      end
+
+      it 'uses the configured account id when reguesting authorization' do
+        provider.check_auth
+        expect(ecr_client).to have_received(:get_authorization_token).with(registry_ids: ['54321'])
+      end
+    end
+
+    context 'with multiple regions' do
+      let :options do
+        super().merge(aws_region: ['rp-central-1', 'rp-south-1'])
+      end
+
+      it 'authenticates in both regions', :aggregate_failures do
+        provider.check_auth
+        expect(Aws::ECR::Client).to have_received(:new).with(region: 'rp-central-1')
+        expect(Aws::ECR::Client).to have_received(:new).with(region: 'rp-south-1')
+        expect(ecr_client).to have_received(:get_authorization_token).twice
+      end
+
+      it 'decorates each target with the corresponding endpoint', :aggregate_failures do
+        provider.check_auth
+        expect(provider.endpoints).to include('rp-central-1' => 'https://ze-endpoint')
+        expect(provider.endpoints).to include('rp-south-1' => 'https://ze-endpoint')
+      end
+    end
+  end
+
+  describe '#check_app' do
+    it 'validates that the image exists' do
+      provider.check_app
+      expect(Docker::Image).to have_received(:get).with('source/repo')
+    end
+
+    context 'when the image does not exist in the local repository' do
+      before { allow(Docker::Image).to receive(:get).and_raise(Docker::Error::NotFoundError) }
+
+      it 'raises a DPL error' do
+        expect { provider.check_app }.to raise_error(DPL::Error, /source\/repo/)
+      end
+    end
+  end
+
+  describe '#push_app' do
+    before do
+      allow(provider).to receive(:endpoints).and_return({
+        'rp-north-1' => 'https://north-endpoint',
+        'rp-central-1' => 'https://central-endpoint',
+        'rp-south-1' => 'https://south-endpoint'
+      })
+      ENV['AWS_REGION'] = 'rp-north-1'
+    end
+
+    context 'with minimal options' do
+      it 'pushes the image to ecr' do
+        provider.push_app
+        expect(image).to have_received(:push).with(nil, repo_tag: 'north-endpoint/target/repo')
+      end
+    end
+
+    context 'with multiple regions' do
+      let :options do
+        super().merge(aws_region: ['rp-central-1', 'rp-south-1'])
+      end
+
+      it 'pushes the image to both registries', :aggregate_failures do
+        provider.push_app
+        expect(image).to have_received(:push).with(nil, repo_tag: 'central-endpoint/target/repo')
+        expect(image).to have_received(:push).with(nil, repo_tag: 'south-endpoint/target/repo')
+      end
+    end
+
+    context 'with multiple targets' do
+      let :options do
+        super().merge(target: ['target/repo:1.0', 'target/repo:latest'])
+      end
+
+      it 'pushes the image with both tags', :aggregate_failures do
+        provider.push_app
+        expect(image).to have_received(:push).with(nil, repo_tag: 'north-endpoint/target/repo:1.0')
+        expect(image).to have_received(:push).with(nil, repo_tag: 'north-endpoint/target/repo:latest')
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Usage

The ECR provider deploys a Docker image to one or more AWS ECR Docker repositories. This repository must already exist.

A simple configuration looks like this:
```
before_deploy:
  - docker build -t ze-image .
deploy:
  - provider: ecr
    source: ze-image
    target: ze-image
```
The provider honors `AWS_REGION`. Authentication can be done by setting `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables or can be explicitly set in the configuration as fits your needs:
```
deploy:
  - provider: ecr
    aws_access_key_id: AKIAFOOBAR
    aws_secret_access_key:
      secret: verysecret64==
    source: ze-image
    target: ze-image
```
The ECR provider is limited to push a single image identified by source, but it can push that image multiple times by creating a matrix of regions and targets. For example, if you want to push both a specific tag and latest to two regions, this will result in four push operations:
```
deploy:
  - provider: ecr
    source: ze-image
    aws_region:
      - eu-west-1
      - us-east-1
    target: 
      - ze-image:${TRAVIS_COMMIT}
      - ze-image:latest
```

### Reference

- **source**: You can use the repository id (e.g. `1f47fade220d`) or the repository name and optional tag (`mysql:5.6`).
- **target**: One or more partial repository names to push to ECR. Note that you enter `ze-image:latest` to push to `<account-id>.dkr.ecr.<region>.amazonaws.com/ze-image:latest`; the provider abstracts away the need to tell the Docker daemon which registry to push to.
- **aws_region**: One or more regions to push the image to. Overrides `AWS_REGION` environment variable.
- **aws_account_id**: If the repository is owned by a different account than the IAM user, specify it here. 
- **aws_access_key_id**: The access key to use when authenticating. Overrides `AWS_ACCESS_KEY_ID`.
- **aws_secret_access_key**: The secret to use when authenticating. Overrides `AWS_SECRET_ACCESS_KEY`.
