### PR TITLE
add --only option to firebase deploy

### DIFF
--- a/lib/dpl/provider/firebase.rb
+++ b/lib/dpl/provider/firebase.rb
@@ -18,6 +18,7 @@ module DPL
       def push_app
         command = "firebase deploy --non-interactive"
         command << " --project #{options[:project]}" if options[:project]
+        command << " --only '#{options[:only]}'" if options[:only]
         command << " --message '#{options[:message]}'" if options[:message]
         command << " --token '#{options[:token]}'" if options[:token]
         context.shell command or raise Error, "Firebase deployment failed"

--- a/spec/provider/firebase_spec.rb
+++ b/spec/provider/firebase_spec.rb
@@ -32,6 +32,12 @@ describe DPL::Provider::Firebase do
       provider.push_app
     end
 
+    it 'should include only condition specified' do
+      provider.options.update(:only => 'hosting:target')
+      expect(provider.context).to receive(:shell).with("firebase deploy --non-interactive --only 'hosting:target' --token 'abc123'").and_return(true)
+      provider.push_app
+    end
+
     it 'should default to no project override' do
       expect(provider.context).to receive(:shell).with("firebase deploy --non-interactive --token 'abc123'").and_return(true)
       provider.push_app


### PR DESCRIPTION
Firebase allows deploying multiple sites to one firebase project. This option is missing in Travis

https://firebase.google.com/docs/hosting/multisites

`firebase deploy --only hosting:target-name`