### PR TITLE
Add support for multi-regions

### DIFF
--- a/lib/dpl/provider/scalingo.rb
+++ b/lib/dpl/provider/scalingo.rb
@@ -7,9 +7,10 @@ module DPL
   class Provider
     class Scalingo < Provider
       def install_deploy_dependencies
+        download_url = 'https://cli-dl.scalingo.io/release/scalingo_latest_linux_amd64.tar.gz'
         command = 'curl'
         command = "#{command} --silent" if !@debug
-        command = "#{command} -OL https://cli-dl.scalingo.io/release/scalingo_latest_linux_amd64.tar.gz"
+        command = "#{command} --remote-name --location #{download_url}"
         tar_options = 'v' if @debug
         tar_options = "#{tar_options}zxf"
         command = "#{command} && tar -#{tar_options} scalingo_latest_linux_amd64.tar.gz" \
@@ -63,7 +64,7 @@ module DPL
           end
         end
 
-        if !context.shell "git push #{@remote} #{@branch} -f"
+        if !context.shell "git push #{@remote} #{@branch} --force"
           error "Couldn't push your app."
         end
       end

--- a/lib/dpl/provider/scalingo.rb
+++ b/lib/dpl/provider/scalingo.rb
@@ -17,6 +17,7 @@ module DPL
         @options = options
         @remote = options[:remote] || 'scalingo'
         @branch = options[:branch] || 'master'
+        @region = options[:region] || 'agora-fr1'
         @timeout = options[:timeout] || '60'
         @debug = !options[:debug].nil?
       end

--- a/lib/dpl/provider/scalingo.rb
+++ b/lib/dpl/provider/scalingo.rb
@@ -24,7 +24,7 @@ module DPL
       def initialize(context, options)
         super
         @options = options
-        @remote = options[:remote] || 'scalingo'
+        @remote = options[:remote] || 'scalingo-dpl'
         @branch = options[:branch] || 'master'
         @region = options[:region] || 'agora-fr1'
         @timeout = options[:timeout] || '60'

--- a/lib/dpl/provider/scalingo.rb
+++ b/lib/dpl/provider/scalingo.rb
@@ -17,6 +17,7 @@ module DPL
         @options = options
         @remote = options[:remote] || 'scalingo'
         @branch = options[:branch] || 'master'
+        @timeout = options[:timeout] || '60'
       end
 
       def logged_in
@@ -26,9 +27,9 @@ module DPL
       def check_auth
         token = @options[:api_key] || @options[:api_token]
         if token
-          context.shell "timeout 2 ./scalingo login --api-token #{token} > /dev/null"
+          context.shell "timeout #{@timeout} ./scalingo login --api-token #{token} > /dev/null"
         elsif @options[:username] && @options[:password]
-          context.shell "echo -e \"#{@options[:username]}\n#{@options[:password]}\" | timeout 2 ./scalingo login > /dev/null"
+          context.shell "echo -e \"#{@options[:username]}\n#{@options[:password]}\" | timeout #{@timeout} ./scalingo login > /dev/null"
         end
         error "Couldn't connect to Scalingo API to check authentication." if !logged_in
       end

--- a/lib/dpl/provider/scalingo.rb
+++ b/lib/dpl/provider/scalingo.rb
@@ -30,17 +30,17 @@ module DPL
         elsif @options[:username] && @options[:password]
           context.shell "echo -e \"#{@options[:username]}\n#{@options[:password]}\" | timeout 2 ./scalingo login > /dev/null"
         end
-        error "Couldn't connect to Scalingo API." if !logged_in
+        error "Couldn't connect to Scalingo API to check authentication." if !logged_in
       end
 
       def setup_key(file, _type = nil)
-        error "Couldn't connect to Scalingo API." if !logged_in
-        error "Couldn't add ssh key." if !context.shell "./scalingo keys-add dpl_tmp_key #{file}"
+        error "Couldn't connect to Scalingo API to setup the SSH key." if !logged_in
+        error "Couldn't add SSH key." if !context.shell "./scalingo keys-add dpl_tmp_key #{file}"
       end
 
       def remove_key
