### PR TITLE
Clean up deps before checking gems

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -184,7 +184,7 @@ providers.each do |provider|
     rm_rf "stubs"
     rm_rf "vendor"
     logger.info green("Installing dpl-#{provider} gem")
-    sh "gem install --no-post-install-message dpl-#{provider}-#{gem_version}.gem"
+    sh "gem install --no-document --no-post-install-message dpl-#{provider}-#{gem_version}.gem"
     logger.info green("Testing dpl-#{provider} loads correctly")
     ruby "-S dpl --provider=#{provider} --skip-cleanup=true --no-deploy"
   end

--- a/Rakefile
+++ b/Rakefile
@@ -181,6 +181,8 @@ providers.each do |provider|
 
   desc "Test dpl-#{provider} gem"
   task "check-#{provider}" => [Rake::FileTask[dpl_bin], "dpl-#{provider}-#{gem_version}.gem"] do
+    rm_rf "stubs"
+    rm_rf "vendor"
     logger.info green("Installing dpl-#{provider} gem")
     sh "gem install --no-post-install-message dpl-#{provider}-#{gem_version}.gem"
     logger.info green("Testing dpl-#{provider} loads correctly")


### PR DESCRIPTION
The 'vendor' directory could interfere with our check by
providing a version of dependent gem that might not be satisfied
otherwise by the specifications provided in the gemspec at hand.