### PR TITLE
Add force option to Firebase provider

### DIFF
--- a/lib/dpl/provider/firebase.rb
+++ b/lib/dpl/provider/firebase.rb
@@ -19,6 +19,7 @@ module DPL
         command = "firebase deploy --non-interactive"
         command << " --project #{options[:project]}" if options[:project]
         command << " --message '#{options[:message]}'" if options[:message]
+        command << " --force" if options[:force]
         command << " --token '#{options[:token]}'" if options[:token]
         context.shell command or raise Error, "Firebase deployment failed"
       end

--- a/spec/provider/firebase_spec.rb
+++ b/spec/provider/firebase_spec.rb
@@ -32,6 +32,12 @@ describe DPL::Provider::Firebase do
       provider.push_app
     end
 
+    it 'should include force if specified' do
+      provider.options.update(:force => true)
+      expect(provider.context).to receive(:shell).with("firebase deploy --non-interactive --force --token 'abc123'").and_return(true)
+      provider.push_app
+    end
+
     it 'should default to no project override' do
       expect(provider.context).to receive(:shell).with("firebase deploy --non-interactive --token 'abc123'").and_return(true)
       provider.push_app


### PR DESCRIPTION
[firebase-tools v5.1.0](https://github.com/firebase/firebase-tools/releases/tag/v5.1.0) added a `force` flag that allows deployments to delete firebase functions non-interactively.

This PR adds this option to the firebase provider.

Example of a build that fails to deploy since it can't non-interactively delete a function:
https://travis-ci.com/jgollhardt/firebase-travis-example/builds/97981380

Here's the following build after [enabling force](https://github.com/jgollhardt/firebase-travis-example/commit/b484eacca2d0fa2c625616fd04ca50a5b7e1f9fc):
https://travis-ci.com/jgollhardt/firebase-travis-example/builds/97981542
