### PR TITLE
Resolve `public_suffix` and `ohai` dependency

### DIFF
--- a/dpl-chef_supermarket.gemspec
+++ b/dpl-chef_supermarket.gemspec
@@ -1,10 +1,9 @@
 require './gemspec_helper'
 
 if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.3.0")
-    gemspec_for 'chef_supermarket', [['rack'], ['mime-types'], ['net-telnet', '~> 0.1.0'], ['chef', '~> 12.0']]
+    gemspec_for 'chef_supermarket', [['rack'], ['mime-types'], ['net-telnet', '~> 0.1.0'], ['chef', '~> 12.0'], ['public_suffix', '< 3.1.0']]
 elsif Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.4.0")
-  gemspec_for 'chef_supermarket', [['rack'], ['mime-types'], ['chef', '~> 13.0']]
+  gemspec_for 'chef_supermarket', [['rack'], ['mime-types'], ['chef', '~> 13.0'], ['public_suffix', '< 3.1.0']]
 else
-  gemspec_for 'chef_supermarket', [['rack'], ['mime-types'], ['chef', '>= 14']]
+  gemspec_for 'chef_supermarket', [['rack'], ['mime-types'], ['chef', '>= 14'], ['public_suffix', '< 3.1.0']]
 end
-

--- a/dpl-chef_supermarket.gemspec
+++ b/dpl-chef_supermarket.gemspec
@@ -3,7 +3,7 @@ require './gemspec_helper'
 if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.3.0")
     gemspec_for 'chef_supermarket', [['rack'], ['mime-types'], ['net-telnet', '~> 0.1.0'], ['chef', '~> 12.0'], ['public_suffix', '< 3.1.0']]
 elsif Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.4.0")
-  gemspec_for 'chef_supermarket', [['rack'], ['mime-types'], ['chef', '~> 13.0'], ['public_suffix', '< 3.1.0']]
+  gemspec_for 'chef_supermarket', [['rack'], ['mime-types'], ['chef', '~> 13.0'], ['public_suffix', '< 3.1.0'], ['ohai', '~> 13.0']]
 else
   gemspec_for 'chef_supermarket', [['rack'], ['mime-types'], ['chef', '>= 14'], ['public_suffix', '< 3.1.0']]
 end

--- a/dpl-chef_supermarket.gemspec
+++ b/dpl-chef_supermarket.gemspec
@@ -1,9 +1,17 @@
 require './gemspec_helper'
 
+deps = [
+  ['rack'],
+  ['mime-types'],
+  ['public_suffix', '< 3.1.0'],
+  ['ohai', '~> 13.0'],
+]
+
 if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.3.0")
-    gemspec_for 'chef_supermarket', [['rack'], ['mime-types'], ['net-telnet', '~> 0.1.0'], ['chef', '~> 12.0'], ['public_suffix', '< 3.1.0']]
+    deps << ['net-telnet', '~> 0.1.0'] << ['chef', '~> 12.0']
+    gemspec_for 'chef_supermarket', deps
 elsif Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.4.0")
-  gemspec_for 'chef_supermarket', [['rack'], ['mime-types'], ['chef', '~> 13.0'], ['public_suffix', '< 3.1.0'], ['ohai', '~> 13.0']]
+  gemspec_for 'chef_supermarket', (deps << ['chef', '~> 13.0'])
 else
-  gemspec_for 'chef_supermarket', [['rack'], ['mime-types'], ['chef', '>= 14'], ['public_suffix', '< 3.1.0']]
+  gemspec_for 'chef_supermarket', (deps << ['chef', '>= 14'])
 end

--- a/dpl-chef_supermarket.gemspec
+++ b/dpl-chef_supermarket.gemspec
@@ -3,15 +3,15 @@ require './gemspec_helper'
 deps = [
   ['rack'],
   ['mime-types'],
-  ['public_suffix', '< 3.1.0'],
-  ['ohai', '~> 13.0'],
 ]
 
 if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.3.0")
-    deps << ['net-telnet', '~> 0.1.0'] << ['chef', '~> 12.0']
+    deps << ['net-telnet', '~> 0.1.0'] << ['chef', '~> 12.0'] << ['public_suffix', '< 3.1.0']
     gemspec_for 'chef_supermarket', deps
 elsif Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.4.0")
   gemspec_for 'chef_supermarket', (deps << ['chef', '~> 13.0'])
+elsif Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.5.0")
+  gemspec_for 'chef_supermarket', (deps << ['chef', '~> 14.0'])
 else
   gemspec_for 'chef_supermarket', (deps << ['chef', '>= 14'])
 end

--- a/dpl-pages.gemspec
+++ b/dpl-pages.gemspec
@@ -1,3 +1,3 @@
 require './gemspec_helper'
 
-gemspec_for 'pages', [['octokit', '~> 4.6.2']]
+gemspec_for 'pages', [['octokit', '~> 4.6.2'], ['public_suffix', '< 3.1.0']]


### PR DESCRIPTION
3.1.0 requires Ruby 2.3, which is not suitable for our releases
just yet.

Fixes #995.