-        error "Couldn't connect to Scalingo API." if !logged_in
-        error "Couldn't remove ssh key." if !context.shell './scalingo keys-remove dpl_tmp_key'
+        error "Couldn't connect to Scalingo API to remove the SSH key." if !logged_in
+        error "Couldn't remove SSH key." if !context.shell './scalingo keys-remove dpl_tmp_key'
       end
 
       def push_app

--- a/lib/dpl/provider/scalingo.rb
+++ b/lib/dpl/provider/scalingo.rb
@@ -45,8 +45,11 @@ module DPL
 
       def push_app
         if @options[:app]
-          context.shell "git remote add #{@remote} git@scalingo.com:#{@options[:app]}.git > /dev/null"
+          if !context.shell "./scalingo --app #{@options[:app]} git-setup --remote #{@remote}"
+            error 'Failed to add the Git remote.'
+          end
         end
+
         error "Couldn't push your app." if !context.shell "git push #{@remote} #{@branch} -f"
       end
     end

--- a/lib/dpl/provider/scalingo.rb
+++ b/lib/dpl/provider/scalingo.rb
@@ -31,10 +31,6 @@ module DPL
         @debug = !options[:debug].nil?
       end
 
-      def logged_in
-        scalingo('login', ['DISABLE_INTERACTIVE=true'])
-      end
-
       def check_auth
         token = @options[:api_key] || @options[:api_token]
         if token
@@ -42,17 +38,18 @@ module DPL
         elsif @options[:username] && @options[:password]
           scalingo('login', [], "echo -e \"#{@options[:username]}\n#{@options[:password]}\"")
         end
-        error "Couldn't connect to Scalingo API to check authentication." if !logged_in
       end
 
       def setup_key(file, _type = nil)
-        error "Couldn't connect to Scalingo API to setup the SSH key." if !logged_in
-        error "Couldn't add SSH key." if !scalingo("keys-add dpl_tmp_key #{file}")
+        if !scalingo("keys-add dpl_tmp_key #{file}")
+          error "Couldn't add SSH key."
+        end
       end
 
       def remove_key
-        error "Couldn't connect to Scalingo API to remove the SSH key." if !logged_in
-        error "Couldn't remove SSH key." if !scalingo('keys-remove dpl_tmp_key')
+        if !scalingo('keys-remove dpl_tmp_key')
+          error "Couldn't remove SSH key."
+        end
       end
 
       def push_app

--- a/lib/dpl/provider/scalingo.rb
+++ b/lib/dpl/provider/scalingo.rb
@@ -63,7 +63,9 @@ module DPL
           end
         end
 
-        error "Couldn't push your app." if !context.shell "git push #{@remote} #{@branch} -f"
+        if !context.shell "git push #{@remote} #{@branch} -f"
+          error "Couldn't push your app."
+        end
       end
 
       def scalingo(command, env = [], input = '')

--- a/lib/dpl/provider/scalingo.rb
+++ b/lib/dpl/provider/scalingo.rb
@@ -20,15 +20,15 @@ module DPL
       end
 
       def logged_in
-        context.shell 'DISABLE_INTERACTIVE=true ./scalingo login 2> /dev/null > /dev/null'
+        context.shell 'DISABLE_INTERACTIVE=true ./scalingo login > /dev/null'
       end
 
       def check_auth
         token = @options[:api_key] || @options[:api_token]
         if token
-          context.shell "timeout 2 ./scalingo login --api-token #{token} 2> /dev/null > /dev/null"
+          context.shell "timeout 2 ./scalingo login --api-token #{token} > /dev/null"
         elsif @options[:username] && @options[:password]
