### PR TITLE
Releases improvements

### DIFF
--- a/lib/dpl/provider.rb
+++ b/lib/dpl/provider.rb
@@ -158,7 +158,7 @@ module DPL
 
     def initialize(context, options)
       @context, @options = context, options
-      context.env['GIT_HTTP_USER_AGENT'] = user_agent(git: `git --version`[/[\d\.]+/])
+      context.env['GIT_HTTP_USER_AGENT'] = user_agent(git: `git --version`[/[\d\.]+/]) if needs_git_http_user_agent?
     end
 
     def user_agent(*strings)
@@ -303,6 +303,10 @@ module DPL
 
     def error(message)
       raise Error, message
+    end
+
+    def needs_git_http_user_agent?
+      true
     end
   end
 end

--- a/lib/dpl/provider.rb
+++ b/lib/dpl/provider.rb
@@ -158,7 +158,11 @@ module DPL
 
     def initialize(context, options)
       @context, @options = context, options
-      context.env['GIT_HTTP_USER_AGENT'] = user_agent(git: `git --version`[/[\d\.]+/]) if needs_git_http_user_agent?
+      if options.key?(:needs_git_http_user_agent) && !options[:needs_git_http_user_agent]
+        context.env.delete 'GIT_HTTP_USER_AGENT'
+      else
+        context.env['GIT_HTTP_USER_AGENT'] = user_agent(git: `git --version`[/[\d\.]+/])
+      end
     end
 
     def user_agent(*strings)
@@ -303,10 +307,6 @@ module DPL
 
     def error(message)
       raise Error, message
-    end
-
-    def needs_git_http_user_agent?
-      true
     end
   end
 end

--- a/lib/dpl/provider/atlas.rb
+++ b/lib/dpl/provider/atlas.rb
@@ -60,9 +60,7 @@ module DPL
       private
 
       def install_atlas_upload
-        without_git_http_user_agent do
-          context.shell ATLAS_UPLOAD_INSTALL_SCRIPT
-        end
+        context.shell ATLAS_UPLOAD_INSTALL_SCRIPT
       end
 
       def assert_app_present!
@@ -97,12 +95,9 @@ module DPL
         @atlas_app ||= options.fetch(:app).to_s
       end
 
-      def without_git_http_user_agent(&block)
-        git_http_user_agent = ENV.delete("GIT_HTTP_USER_AGENT")
-        yield
-        ENV["GIT_HTTP_USER_AGENT"] = git_http_user_agent
+      def needs_git_http_user_agent?
+        false
       end
-
     end
   end
 end

--- a/lib/dpl/provider/atlas.rb
+++ b/lib/dpl/provider/atlas.rb
@@ -30,6 +30,10 @@ module DPL
 
       experimental 'Atlas'
 
+      def self.new(context, options)
+        super(context, options.merge!({needs_git_http_user_agent: false}))
+      end
+
       def deploy
         assert_app_present!
         install_atlas_upload
@@ -93,10 +97,6 @@ module DPL
 
       def atlas_app
         @atlas_app ||= options.fetch(:app).to_s
-      end
-
-      def needs_git_http_user_agent?
-        false
       end
     end
   end

--- a/lib/dpl/provider/releases.rb
+++ b/lib/dpl/provider/releases.rb
@@ -147,8 +147,8 @@ module DPL
           options[:tag_name] = get_tag.tap {|tag| log "Setting tag_name to #{tag}"}
         end
 
-        unless options.key?(:target_committish)
-          options[:target_committish] = sha
+        unless options.key?(:target_commitish)
+          options[:target_commitish] = sha.tap {|commitish| log "Setting target_commitish to #{commitish}"}
         end
 
         api.update_release(release_url, {:draft => false}.merge(options))

--- a/lib/dpl/provider/releases.rb
+++ b/lib/dpl/provider/releases.rb
@@ -72,10 +72,6 @@ module DPL
         false
       end
 
