### PR TITLE
Send only processable keys to GitHub Releases API

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,10 +535,16 @@ You first need to create an [Atlas account](https://atlas.hashicorp.com/account/
 * **file_glob**: If files should be interpreted as globs (\* and \*\* wildcards). Defaults to false.
 * **overwrite**: If files with the same name should be overwritten. Defaults to false.
 * **release-number**: Overide automatic release detection, set a release manually.
-* **prerelease**: Identify the release as a prerelease.
 
-Additionally, options can be passed to [Octokit](https://github.com/octokit/octokit.rb) client.
+The following flags can be passed to [Octokit](https://github.com/octokit/octokit.rb) client.
 These are documented in https://github.com/octokit/octokit.rb/blob/master/lib/octokit/client/releases.rb.
+
+* **tag_name**: Override the tag name.
+* **target_commitish**: Override the commit associated with the release.
+* **name**: Name of the release.
+* **body**: Release body text. Formatting is not preserved.
+* **draft**: Boolean. Whether or not the release is a draft. Defaults to `false`.
+* **prerelease**: Identify the release as a prerelease. Defaults to `false`.
 
 #### GitHub Two Factor Authentication
 

--- a/lib/dpl/provider/releases.rb
+++ b/lib/dpl/provider/releases.rb
@@ -11,6 +11,16 @@ module DPL
         prerelease
       )
 
+      GITHUB_API_RELEASE_KEYS = %i(
+        tag_name
+        target_commitish
+        name
+        body
+        draft
+        prerelease
+        label
+      )
+
       def self.new(context, options)
         super(context, options.merge!({needs_git_http_user_agent: false}))
       end
@@ -151,7 +161,7 @@ module DPL
           options[:target_commitish] = sha.tap {|commitish| log "Setting target_commitish to #{commitish}"}
         end
 
-        api.update_release(release_url, {:draft => false}.merge(options))
+        api.update_release(release_url, {:draft => false}.merge(filter_options(options)))
       end
 
       def upload_file(file, filename, release_url)
@@ -182,6 +192,10 @@ module DPL
             v
           end
         end
+      end
+
+      def filter_options(options)
+        options.slice(*GITHUB_API_RELEASE_KEYS)
       end
     end
   end

--- a/lib/dpl/provider/releases.rb
+++ b/lib/dpl/provider/releases.rb
@@ -195,7 +195,9 @@ module DPL
       end
 
       def filter_options(options)
-        options.slice(*GITHUB_API_RELEASE_KEYS)
+        options.dup.delete_if do |k,v|
+          ! GITHUB_API_RELEASE_KEYS.include? k
+        end
       end
     end
   end

--- a/lib/dpl/provider/releases.rb
+++ b/lib/dpl/provider/releases.rb
@@ -18,7 +18,6 @@ module DPL
         body
         draft
         prerelease
-        label
       )
 
       def self.new(context, options)

--- a/lib/dpl/provider/releases.rb
+++ b/lib/dpl/provider/releases.rb
@@ -122,7 +122,7 @@ module DPL
 
         #If for some reason GitHub hasn't already created a release for the tag, create one
         if tag_matched == false
-          release_url = api.create_release(slug, get_tag, options.merge({:draft => true})).rels[:self].href
+          release_url = api.create_release(slug, get_tag, filter_options(options.merge({:draft => true}))).rels[:self].href
         end
 
         files.each do |file|

--- a/spec/provider/releases_spec.rb
+++ b/spec/provider/releases_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 require 'dpl/provider/releases'
 require 'octokit'
 
+RSpec::Matchers.define_negated_matcher :excluding, :include
+
 describe DPL::Provider::Releases do
   subject :provider do
     described_class.new(DummyContext.new, :api_key => '0123445789qwertyuiop0123445789qwertyuiop', :file => 'blah.txt')
@@ -175,7 +177,7 @@ describe DPL::Provider::Releases do
 
       expect(provider.api).to receive(:upload_asset).with(anything, "test/foo.bar", {:name=>"foo.bar", :content_type=>"application/octet-stream"})
       expect(provider.api).to receive(:upload_asset).with(anything, "bar.txt", {:name=>"bar.txt", :content_type=>"text/plain"})
-      expect(provider.api).to receive(:update_release).with(anything, hash_including(:draft => false))
+      expect(provider.api).to receive(:update_release).with(anything, a_hash_including(:draft => false).and(excluding(:file => ["test/foo.bar", "bar.txt"])))
 
       provider.push_app
     end
@@ -202,7 +204,7 @@ describe DPL::Provider::Releases do
 
       expect(provider.api).to receive(:upload_asset).with(anything, "bar.txt", {:name=>"bar.txt", :content_type=>"text/plain"})
       allow(provider).to receive(:log)
-      expect(provider.api).to receive(:update_release).with(anything, hash_including(:draft => false))
+      expect(provider.api).to receive(:update_release).with(anything, a_hash_including(:draft => false).and(excluding(:file => ["test/foo.bar", "bar.txt"])))
 
       provider.push_app
     end
@@ -228,7 +230,7 @@ describe DPL::Provider::Releases do
 
       expect(provider.api).to receive(:delete_release_asset).with("release-url").and_return(true)
       expect(provider.api).to receive(:upload_asset).with(anything, "exists.txt", {:name=>"exists.txt", :content_type=>"text/plain"})
-      expect(provider.api).to receive(:update_release).with(anything, hash_including(:draft => false))
+      expect(provider.api).to receive(:update_release).with(anything, a_hash_including(:draft => false).and(excluding(:file => ["exists.txt"])))
 
       provider.push_app
     end
@@ -258,7 +260,7 @@ describe DPL::Provider::Releases do
 
       expect(provider.api).to receive(:upload_asset).with(anything, "test/foo.bar", {:name=>"foo.bar", :content_type=>"application/octet-stream"})
       expect(provider.api).to receive(:upload_asset).with(anything, "bar.txt", {:name=>"bar.txt", :content_type=>"text/plain"})
-      expect(provider.api).to receive(:update_release).with(anything, hash_including(:draft => false))
+      expect(provider.api).to receive(:update_release).with(anything, a_hash_including(:draft => false).and(excluding(:file => ["test/foo.bar", "bar.txt"])))
 
       provider.push_app
     end
@@ -276,7 +278,7 @@ describe DPL::Provider::Releases do
       allow(provider.api).to receive(:release_assets).and_return([])
 
       expect(provider.api).to receive(:upload_asset).with("https://api.github.com/repos/foo/bar/releases/1234", "bar.txt", {:name=>"bar.txt", :content_type=>"text/plain"})
-      expect(provider.api).to receive(:update_release).with(anything, hash_including(:draft => false))
+      expect(provider.api).to receive(:update_release).with(anything, a_hash_including(:draft => false).and(excluding(:file => ["bar.txt"])))
 
       provider.push_app
     end
@@ -294,7 +296,7 @@ describe DPL::Provider::Releases do
       allow(provider.api).to receive(:release_assets).and_return([])
 
       expect(provider.api).to receive(:upload_asset).with("https://api.github.com/repos/foo/bar/releases/1234", "bar.txt", {:name=>"bar.txt", :content_type=>"text/plain"})
-      expect(provider.api).to receive(:update_release).with(anything, hash_including(:draft => true))
+      expect(provider.api).to receive(:update_release).with(anything, a_hash_including(:draft => true).and(excluding(:file => ["bar.txt"])))
 
       provider.push_app
     end
@@ -312,7 +314,7 @@ describe DPL::Provider::Releases do
       allow(provider.api).to receive(:release_assets).and_return([])
 
       expect(provider.api).to receive(:upload_asset).with("https://api.github.com/repos/foo/bar/releases/1234", "bar.txt", {:name=>"bar.txt", :content_type=>"text/plain"})
-      expect(provider.api).to receive(:update_release).with(anything, hash_including(:prerelease => true))
+      expect(provider.api).to receive(:update_release).with(anything, a_hash_including(:prerelease => true).and(excluding(:file => ["bar.txt"])))
 
       provider.push_app
     end
@@ -331,7 +333,7 @@ describe DPL::Provider::Releases do
       allow(provider.api).to receive(:release_assets).and_return([])
 
       expect(provider.api).to receive(:upload_asset).with("https://api.github.com/repos/foo/bar/releases/1234", "bar.txt", {:name=>"bar.txt", :content_type=>"text/plain"})
-      expect(provider.api).to receive(:update_release).with(anything, hash_including(:prerelease => true, :name => 'true'))
+      expect(provider.api).to receive(:update_release).with(anything, a_hash_including(:prerelease => true, :name => 'true').and(excluding(:file => ["bar.txt"])))
 
       provider.push_app
     end


### PR DESCRIPTION
GitHub Releases API may reject requests with

    422 - Invalid request. (Octokit::UnprocessableEntity)
    "api_key", "app", "file", "fold", "key_name", 
    "needs_git_http_user_agent", "provider", "script", "skip_cleanup" are 
    not permitted keys.

if it receives extra parameters.

This PR therefore restricts the filter the options passed to GitHub Releases API to the defined list:

* `tag_name`
* `target_commitish`
* `name`
* `body`
* `draft` (boolean)
* `prerelease` (boolean)