-          context.shell "echo -e \"#{@options[:username]}\n#{@options[:password]}\" | timeout 2 ./scalingo login 2> /dev/null > /dev/null"
+          context.shell "echo -e \"#{@options[:username]}\n#{@options[:password]}\" | timeout 2 ./scalingo login > /dev/null"
         end
         error "Couldn't connect to Scalingo API." if !logged_in
       end
@@ -45,7 +45,7 @@ module DPL
 
       def push_app
         if @options[:app]
-          context.shell "git remote add #{@remote} git@scalingo.com:#{@options[:app]}.git 2> /dev/null > /dev/null"
+          context.shell "git remote add #{@remote} git@scalingo.com:#{@options[:app]}.git > /dev/null"
         end
         error "Couldn't push your app." if !context.shell "git push #{@remote} #{@branch} -f"
       end

--- a/lib/dpl/provider/scalingo.rb
+++ b/lib/dpl/provider/scalingo.rb
@@ -77,8 +77,8 @@ module DPL
         else
           command += ' > /dev/null'
         end
-        command = "#{input} | #{command}" if input != ''
         command = "#{env.join(' ')} timeout #{@timeout} ./scalingo #{command}"
+        command = "#{input} | #{command}" if input != ''
 
         puts "Execute #{command}" if @debug
 

--- a/spec/provider/scalingo_spec.rb
+++ b/spec/provider/scalingo_spec.rb
@@ -2,7 +2,6 @@ require 'spec_helper'
 require 'dpl/provider/scalingo'
 
 describe DPL::Provider::Scalingo do
-
   subject :provider do
     described_class.new(DummyContext.new, :username => 'travis', :password => 'secret', :remote => 'scalingo', :branch => 'master')
   end
@@ -10,7 +9,7 @@ describe DPL::Provider::Scalingo do
   describe "#install_deploy_dependencies" do
     example do
       expect(provider.context).to receive(:shell).with(
-              'curl -OL https://cli-dl.scalingo.io/release/scalingo_latest_linux_amd64.tar.gz && tar -zxvf scalingo_latest_linux_amd64.tar.gz && mv scalingo_*_linux_amd64/scalingo . && rm scalingo_latest_linux_amd64.tar.gz && rm -r scalingo_*_linux_amd64'
+              'curl --silent --remote-name --location https://cli-dl.scalingo.io/release/scalingo_latest_linux_amd64.tar.gz && tar -zxf scalingo_latest_linux_amd64.tar.gz && mv scalingo_*_linux_amd64/scalingo . && rm scalingo_latest_linux_amd64.tar.gz && rm -r scalingo_*_linux_amd64'
       ).and_return(true)
       provider.install_deploy_dependencies
     end
@@ -19,10 +18,10 @@ describe DPL::Provider::Scalingo do
   describe "#check_auth" do
     example do
       expect(provider.context).to receive(:shell).with(
-        "echo -e \"travis\nsecret\" | timeout 2 ./scalingo login 2> /dev/null > /dev/null"
+        "echo -e \"travis\nsecret\" | SCALINGO_REGION=agora-fr1 timeout 60 ./scalingo login > /dev/null"
       ).and_return(true)
       expect(provider.context).to receive(:shell).with(
-        'DISABLE_INTERACTIVE=true ./scalingo login 2> /dev/null > /dev/null'
+        'DISABLE_INTERACTIVE=true SCALINGO_REGION=agora-fr1 timeout 60 ./scalingo login > /dev/null'
       ).and_return(true)
       provider.check_auth
     end
@@ -31,10 +30,10 @@ describe DPL::Provider::Scalingo do
   describe "#setup_key" do
     example do
       expect(provider.context).to receive(:shell).with(
-        './scalingo keys-add dpl_tmp_key key_file'
+        'SCALINGO_REGION=agora-fr1 timeout 60 ./scalingo keys-add dpl_tmp_key key_file > /dev/null'
       ).and_return(true)
       expect(provider.context).to receive(:shell).with(
-        'DISABLE_INTERACTIVE=true ./scalingo login 2> /dev/null > /dev/null'
+        'DISABLE_INTERACTIVE=true SCALINGO_REGION=agora-fr1 timeout 60 ./scalingo login > /dev/null'
       ).and_return(true)
       provider.setup_key('key_file')
     end
