### PR TITLE
Require Chef's libraries

### DIFF
--- a/dpl-chef_supermarket.gemspec
+++ b/dpl-chef_supermarket.gemspec
@@ -1,10 +1,9 @@
 require './gemspec_helper'
 
 if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.3.0")
-    gemspec_for 'chef_supermarket', [['rack'], ['mime-types'], ['net-telnet', '~> 0.1.0'], ['chef', '~> 12.0']]
+    gemspec_for 'chef_supermarket', [['rack'], ['mime-types'], ['net-telnet', '~> 0.1.0'], ['chef', '~> 12.0'], ['openssl']]
 elsif Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.4.0")
-  gemspec_for 'chef_supermarket', [['rack'], ['mime-types'], ['chef', '~> 13.0']]
+  gemspec_for 'chef_supermarket', [['rack'], ['mime-types'], ['chef', '~> 13.0'], ['openssl']]
 else
-  gemspec_for 'chef_supermarket', [['rack'], ['mime-types'], ['chef', '>= 14']]
+  gemspec_for 'chef_supermarket', [['rack'], ['mime-types'], ['chef', '>= 14'], ['openssl']]
 end
-

--- a/dpl-chef_supermarket.gemspec
+++ b/dpl-chef_supermarket.gemspec
@@ -3,16 +3,15 @@ require './gemspec_helper'
 deps = [
   ['rack'],
   ['mime-types'],
-  ['openssl']
 ]
 
 if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.3.0")
     deps << ['net-telnet', '~> 0.1.0'] << ['chef', '~> 12.0'] << ['public_suffix', '< 3.1.0']
     gemspec_for 'chef_supermarket', deps
 elsif Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.4.0")
-  gemspec_for 'chef_supermarket', (deps << ['chef', '~> 13.0'])
+  gemspec_for 'chef_supermarket', (deps << ['chef', '~> 13.0'] << ['openssl'])
 elsif Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.5.0")
-  gemspec_for 'chef_supermarket', (deps << ['chef', '~> 14.0'])
+  gemspec_for 'chef_supermarket', (deps << ['chef', '~> 14.0'] << ['openssl'])
 else
-  gemspec_for 'chef_supermarket', (deps << ['chef', '>= 14'])
+  gemspec_for 'chef_supermarket', (deps << ['chef', '>= 14'] << ['openssl'])
 end

--- a/lib/dpl/provider/chef_supermarket.rb
+++ b/lib/dpl/provider/chef_supermarket.rb
@@ -1,4 +1,8 @@
 require 'chef'
+require 'chef/config'
+require 'chef/cookbook_loader'
+require 'chef/cookbook_uploader'
+require 'chef/cookbook_site_streaming_uploader'
 
 module DPL
   class Provider

--- a/lib/dpl/provider/chef_supermarket.rb
+++ b/lib/dpl/provider/chef_supermarket.rb
@@ -37,7 +37,7 @@ module DPL
         # So we assume cookbook path is '..'
         cl = ::Chef::CookbookLoader.new '..'
         @cookbook = cl[cookbook_name]
-        cl.validate_cookbooks
+        ::Chef::CookbookUploader.new(cookbook).validate_cookbooks
       end
 
       def push_app

--- a/lib/dpl/provider/chef_supermarket.rb
+++ b/lib/dpl/provider/chef_supermarket.rb
@@ -37,7 +37,7 @@ module DPL
         # So we assume cookbook path is '..'
         cl = ::Chef::CookbookLoader.new '..'
         @cookbook = cl[cookbook_name]
-        ::Chef::CookbookUploader.new(cookbook, '..').validate_cookbooks
+        cl.validate_cookbooks
       end
 
       def push_app

--- a/spec/provider/chef_supermarket_spec.rb
+++ b/spec/provider/chef_supermarket_spec.rb
@@ -1,7 +1,4 @@
 require 'spec_helper'
-require 'chef/cookbook_loader'
-require 'chef/cookbook_uploader'
-require 'chef/cookbook_site_streaming_uploader'
 require 'dpl/provider/chef_supermarket'
 
 describe DPL::Provider::ChefSupermarket do


### PR DESCRIPTION
Resolves https://github.com/travis-ci/dpl/issues/969

The issue described in #969 should have been present ever since version 1.9.0 (March 8, 2018), but was not reported until very recently. This PR fixes it by `require`ing appropriate files.

(Specs did not catch this error, because the spec file explicitly `require`d indirect dependencies.)