-      def needs_git_http_user_agent?
-        false
-      end
-
       def check_app
         log "Deploying to repo: #{slug}"
 

--- a/lib/dpl/provider/releases.rb
+++ b/lib/dpl/provider/releases.rb
@@ -68,6 +68,10 @@ module DPL
         false
       end
 
+      def needs_git_http_user_agent?
+        false
+      end
+
       def check_app
         log "Deploying to repo: #{slug}"
 

--- a/lib/dpl/provider/releases.rb
+++ b/lib/dpl/provider/releases.rb
@@ -117,7 +117,14 @@ module DPL
         end
 
         files.each do |file|
-          next unless File.file?(file)
+          unless File.exist?(file)
+            log "#{file} does not exist."
+            next
+          end
+          unless File.file?(file)
+            log "#{file} is not a regular file. Skipping."
+            next
+          end
           existing_url = nil
           filename = Pathname.new(file).basename.to_s
           api.release_assets(release_url).each do |existing_file|

--- a/lib/dpl/provider/releases.rb
+++ b/lib/dpl/provider/releases.rb
@@ -143,8 +143,8 @@ module DPL
           end
         end
 
-        unless options.key?(:tag_name)
-          options[:tag_name] = get_tag
+        if ! options.key?(:tag_name) && options[:draft]
+          options[:tag_name] = get_tag.tap {|tag| log "Setting tag_name to #{tag}"}
         end
 
         unless options.key?(:target_committish)

--- a/lib/dpl/provider/releases.rb
+++ b/lib/dpl/provider/releases.rb
@@ -11,6 +11,10 @@ module DPL
         prerelease
       )
 
+      def self.new(context, options)
+        super(context, options.merge!({needs_git_http_user_agent: false}))
+      end
+
       def travis_tag
         # Check if $TRAVIS_TAG is unset or set but empty
         if context.env.fetch('TRAVIS_TAG','') == ''

--- a/lib/dpl/provider/releases.rb
+++ b/lib/dpl/provider/releases.rb
@@ -143,6 +143,14 @@ module DPL
           end
         end
 
+        unless options.key?(:tag_name)
+          options[:tag_name] = get_tag
+        end
+
+        unless options.key?(:target_committish)
+          options[:target_committish] = sha
+        end
+
         api.update_release(release_url, {:draft => false}.merge(options))
       end
 

--- a/lib/dpl/provider/script.rb
+++ b/lib/dpl/provider/script.rb
@@ -21,6 +21,10 @@ module DPL
       def script
         options[:script]
       end
+
+      def needs_git_http_user_agent?
+        false
+      end
     end
   end
 end

--- a/lib/dpl/provider/script.rb
+++ b/lib/dpl/provider/script.rb
@@ -1,6 +1,10 @@
 module DPL
   class Provider
     class Script < Provider
+      def self.new(context, options)
+        super(context, options.merge!({needs_git_http_user_agent: false}))
+      end
+
       def check_auth
       end
 
@@ -20,10 +24,6 @@ module DPL
 
       def script
         options[:script]
-      end
-
-      def needs_git_http_user_agent?
-        false
       end
     end
   end

--- a/spec/provider/releases_spec.rb
+++ b/spec/provider/releases_spec.rb
@@ -160,6 +160,8 @@ describe DPL::Provider::Releases do
 
       allow(provider).to receive(:releases).and_return([""])
       allow(provider).to receive(:get_tag).and_return("v0.0.0")
+      expect(File).to receive(:exist?).with("test/foo.bar").and_return(true)
+      expect(File).to receive(:exist?).with("bar.txt").and_return(true)
       expect(File).to receive(:file?).with("test/foo.bar").and_return(true)
       expect(File).to receive(:file?).with("bar.txt").and_return(true)
 
@@ -185,6 +187,8 @@ describe DPL::Provider::Releases do
 
       allow(provider).to receive(:releases).and_return([""])
       allow(provider).to receive(:get_tag).and_return("v0.0.0")
