### PR TITLE
Add Gleis provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Dpl supports the following providers:
 * [Firebase](#firebase)
 * [Github Pages](#github-pages)
 * [Github Releases](#github-releases)
+* [Gleis](#gleis)
 * [Google App Engine (experimental)](#google-app-engine)
 * [Google Cloud Storage](#google-cloud-storage)
 * [Hackage](#hackage)
@@ -955,6 +956,22 @@ Deploys built snaps to the [snap store](https://snapcraft.io/).
 #### Examples:
 
     dpl --provider=bluemixcloudfoundry --username=<username> --password=<password> --organization=<organization> --region=<region> --space=<space> --skip-ssl-validation
+
+### Gleis:
+
+The Gleis provider uses the [Gleis CLI Ruby gem](https://rubygems.org/gems/gleis) in order to deploy your Ruby on Rails app to the Gleis cloud.
+
+#### Options:
+
+* **username**: Gleis username.
+* **password**: Gleis password.
+* **app**: Gleis application name. Defaults to git repo's name. Optional.
+* **verbose**: Be verbose about push app process. Defaults to false. Optional.
+
+#### Examples:
+
+    dpl --provider=gleis --username=<username> --password=<password>
+    dpl --provider=gleis --username=<username> --password=<password> --app=<application>
 
 ## `dpl` and `sudo`
 

--- a/dpl-gleis.gemspec
+++ b/dpl-gleis.gemspec
@@ -1,0 +1,3 @@
+require './gemspec_helper'
+
+gemspec_for 'gleis'

--- a/lib/dpl/provider.rb
+++ b/lib/dpl/provider.rb
@@ -32,6 +32,7 @@ module DPL
       'Firebase'            => 'firebase',
       'GAE'                 => 'gae',
       'GCS'                 => 'gcs',
+      'Gleis'               => 'gleis',
       'Hackage'             => 'hackage',
       'Hephy'               => 'hephy',
       'Heroku'              => 'heroku',

--- a/lib/dpl/provider/gleis.rb
+++ b/lib/dpl/provider/gleis.rb
@@ -10,7 +10,7 @@ module DPL
       end
 
       def check_auth
-        error 'Login failed' unless context.shell "gleis auth login #{option(:username)} #{option(:password)}"
+        error 'Login failed' unless context.shell "gleis auth login #{option(:username)} #{option(:password)} --skip-keygen"
       end
 
       def check_app

--- a/lib/dpl/provider/gleis.rb
+++ b/lib/dpl/provider/gleis.rb
@@ -33,7 +33,7 @@ module DPL
       def push_app
         git_url = repository_url
         error 'Git repo URL is empty' unless git_url
-        error 'Deploying application failed' unless context.shell "git push #{verbose_flag} #{git_url} HEAD:refs/heads/master"
+        error 'Deploying application failed' unless context.shell "git push #{verbose_flag} -f #{git_url} HEAD:refs/heads/master"
       end
 
       def cleanup; end

--- a/lib/dpl/provider/gleis.rb
+++ b/lib/dpl/provider/gleis.rb
@@ -1,0 +1,50 @@
+module DPL
+  class Provider
+    class Gleis < Provider
+      def install_deploy_dependencies
+        context.shell 'gem install gleis'
+      end
+
+      def needs_key?
+        true
+      end
+
+      def check_auth
+        error 'Login failed' unless context.shell "gleis auth login #{option(:username)} #{option(:password)}"
+      end
+
+      def check_app
+        error 'Application not found' unless context.shell "gleis app status -a #{option(:app)}"
+      end
+
+      def setup_key(file)
+        error 'Adding key failed' unless context.shell "gleis auth key add #{file} dpl_#{option(:key_name)}"
+      end
+
+      def remove_key
+        error 'Removing key failed' unless context.shell "gleis auth key remove dpl_#{option(:key_name)}"
+      end
+
+      def repository_url
+        error 'Failed to get git repo URL' unless context.shell "gleis app git -a #{option(:app)} -q > .dpl/git-url"
+        File.read('.dpl/git-url').chomp if File.exist?('.dpl/git-url')
+      end
+
+      def push_app
+        git_url = repository_url
+        error 'Git repo URL is empty' unless git_url
+        error 'Deploying application failed' unless context.shell "git push #{verbose_flag} #{git_url} HEAD:refs/heads/master"
+      end
+
+      def cleanup; end
+
+      def uncleanup
+        context.shell 'gleis auth logout'
+      end
+
+      def verbose_flag
+        '-v' if options[:verbose]
+      end
+    end
+  end
+end

--- a/spec/provider/gleis_spec.rb
+++ b/spec/provider/gleis_spec.rb
@@ -1,0 +1,98 @@
+require 'spec_helper'
+require 'dpl/provider/gleis'
+
+describe DPL::Provider::Gleis do
+  let(:options) do
+    {
+      app: 'sample',
+      key_name: 'key',
+      username: 'user@domain.tld',
+      password: 'secret'
+    }
+  end
+
+  subject :provider do
+    described_class.new(DummyContext.new, options)
+  end
+
+  describe "#install_deploy_dependencies" do
+    example do
+      expect(provider.context).to receive(:shell).with(
+        'gem install gleis'
+      ).and_return(true)
+      provider.install_deploy_dependencies
+    end
+  end
+
+  describe "#needs_key?" do
+    example do
+      expect(provider.needs_key?).to eq(true)
+    end
+  end
+
+  describe "#check_auth" do
+    example do
+      expect(provider.context).to receive(:shell).with(
+        'gleis auth login user@domain.tld secret'
+      ).and_return(true)
+      provider.check_auth
+    end
+  end
+
+  describe "#check_app" do
+    example do
+      expect(provider.context).to receive(:shell).with(
+        'gleis app status -a sample'
+      ).and_return(true)
+      provider.check_app
+    end
+  end
+
+  describe "#setup_key" do
+    example do
+      expect(provider.context).to receive(:shell).with(
+        'gleis auth key add key_file dpl_key'
+      ).and_return(true)
+      provider.setup_key('key_file')
+    end
+  end
+
+  describe "#remove_key" do
+    example do
+      expect(provider.context).to receive(:shell).with(
+        'gleis auth key remove dpl_key'
+      ).and_return(true)
+      provider.remove_key
+    end
+  end
+
+  describe "#push_app" do
+    before(:example) do
+      create_git_url_file('.dpl/git-url')
+    end
+
+    after(:example) do
+      delete_git_url_file('.dpl/git-url')
+    end
+
+    example do
+      expect(provider.context).to receive(:shell).with(
+        'git push  git://something HEAD:refs/heads/master'
+      ).and_return(true)
+      expect(provider.context).to receive(:shell).with(
+        "gleis app git -a #{options[:app]} -q > .dpl/git-url"
+      ).and_return(true)
+      provider.push_app
+    end
+
+    def create_git_url_file(filename)
+      File.open filename, 'w' do |file|
+        file.write('git://something')
+      end
+    end
+
+    def delete_git_url_file(filename)
+      FileUtils.rm_f filename
+    end
+  end
+end

--- a/spec/provider/gleis_spec.rb
+++ b/spec/provider/gleis_spec.rb
@@ -77,7 +77,7 @@ describe DPL::Provider::Gleis do
 
     example do
       expect(provider.context).to receive(:shell).with(
-        'git push  git://something HEAD:refs/heads/master'
+        'git push  -f git://something HEAD:refs/heads/master'
       ).and_return(true)
       expect(provider.context).to receive(:shell).with(
         "gleis app git -a #{options[:app]} -q > .dpl/git-url"

--- a/spec/provider/gleis_spec.rb
+++ b/spec/provider/gleis_spec.rb
@@ -33,7 +33,7 @@ describe DPL::Provider::Gleis do
   describe "#check_auth" do
     example do
       expect(provider.context).to receive(:shell).with(
-        'gleis auth login user@domain.tld secret'
+        'gleis auth login user@domain.tld secret --skip-keygen'
       ).and_return(true)
       provider.check_auth
     end


### PR DESCRIPTION
This PR adds a new provider for deploying Ruby on Rails apps to the https://gleis.cloud PaaS. Currently it supports the following four options:

* **username** (required): Gleis username.
* **password** (required): Gleis password.
* **app** (optional): Gleis application name. Defaults to git repo's name.
* **verbose** (optional): Be verbose about push app process. Defaults to false.

The RSpec tests are included and all pass.