### PR TITLE
Fixes lambda provider env var parsing

### DIFF
--- a/lib/dpl/provider/lambda.rb
+++ b/lib/dpl/provider/lambda.rb
@@ -226,7 +226,7 @@ module DPL
       def split_string_array_to_hash(arr, delimiter="=")
         variables = {}
         Array(arr).map do |val|
-          keyval = val.split(delimiter)
+          keyval = val.split(delimiter, 2)
           variables[keyval[0]] = keyval[1]
         end
         variables


### PR DESCRIPTION
Fixes small bug in aws lambda provider where base64 encoded values lose
trailing '='s. Fix is to use `limit=2` in string `split` to ensure max
two tokens extracted.

Issue: https://github.com/travis-ci/dpl/issues/942