### PR TITLE
Support for deploying specific firebase services

### DIFF
--- a/lib/dpl/provider/firebase.rb
+++ b/lib/dpl/provider/firebase.rb
@@ -18,6 +18,7 @@ module DPL
       def push_app
         command = "firebase deploy --non-interactive"
         command << " --project #{options[:project]}" if options[:project]
+        command << " --only #{options[:only]}" if options[:only]
         command << " --message '#{options[:message]}'" if options[:message]
         command << " --token '#{options[:token]}'" if options[:token]
         context.shell command or raise Error, "Firebase deployment failed"

--- a/spec/provider/firebase_spec.rb
+++ b/spec/provider/firebase_spec.rb
@@ -26,6 +26,12 @@ describe DPL::Provider::Firebase do
       provider.push_app
     end
 
+    it 'should include only condition specified' do
+      provider.options.update(:only => 'hosting:target')
+      expect(provider.context).to receive(:shell).with("firebase deploy --non-interactive --only 'hosting:target' --token 'abc123'").and_return(true)
+      provider.push_app
+    end
+
     it 'should include the message specified' do
       provider.options.update(:message => 'test message')
       expect(provider.context).to receive(:shell).with("firebase deploy --non-interactive --message 'test message' --token 'abc123'").and_return(true)


### PR DESCRIPTION
Support for deploying specific firebase services with the use of --only flag .

This helps in multi site deployment for same firebase project .

This solves below issue
https://travis-ci.community/t/firebase-multisite-deployment-within-same-project/3858 .

Test build :
https://travis-ci.org/karthikbalajikb/dpl/builds/549446801

Screenshot of firebase console deployment to development site :
![image](https://user-images.githubusercontent.com/8594076/59981282-a997e480-961e-11e9-92e1-be90a510469a.png)

@BanzaiMan 