### PR TITLE
Fixes test for multiple snaps error

### DIFF
--- a/dpl-cloud_files.gemspec
+++ b/dpl-cloud_files.gemspec
@@ -1,7 +1,3 @@
 require './gemspec_helper'
 
-if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.3.0")
-  gemspec_for 'cloud_files', [['net-ssh'], ['mime-types'], ['nokogiri', '< 1.10'], ['fog-rackspace']]
-else
-  gemspec_for 'cloud_files', [['net-ssh'], ['mime-types'], ['nokogiri'], ['fog-rackspace']]
-end
+gemspec_for 'cloud_files', [['net-ssh'], ['mime-types'], ['nokogiri'], ['fog-rackspace']]

--- a/dpl-cloud_files.gemspec
+++ b/dpl-cloud_files.gemspec
@@ -1,3 +1,7 @@
 require './gemspec_helper'
 
-gemspec_for 'cloud_files', [['net-ssh'], ['mime-types'], ['nokogiri'], ['fog-rackspace']]
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.3.0")
+  gemspec_for 'cloud_files', [['net-ssh'], ['mime-types'], ['nokogiri', '< 1.10'], ['fog-rackspace']]
+else
+  gemspec_for 'cloud_files', [['net-ssh'], ['mime-types'], ['nokogiri'], ['fog-rackspace']]
+end

--- a/spec/provider/snap_spec.rb
+++ b/spec/provider/snap_spec.rb
@@ -80,7 +80,7 @@ describe DPL::Provider::Snap do
       provider.options[:snap] = "*.snap"
       expect{provider.push_app}.to raise_error(
         DPL::Error,
-        /^Multiple snaps found matching '\*.snap': /
+        /^Multiple snaps found matching '\*.snap': /)
     end
 
     example "missing channel should default to edge" do

--- a/spec/provider/snap_spec.rb
+++ b/spec/provider/snap_spec.rb
@@ -80,7 +80,7 @@ describe DPL::Provider::Snap do
       provider.options[:snap] = "*.snap"
       expect{provider.push_app}.to raise_error(
         DPL::Error,
-        "Multiple snaps found matching '*.snap': #{Dir.glob('*.snap').join(', ')}")
+        /^Multiple snaps found matching '\*.snap': /
     end
 
     example "missing channel should default to edge" do

--- a/spec/provider/snap_spec.rb
+++ b/spec/provider/snap_spec.rb
@@ -80,7 +80,7 @@ describe DPL::Provider::Snap do
       provider.options[:snap] = "*.snap"
       expect{provider.push_app}.to raise_error(
         DPL::Error,
-        "Multiple snaps found matching '*.snap': foo.snap, bar.snap")
+        "Multiple snaps found matching '*.snap': #{Dir.glob('*.snap').join(', ')}")
     end
 
     example "missing channel should default to edge" do


### PR DESCRIPTION
Fixes test asserting a specific error is thrown when pushing multiple
snaps. Previous version of test expected a specific error message, which
assumed `Dir.glob` returned results in a specific order, which is system
dependent. ~This fix uses `Dir.glob` in the test itself.~ This fix uses regex to match the error message more flexibly.