### PR TITLE
Clean up after a failed `git clone'

### DIFF
--- a/lib/dpl/provider/pages.rb
+++ b/lib/dpl/provider/pages.rb
@@ -138,6 +138,7 @@ module DPL
         unless context.shell "git clone --quiet --branch='#{@target_branch}' --depth=1 '#{gh_remote_url}' '#{target_dir}' > /dev/null 2>&1"
           # if such branch doesn't exist at remote, init it from scratch
           print_step "Cloning #{@target_branch} branch failed"
+          FileUtils.rm_rf(target_dir)
           Dir.mkdir(target_dir)  # Restore dir destroyed by failed `git clone`
           github_init(target_dir)
         end


### PR DESCRIPTION
Should fix https://travis-ci.community/t/failed-to-deploy-because-of-ruby-error/1143 according to https://travis-ci.community/t/failed-to-deploy-because-of-ruby-error/1143/7