### PR TITLE
Cloud Foundry Deprecation Warnings

### DIFF
--- a/spec/provider/cloud_foundry_spec.rb
+++ b/spec/provider/cloud_foundry_spec.rb
@@ -45,14 +45,14 @@ describe DPL::Provider::CloudFoundry do
   describe "#check_app" do
     context 'when the manifest file exists' do
       example do
-        File.stub(:exists?).with('worker-manifest.yml').and_return(true)
+        allow(File).to receive(:exists?).and_return(true)
         expect{provider.check_app}.not_to raise_error
       end
     end
 
     context 'when the manifest file exists' do
       example do
-        File.stub(:exists?).with('worker-manifest.yml').and_return(false)
+        allow(File).to receive(:exists?).and_return(false)
         expect{provider.check_app}.to raise_error('Application must have a manifest.yml for unattended deployment')
       end
     end


### PR DESCRIPTION
Cleans up this error from the tests.

```
Using `stub` from rspec-mocks' old `:should` syntax without explicitly enabling the syntax is deprecated. Use the new `:expect` syntax or explicitly enable `:should` instead. Called from /Users/osis/workspace/dpl/spec/provider/cloud_foundry_spec.rb:48&56:in `block (4 levels) in <top (required)>'.
```