### PR TITLE
Ignore gemspec option when looking for gem file to upload

### DIFF
--- a/lib/dpl/provider/rubygems.rb
+++ b/lib/dpl/provider/rubygems.rb
@@ -38,7 +38,7 @@ module DPL
         setup_auth
         setup_gem
         context.shell "for f in #{gemspec_glob}; do gem build $f; done"
-        Dir.glob("#{gemspec || option(:gem)}-*.gem") do |f|
+        Dir.glob("#{option(:gem)}-*.gem") do |f|
           if options[:host]
             log ::Gems.push(File.new(f), options[:host])
           else

--- a/spec/provider/rubygems_spec.rb
+++ b/spec/provider/rubygems_spec.rb
@@ -65,7 +65,7 @@ describe DPL::Provider::RubyGems do
     example "with options[:gemspec]" do
       provider.options.update(:gemspec => 'blah.gemspec')
       expect(provider.context).to receive(:shell).with("for f in blah.gemspec; do gem build $f; done")
-      expect(Dir).to receive(:glob).with('blah-*.gem').and_yield('File')
+      expect(Dir).to receive(:glob).with('example-*.gem').and_yield('File')
       expect(::Gems).to receive(:push).with('Test file').and_return('Yes!')
     end
 


### PR DESCRIPTION
The `gemspec` option is for specifying the `*.gemspec` file to build the gem(s), and it should not influence the gem file to push.

Resolves #908.

To test:

```yaml
deploy:
  provider: rubygems
  edge:
    branch: rubygems-gem-detection
  ⋮ # rest
```