@@ -43,10 +42,10 @@ describe DPL::Provider::Scalingo do
   describe "#remove_key" do
     example do
       expect(provider.context).to receive(:shell).with(
-        './scalingo keys-remove dpl_tmp_key'
+        'SCALINGO_REGION=agora-fr1 timeout 60 ./scalingo keys-remove dpl_tmp_key > /dev/null'
       ).and_return(true)
       expect(provider.context).to receive(:shell).with(
-        'DISABLE_INTERACTIVE=true ./scalingo login 2> /dev/null > /dev/null'
+        'DISABLE_INTERACTIVE=true SCALINGO_REGION=agora-fr1 timeout 60 ./scalingo login > /dev/null'
       ).and_return(true)
       provider.remove_key
     end
@@ -55,10 +54,12 @@ describe DPL::Provider::Scalingo do
   describe "#push_app" do
     example do
       expect(provider.context).to receive(:shell).with(
-        'git push scalingo master -f'
+              'curl --silent --remote-name --location https://cli-dl.scalingo.io/release/scalingo_latest_linux_amd64.tar.gz && tar -zxf scalingo_latest_linux_amd64.tar.gz && mv scalingo_*_linux_amd64/scalingo . && rm scalingo_latest_linux_amd64.tar.gz && rm -r scalingo_*_linux_amd64'
+      ).and_return(true)
+      expect(provider.context).to receive(:shell).with(
+        'git push scalingo master --force'
       ).and_return(true)
       provider.push_app
     end
   end
-
 end

--- a/spec/provider/scalingo_spec.rb
+++ b/spec/provider/scalingo_spec.rb
@@ -20,9 +20,6 @@ describe DPL::Provider::Scalingo do
       expect(provider.context).to receive(:shell).with(
         "echo -e \"travis\nsecret\" | SCALINGO_REGION=agora-fr1 timeout 60 ./scalingo login > /dev/null"
       ).and_return(true)
-      expect(provider.context).to receive(:shell).with(
-        'DISABLE_INTERACTIVE=true SCALINGO_REGION=agora-fr1 timeout 60 ./scalingo login > /dev/null'
-      ).and_return(true)
       provider.check_auth
     end
   end
@@ -32,9 +29,6 @@ describe DPL::Provider::Scalingo do
       expect(provider.context).to receive(:shell).with(
         'SCALINGO_REGION=agora-fr1 timeout 60 ./scalingo keys-add dpl_tmp_key key_file > /dev/null'
       ).and_return(true)
-      expect(provider.context).to receive(:shell).with(
-        'DISABLE_INTERACTIVE=true SCALINGO_REGION=agora-fr1 timeout 60 ./scalingo login > /dev/null'
-      ).and_return(true)
       provider.setup_key('key_file')
     end
   end
@@ -43,9 +37,6 @@ describe DPL::Provider::Scalingo do
     example do
       expect(provider.context).to receive(:shell).with(
         'SCALINGO_REGION=agora-fr1 timeout 60 ./scalingo keys-remove dpl_tmp_key > /dev/null'
-      ).and_return(true)
-      expect(provider.context).to receive(:shell).with(
-        'DISABLE_INTERACTIVE=true SCALINGO_REGION=agora-fr1 timeout 60 ./scalingo login > /dev/null'
       ).and_return(true)
       provider.remove_key
     end


### PR DESCRIPTION
* Added `--region` flag: Scalingo is now [available on multiple regions](https://scalingo.com/articles/2019/07/01/new-osc-fr1-region.html) which slightly changes the way it deploys.
* Added `--debug` flag: We also improved a little bit the implementation so that it's easier to debug a failed deployment.
* Added `--timeout` flag: Make the timeout configurable and increase it by default. Some deployments failed due to this too low timeout.