### PR TITLE
Copy GitHub Pages symbolic links

### DIFF
--- a/lib/dpl/provider/pages.rb
+++ b/lib/dpl/provider/pages.rb
@@ -196,7 +196,7 @@ module DPL
 
             FileUtils.cd(workdir, :verbose => true) do
               print_step "Copying #{@build_dir} contents to #{workdir} (workdir: #{Dir.pwd})..."
-              context.shell "rsync -r --exclude .git --delete '#{@build_dir}/' '#{workdir}'" or error "Could not copy #{@build_dir}."
+              context.shell "rsync -rl --exclude .git --delete '#{@build_dir}/' '#{workdir}'" or error "Could not copy #{@build_dir}."
 
               github_configure
               github_commit


### PR DESCRIPTION
Instead ignoring symbolic links while deploying to GitHub Pages, the PR proposes to include symbolic links on deploy, which particularly benefit builds that bypasses Jekyll via `.nojekyll`.