### PR TITLE
Upgrade mime-types gem

### DIFF
--- a/dpl-gcs.gemspec
+++ b/dpl-gcs.gemspec
@@ -1,3 +1,3 @@
 require './gemspec_helper'
 
-gemspec_for 'gcs', [['gstore'], ['mime-types', '~> 2.0']]
+gemspec_for 'gcs', [['gstore'], ['mime-types', '~> 3.0']]

--- a/dpl-releases.gemspec
+++ b/dpl-releases.gemspec
@@ -1,3 +1,3 @@
 require './gemspec_helper'
 
-gemspec_for 'releases', [['octokit', '~> 4.6.2'], ['mime-types', '~> 2.0']]
+gemspec_for 'releases', [['octokit', '~> 4.6.2'], ['mime-types', '~> 3.0']]

--- a/dpl-s3.gemspec
+++ b/dpl-s3.gemspec
@@ -1,3 +1,3 @@
 require './gemspec_helper'
 
-gemspec_for 's3', [['aws-sdk', '~> 2.0'], ['mime-types', '~> 2.0']]
+gemspec_for 's3', [['aws-sdk', '~> 2.0'], ['mime-types', '~> 3.0']]


### PR DESCRIPTION
The Github Releases, AWS S3, and Google Cloud Storage providers use the mime-types gem 2.x. This PR changes them to use mime-types gem 3.x.

The mime-types gem 2.x was no longer supported as of 2017-11-21. 

This means that new mime-types added in mime-types 3.x are not being uploaded with the correct Content-Type.

This solves my particular problem of webassembly files not having the correct Content-Type on AWS S3, but hopefully it makes life a little easier for other users too at some point.

`rake spec-releases spec-gcs spec-s3` shows no failures, and I have a working deployment using my fork: https://travis-ci.com/jonstites/game_of_life/jobs/191123300

