### PR TITLE
Preserve "=" in the RHS of env var

### DIFF
--- a/lib/dpl/provider/lambda.rb
+++ b/lib/dpl/provider/lambda.rb
@@ -226,7 +226,7 @@ module DPL
       def split_string_array_to_hash(arr, delimiter="=")
         variables = {}
         Array(arr).map do |val|
-          keyval = val.split(delimiter)
+          keyval = val.split(delimiter, 2)
           variables[keyval[0]] = keyval[1]
         end
         variables


### PR DESCRIPTION
https://travis-ci.community/t/aws-lambda-deployment-provider-equals-sign-in-environment-variables-value/4247

When the env var contains `=`, the right of it is dropped.