### PR TITLE
Fix cloud_files gemspec: nokogiri <1.10 for ruby <2.3

### DIFF
--- a/dpl-cloud_files.gemspec
+++ b/dpl-cloud_files.gemspec
@@ -1,3 +1,7 @@
 require './gemspec_helper'
 
-gemspec_for 'cloud_files', [['net-ssh'], ['mime-types'], ['nokogiri'], ['fog-rackspace']]
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.3.0")
+  gemspec_for 'cloud_files', [['net-ssh'], ['mime-types'], ['nokogiri', '< 1.10'], ['fog-rackspace']]
+else
+  gemspec_for 'cloud_files', [['net-ssh'], ['mime-types'], ['nokogiri'], ['fog-rackspace']]
+end


### PR DESCRIPTION
In cloud_files gemspec, fix nokogiri to <1.10 for ruby <2.3 to accommodate dependence of Nokogiri 1.10 on ruby2.3+

Fixes: https://github.com/travis-ci/dpl/issues/946