### PR TITLE
Set a custom user-agent for all heroku API calls

### DIFF
--- a/gemspec_helper.rb
+++ b/gemspec_helper.rb
@@ -39,7 +39,7 @@ def gemspec_for(provider_name=nil, runtime_dependencies=[])
 
     # set up files
     if provider_name
-      s.files       = `git ls-files`.split("\n").grep(Regexp.new provider_name.to_s)
+      s.files       = `git ls-files`.split("\n").grep(Regexp.new provider_name.to_s) + ["lib/dpl/version.rb"]
       s.test_files  = `git ls-files -- {test,spec,features}/*`.split("\n").grep(Regexp.new provider_name.to_s)
     else
       s.files      = `git ls-files`.split("\n").reject {|f| f =~ Regexp.new("provider/")}

--- a/lib/dpl/provider/heroku/api.rb
+++ b/lib/dpl/provider/heroku/api.rb
@@ -26,7 +26,7 @@ module DPL
 
         def upload_archive
           log "uploading application archive"
-          context.shell "curl#{curl_options} #{Shellwords.escape(put_url)} -X PUT -H 'Content-Type:' -H 'Accept: application/vnd.heroku+json; version=3' --data-binary @#{archive_file}"
+          context.shell "curl#{curl_options} #{Shellwords.escape(put_url)} -X PUT -H 'Content-Type:' -H 'Accept: application/vnd.heroku+json; version=3' -H 'User-Agent: #{user_agent}' --data-binary @#{archive_file}"
         end
 
         def trigger_build
@@ -44,7 +44,7 @@ module DPL
           if response.success?
             @build_id  = JSON.parse(response.body)['id']
             output_stream_url = JSON.parse(response.body)['output_stream_url']
-            context.shell "curl#{curl_options} #{Shellwords.escape(output_stream_url)} -H 'Accept: application/vnd.heroku+json; version=3'"
+            context.shell "curl#{curl_options} #{Shellwords.escape(output_stream_url)} -H 'Accept: application/vnd.heroku+json; version=3' -H 'User-Agent: #{user_agent}'"
           else
             handle_error_response(response)
           end

--- a/lib/dpl/provider/heroku/generic.rb
+++ b/lib/dpl/provider/heroku/generic.rb
@@ -12,7 +12,10 @@ module DPL
 
         def faraday
           return @conn if @conn
-          headers = { "Accept" => "application/vnd.heroku+json; version=3" }
+          headers = {
+            "Accept" => "application/vnd.heroku+json; version=3",
+            "User-Agent" => user_agent,
+          }
 
           if options[:user] and options[:password]
             # no-op

--- a/spec/provider/heroku_spec.rb
+++ b/spec/provider/heroku_spec.rb
@@ -231,7 +231,7 @@ describe DPL::Provider::Heroku, :api do
       expect(provider).to receive(:faraday).at_least(:once).and_return(faraday)
       expect(provider).to receive(:get_url).and_return 'http://example.com/source.tgz'
       expect(provider).to receive(:version).and_return 'v1.3.0'
-      expect(provider.context).to receive(:shell).with("curl https://build-output.heroku.com/streams/01234567-89ab-cdef-0123-456789abcdef -H 'Accept: application/vnd.heroku+json; version=3'")
+      expect(provider.context).to receive(:shell).with("curl https://build-output.heroku.com/streams/01234567-89ab-cdef-0123-456789abcdef -H 'Accept: application/vnd.heroku+json; version=3' -H 'User-Agent: dpl/#{DPL::VERSION}'")
       provider.trigger_build
       expect(provider.build_id).to eq('01234567-89ab-cdef-0123-456789abcdef')
     end
@@ -251,7 +251,7 @@ describe DPL::Provider::Heroku, :api do
         expect(provider).to receive(:faraday).at_least(:once).and_return(faraday)
         expect(provider).to receive(:get_url).and_return 'http://example.com/source.tgz'
         expect(provider).to receive(:version).and_return 'v1.3.0'
-        expect(provider.context).to receive(:shell).with("curl -sS https://build-output.heroku.com/streams/01234567-89ab-cdef-0123-456789abcdef -H 'Accept: application/vnd.heroku+json; version=3'")
+        expect(provider.context).to receive(:shell).with("curl -sS https://build-output.heroku.com/streams/01234567-89ab-cdef-0123-456789abcdef -H 'Accept: application/vnd.heroku+json; version=3' -H 'User-Agent: dpl/#{DPL::VERSION}'")
         provider.trigger_build
         expect(provider.build_id).to eq('01234567-89ab-cdef-0123-456789abcdef')
       end


### PR DESCRIPTION
When deprecating the build result endpoint, we didn't see dpl was still using that endpoint due to the lack of custom User Agent, which led us to fix it a bit late (https://github.com/travis-ci/dpl/pull/917).

This sets a custom user agent, to prevent this kind of issue from happening again.