### PR TITLE
Allow cookbook name to come from metadata.rb

### DIFF
--- a/lib/dpl/provider/chef_supermarket.rb
+++ b/lib/dpl/provider/chef_supermarket.rb
@@ -1,4 +1,5 @@
 require 'chef'
+require 'chef/cookbook/metadata'
 
 module DPL
   class Provider
@@ -20,8 +21,16 @@ module DPL
         error "#{options[:client_key]} does not exist" unless ::File.exist?(options[:client_key])
       end
 
+      def cookbook_metadata
+        # credit: https://coderwall.com/p/wwt0sw/easiest-way-to-parse-a-cookbook-s-metadata-file
+        metadata_file = 'metadata.rb'
+        # read in metadata
+        @metadata = Chef::Cookbook::Metadata.new
+        @metadata.from_file(metadata_file)
+      end
+
       def check_app
-        @cookbook_name = options[:cookbook_name] || options[:app]
+        @cookbook_name = options[:cookbook_name] || options[:app] || @metadata.name
         @cookbook_category = options[:cookbook_category]
         unless cookbook_category
           error "Missing cookbook_category option\n" +


### PR DESCRIPTION
Added a `cookbook_metadata` function that returns a `@metadata` instance variable that will contain any data that is part of the chef cookbook metadata spec.

This remains backwards compatible and will use the following priority: `options[:cookbook_name]` -> `options[:app]` -> Local `metadata.rb` name value.

Motivated by: https://travis-ci.org/Netuitive/chef-netuitive/jobs/505025901#L1176

I did not add a test for it as the logic is pretty straightforward but if you want I can write one though I may need some pointers on testing.

Here is a quick test with irb:
```ruby
$ irb
irb(main):> require 'chef/cookbook/metadata'
=> true

irb(main):> @metadata = Chef::Cookbook::Metadata.new
=> #<Chef::Cookbook::Metadata:0x005639f19aafe8 @name=nil, @description="", @long_description="", @license="All rights reserved", @maintainer="", @maintainer_email="", @platforms={}, @dependencies={}, @providing={}, @attributes={}, @recipes={}, @version=0.0.0, @source_url="", @issues_url="", @privacy=false, @chef_versions=[], @ohai_versions=[], @gems=[], @errors=[]>

irb(main):> metadata_file = '/home/<REDACTED>/projects/personal/chef-netuitive/metadata.rb'
=> "/home/<REDACTED>/projects/personal/chef-netuitive/metadata.rb"

irb(main):> @metadata.from_file(metadata_file)
=> ["ubuntu", "debian", "centos", "redhat"]

irb(main):> @metadata
=> #<Chef::Cookbook::Metadata:0x005639f19aafe8 @name="netuitive", @description="Installs/Configures netuitive", @long_description="Installs/Configures netuitive", @license="MIT", @maintainer="Ben Abrams", @maintainer_email="me@benabrams.it", @platforms={"ubuntu"=>">= 0.0.0", "debian"=>">= 0.0.0", "centos"=>">= 0.0.0", "redhat"=>">= 0.0.0"}, @dependencies={"apt"=>">= 0.0.0", "yum"=>">= 0.0.0"}, @providing={}, @attributes={}, @recipes={}, @version=0.21.0, @source_url="https://github.com/Netuitive/chef-netuitive", @issues_url="https://github.com/Netuitive/chef-netuitive/issues", @privacy=false, @chef_versions=[<Gem::Dependency type=:runtime name="chef" requirements=">= 12.5">, <Gem::Dependency type=:runtime name="chef" requirements=">= 12.5">], @ohai_versions=[], @gems=[], @errors=[], @source_file="/home/<REDACTED>/projects/personal/chef-netuitive/metadata.rb", @validation_message={}>

irb(main):> @metadata.name
=> "netuitive"

```

Signed-off-by: Ben Abrams <me@benabrams.it>