### PR TITLE
Fixed file-specific Cache-Control and Expires headers in S3 provider

### DIFF
--- a/lib/dpl/provider/s3.rb
+++ b/lib/dpl/provider/s3.rb
@@ -149,22 +149,18 @@ module DPL
       end
 
       def get_option_value_by_filename(option_values, filename)
-        return option_values if !option_values.kind_of?(Array)
+        options = option_values.split(": ")
+
+        file = (options[1]).split(',').map(&:strip)
+        value = options[0].gsub(/"/, "")
+
         preferred_value = nil
-        hashes = option_values.select {|value| value.kind_of?(Hash) }
-        hashes.each do |hash|
-          hash.each do |value, patterns|
-            unless patterns.kind_of?(Array)
-              patterns = [patterns]
-            end
-            patterns.each do |pattern|
-              if File.fnmatch?(pattern, filename)
-                preferred_value = value
-              end
-            end
+        file.each do |pattern|
+          if File.fnmatch?(pattern, filename)
+            preferred_value = value
           end
         end
-        preferred_value = option_values.select {|value| value.kind_of?(String) }.last if preferred_value.nil?
+
         return preferred_value
       end
     end

--- a/lib/dpl/provider/s3.rb
+++ b/lib/dpl/provider/s3.rb
@@ -149,23 +149,23 @@ module DPL
       end
 
       def get_option_value_by_filename(option_values, filename)
-        return option_values if !option_values.include? ": "
-        options = option_values.split(/,(?=(?:[^'"]|'[^']*'|"[^"]*")*$)/)
+        return option_values if !option_values.include? ": "                # Includes only default assignment, "cache_control: max-age=99999999"
+        options = option_values.split(/,(?=(?:[^'"]|'[^']*'|"[^"]*")*$)/)   # Respect quoted values, e.g. "cache_control: "\"public, max-age=31536000\": *.jpg"
 
-        valueChain = 0
+        defaultValue = 1
         value = ""
         dict = Hash.new
 
-        options.each do |opt|
+        options.each do |opt|                                               # Iterate through comma-separated list
           if !opt.include? ": "
-              if valueChain == 0
-                dict["*"] = opt.gsub(/"/, "")
+              if defaultValue == 1
+                dict["*"] = opt.gsub(/"/, "")                               # Identified the default value, e.g. "max-age=99999999, ..."
               else
-                dict[opt.strip] = value.strip.gsub(/"/, "")
+                dict[opt.strip] = value.strip.gsub(/"/, "")                 # Additional file patterns in a value-chain, e.g. "..., bar.txt, ..."
               end
           else
-            valueChain = 1
-            value = opt.split(": ")[0]
+            defaultValue = 0
+            value = opt.split(": ")[0]                                      # Beginning of a value-chain, e.g. "no-cache: foo.html, ..."
             dict[opt.split(": ")[1]] = value.strip.gsub(/"/, "")
           end
         end

--- a/lib/dpl/provider/s3.rb
+++ b/lib/dpl/provider/s3.rb
@@ -150,7 +150,7 @@ module DPL
 
       def get_option_value_by_filename(option_values, filename)
         return option_values if !option_values.include? ": "
-        options = option_values.split(",")
+        options = option_values.split(/,(?=(?:[^'"]|'[^']*'|"[^"]*")*$)/)
 
         valueChain = 0
         value = ""

--- a/lib/dpl/provider/s3.rb
+++ b/lib/dpl/provider/s3.rb
@@ -149,6 +149,7 @@ module DPL
       end
 
       def get_option_value_by_filename(option_values, filename)
+        return option_values if !option_values.include? ": "
         options = option_values.split(": ")
 
         file = (options[1]).split(',').map(&:strip)

--- a/lib/dpl/provider/s3.rb
+++ b/lib/dpl/provider/s3.rb
@@ -150,14 +150,29 @@ module DPL
 
       def get_option_value_by_filename(option_values, filename)
         return option_values if !option_values.include? ": "
-        options = option_values.split(": ")
+        options = option_values.split(",")
 
-        file = (options[1]).split(',').map(&:strip)
-        value = options[0].gsub(/"/, "")
+        valueChain = 0
+        value = ""
+        dict = Hash.new
+
+        options.each do |opt|
+          if !opt.include? ": "
+              if valueChain == 0
+                dict["*"] = opt.gsub(/"/, "")
+              else
+                dict[opt.strip] = value.strip.gsub(/"/, "")
+              end
+          else
+            valueChain = 1
+            value = opt.split(": ")[0]
+            dict[opt.split(": ")[1]] = value.strip.gsub(/"/, "")
+          end
+        end
 
         preferred_value = nil
-        file.each do |pattern|
-          if File.fnmatch?(pattern, filename)
+        dict.each do |name, value|
+          if File.fnmatch?(name, filename)
             preferred_value = value
           end
         end

--- a/spec/provider/s3_spec.rb
+++ b/spec/provider/s3_spec.rb
@@ -124,7 +124,7 @@ describe DPL::Provider::S3 do
 
     example "Sets different Cache and Expiration" do
       option_list = []
-      provider.options.update(:cache_control => ["max-age=99999999", "no-cache" => ["foo.html", "bar.txt"], "max-age=9999" => "*.txt"], :expires => ["2012-12-21 00:00:00 -0000", "1970-01-01 00:00:00 -0000" => "*.html"])
+      provider.options.update(:cache_control => "max-age=99999999, no-cache: foo.html, bar.txt, max-age=9999: *.txt", :expires => "\"2012-12-21 00:00:00 -0000\", \"1970-01-01 00:00:00 -0000\": *.html")
       expect(Dir).to receive(:glob).and_return(%w(foo.html bar.txt baz.js))
       allow_any_instance_of(Aws::S3::Object).to receive(:upload_file) do |obj, _data, options|
         option_list << { key: obj.key, options: options }


### PR DESCRIPTION
Fixed setting of file-specific Cache-Control and Expires headers using value: file[, file] format in S3 provider. 
Now supports: 
--cache_control="no-cache: index.html"
--expires="\"2012-12-21 00:00:00 -0000\": *.css, *.js"

This should address issue #486