### PR TITLE
Add overwrite option for S3.

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,7 @@ This _overrides_ the `gemspec` option.
 * **index_document_suffix**: Set the index document of a S3 website.
 * **default_text_charset**: Set the default character set to append to the content-type of text files you are uploading.
 * **max_threads**: The number of threads to use for S3 file uploads. Default is 5, and the absolute maximum is 15.
+* **overwrite**: When set to `false`, it will skip uploading the files that already exists on the S3 bucket. Defaults to `true`
 
 #### File-specific `Cache-Control` and `Expires` headers
 

--- a/lib/dpl/provider/s3.rb
+++ b/lib/dpl/provider/s3.rb
@@ -103,7 +103,7 @@ module DPL
               filename = files.pop rescue nil
               next unless filename
 
-              if !options[:overwrite] && api.bucket(option(:bucket)).object(upload_path(filename)).exists?
+              if !!options[:overwrite] && api.bucket(option(:bucket)).object(upload_path(filename)).exists?
                 log "skipping #{filename.inspect}, already exists on s3"
                 next
               end

--- a/lib/dpl/provider/s3.rb
+++ b/lib/dpl/provider/s3.rb
@@ -26,7 +26,7 @@ module DPL
 
       def check_app
       end
-      
+
       def needs_key?
         false
       end
@@ -102,6 +102,11 @@ module DPL
               end
               filename = files.pop rescue nil
               next unless filename
+
+              if !options[:overwrite] && api.bucket(option(:bucket)).object(upload_path(filename)).exists?
+                log "skipping #{filename.inspect}, already exists on s3"
+                next
+              end
 
               opts  = content_data_for(filename)
               opts[:cache_control]          = get_option_value_by_filename(options[:cache_control], filename) if options[:cache_control]


### PR DESCRIPTION
Skips uploading an existing file when set to `false`.

I find it too redundant to keep re-uploading all the files that aren't
change. This was useful for situations like Rail's assets where
filenames have hash.