### PR TITLE
NPM --access flag

### DIFF
--- a/lib/dpl/provider/npm.rb
+++ b/lib/dpl/provider/npm.rb
@@ -32,6 +32,7 @@ module DPL
 
         command = "env NPM_API_KEY=#{option(:api_key)} npm publish"
         command << " --tag #{option(:tag)}" if options[:tag]
+        command << " --access #{option(:access)}" if options[:access]
         context.shell "#{command}"
         FileUtils.rm(File.expand_path(NPMRC_FILE))
       end


### PR DESCRIPTION
When you publish to a free organization account you must send `--access public` to publish your module in NPM.

**Example**:

package.json
```
...
  "name": "@my-org/my-package"
...
```

***my-org*** it's a free org account from NPM (https://www.npmjs.com/org/create)

```
npm publish .
```

**Result**: 
```
npm access restricted @my-org/my-package
```

Now
```
npm publish . --access public
```

**Result**: 
```
Done.
```

**About this**:
https://docs.npmjs.com/cli/access
https://docs.npmjs.com/cli/publish
https://docs.npmjs.com/creating-and-publishing-private-packages