### PR TITLE
Bintray: Automatically add artifacts to downloads list 

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,12 +151,14 @@ Running dpl in a terminal that saves history is insecure as your password/api ke
 	The files will be uploaded to Bintray under the gems folder.
 	2. All files under build/docs. The files will be uploaded to Bintray under the docs folder.
 
-	Note: Regular expressions defined as part of the includePattern property must be wrapped with brackets. */
+	Note: Regular expressions defined as part of the includePattern property must be wrapped with brackets.
+    
+    If listInDownloads is set to true matching artifact will appear in the 'Download list'. This can be done only on published version, so publish should be set to true to be taken into account. */
 
 	"files":
 		[
 		{"includePattern": "build/bin(.*)*/(.*\.gem)", "excludePattern": ".*/do-not-deploy/.*", "uploadPattern": "gems/$2"},
-		{"includePattern": "build/docs/(.*)", "uploadPattern": "docs/$1"}
+		{"includePattern": "build/docs/(.*)", "uploadPattern": "docs/$1", "listInDownloads": true}
 		],
 	"publish": true
 }

--- a/lib/dpl/provider/bintray.rb
+++ b/lib/dpl/provider/bintray.rb
@@ -466,7 +466,8 @@ module DPL
           code = res.code.to_i
 
           # Sometimes it makes time for the version to be published so retry it
-          if code == 400 && tries < 4
+          if code == 400 && tries < 400
+            log "Bintray error let's retry in few seconds"
             sleep 1
             redo
           end

--- a/lib/dpl/provider/bintray.rb
+++ b/lib/dpl/provider/bintray.rb
@@ -465,12 +465,13 @@ module DPL
           log_bintray_response(res)
           code = res.code.to_i
 
-          # Sometimes it makes time for the version to be published so retry it
-          if code == 400 && tries < 400
-            log "Bintray error let's retry in few seconds"
-            sleep 1
-            redo
-          end
+          next if code < 400
+          # It makes time for the version to be published so retry it
+          raise "Failed to list artifact #{artifact.upload_path} in download list" if tries > 10
+
+          log "Bintray Bad Request error. It may take some time for a version to be published, let's retry in few seconds..."
+          sleep 6
+          redo
         end
       end
 

--- a/spec/provider/bintray_spec.rb
+++ b/spec/provider/bintray_spec.rb
@@ -194,17 +194,19 @@ describe DPL::Provider::Bintray do
           'p2' => 'b'
       }
 
-      provider.add_if_matches(files_to_upload, 'build/files/a.gem', 'build/files/(.*.gem)', 'exclude', 'a/b/$1', nil)
-      provider.add_if_matches(files_to_upload, 'build/files/b.gem', 'build/files/(.*.gem)', nil, 'a/b/$1', matrix_params)
-      provider.add_if_matches(files_to_upload, 'build/files/c.gem', 'build/files/(.*.gem)', '.*files.*', 'a/b/$1', nil)
-      provider.add_if_matches(files_to_upload, 'build/files/c.txt', 'build/files/(.*.gem)', 'exclude', 'a/b/$1', nil)
+      provider.add_if_matches(files_to_upload, 'build/files/a.gem', 'build/files/(.*.gem)', 'exclude', 'a/b/$1', false, nil)
+      provider.add_if_matches(files_to_upload, 'build/files/b.gem', 'build/files/(.*.gem)', nil, 'a/b/$1', true, matrix_params)
+      provider.add_if_matches(files_to_upload, 'build/files/c.gem', 'build/files/(.*.gem)', '.*files.*', 'a/b/$1', true, nil)
+      provider.add_if_matches(files_to_upload, 'build/files/c.txt', 'build/files/(.*.gem)', 'exclude', 'a/b/$1', false, nil)
 
       expect(files_to_upload["build/files/a.gem"]).not_to eq(nil)
       expect(files_to_upload["build/files/a.gem"].upload_path).to eq('a/b/a.gem')
+      expect(files_to_upload["build/files/a.gem"].list_in_downloads).to eq(false)
       expect(files_to_upload["build/files/a.gem"].matrix_params).to eq(nil)
 
       expect(files_to_upload["build/files/b.gem"]).not_to eq(nil)
       expect(files_to_upload["build/files/b.gem"].upload_path).to eq('a/b/b.gem')
+      expect(files_to_upload["build/files/b.gem"].list_in_downloads).to eq(true)
       expect(files_to_upload["build/files/b.gem"].matrix_params).to eq(matrix_params)
 
       expect(files_to_upload["build/files/c.gem"]).to eq(nil)


### PR DESCRIPTION
This PR fixes #944 
The idea is to allow files in the Bintray file descriptor to be tagged as they should appear in the download list. This way we can select some files to appear in this list and some not (disabled by default).

The tricky part here is that a version should be published before selecting artifacts to appear in the download list. So this feature is disabled if the `publish` is not set to `true` in the file descriptor.
Linked to the publication another trick is while the API responds instantaneously OK to a version publication it takes actually some time (up to 15s in my tests) to be effective. So I had to implement a retry mechanism.

Tested in real conditions using this bintray account: https://bintray.com/beta/#/loicalbertin/dpl-test/auto-upload/
And this Github project https://github.com/loicalbertin/travis-dpl-bintray-test
travis: https://travis-ci.org/loicalbertin/travis-dpl-bintray-test

I updated the bintray file descriptor in README to document this feature.

Please feel free to adapt/tweak retry parameters.