+      expect(File).to receive(:exist?).with("test/foo.bar").and_return(true)
+      expect(File).to receive(:exist?).with("bar.txt").and_return(true)
       expect(File).to receive(:file?).with("test/foo.bar").and_return(true)
       expect(File).to receive(:file?).with("bar.txt").and_return(true)
 
@@ -197,7 +201,7 @@ describe DPL::Provider::Releases do
       allow(provider.api).to receive(:release_assets).and_return([double(:name => "foo.bar", :url => 'foo-bar-url'), double(:name => "foo.foo", :url => 'foo-foo-url')])
 
       expect(provider.api).to receive(:upload_asset).with(anything, "bar.txt", {:name=>"bar.txt", :content_type=>"text/plain"})
-      expect(provider).to receive(:log).with("foo.bar already exists, skipping.")
+      allow(provider).to receive(:log)
       expect(provider.api).to receive(:update_release).with(anything, hash_including(:draft => false))
 
       provider.push_app
@@ -211,6 +215,7 @@ describe DPL::Provider::Releases do
 
       allow(provider).to receive(:releases).and_return([""])
       allow(provider).to receive(:get_tag).and_return("v0.0.0")
+      expect(File).to receive(:exist?).with("exists.txt").and_return(true)
       expect(File).to receive(:file?).with("exists.txt").and_return(true)
 
       provider.releases.map do |release|
@@ -234,6 +239,8 @@ describe DPL::Provider::Releases do
       provider.options.update(:file => ["test/foo.bar", "bar.txt"])
 
       allow(provider).to receive(:releases).and_return([""])
+      expect(File).to receive(:exist?).with("test/foo.bar").and_return(true)
+      expect(File).to receive(:exist?).with("bar.txt").and_return(true)
       expect(File).to receive(:file?).with("test/foo.bar").and_return(true)
       expect(File).to receive(:file?).with("bar.txt").and_return(true)
 
@@ -263,6 +270,7 @@ describe DPL::Provider::Releases do
       provider.options.update(:release_number => "1234")
 
       allow(provider).to receive(:slug).and_return("foo/bar")
+      expect(File).to receive(:exist?).with("bar.txt").and_return(true)
       expect(File).to receive(:file?).with("bar.txt").and_return(true)
 
       allow(provider.api).to receive(:release_assets).and_return([])
@@ -280,6 +288,7 @@ describe DPL::Provider::Releases do
       provider.options.update(:release_number => "1234")
       provider.options.update(:draft => true)
       allow(provider).to receive(:slug).and_return("foo/bar")
+      expect(File).to receive(:exist?).with("bar.txt").and_return(true)
       expect(File).to receive(:file?).with("bar.txt").and_return(true)
 
       allow(provider.api).to receive(:release_assets).and_return([])
@@ -297,6 +306,7 @@ describe DPL::Provider::Releases do
       provider.options.update(:release_number => "1234")
       provider.options.update(:prerelease => 'true')
       allow(provider).to receive(:slug).and_return("foo/bar")
+      expect(File).to receive(:exist?).with("bar.txt").and_return(true)
       expect(File).to receive(:file?).with("bar.txt").and_return(true)
 
       allow(provider.api).to receive(:release_assets).and_return([])
@@ -315,6 +325,7 @@ describe DPL::Provider::Releases do
       provider.options.update(:prerelease => 'true')
       provider.options.update(:name => 'true')
       allow(provider).to receive(:slug).and_return("foo/bar")
+      expect(File).to receive(:exist?).with("bar.txt").and_return(true)
       expect(File).to receive(:file?).with("bar.txt").and_return(true)
 
       allow(provider.api).to receive(:release_assets).and_return([])


### PR DESCRIPTION
This PR adds to Releases:

1. Message when a file is not uploaded (Resolves #842)
1. Creates a draft release correctly when `draft: true` is passed. (Resolves #914)
