### PR TITLE
honor .ebignore for excluding files from the zip

### DIFF
--- a/.travis/providers/aws-elasticbeanstalk/prepare
+++ b/.travis/providers/aws-elasticbeanstalk/prepare
@@ -46,7 +46,3 @@ File.write '.ebignore', <<~str
 str
 
 File.write 'secret.txt', 'secret'
-
-# system 'git init'
-# system 'git add .'
-# system 'git commit -am "dpl test"'

--- a/.travis/providers/aws-elasticbeanstalk/prepare
+++ b/.travis/providers/aws-elasticbeanstalk/prepare
@@ -38,8 +38,15 @@ File.write '.ebextensions/gem_install_bundler.config', <<~str
         gem install bundler -v 2.0.1
 str
 
-# system 'bundle install --path vendor/bundle'
+File.write '.ebignore', <<~str
+  *
+  !Gemfile
+  !config.ru
+  !.ebextensions/gem_install_bundler.config
+str
 
-system 'git init'
-system 'git add .'
-system 'git commit -am "dpl test"'
+File.write 'secret.txt', 'secret'
+
+# system 'git init'
+# system 'git add .'
+# system 'git commit -am "dpl test"'

--- a/.travis/providers/aws-elasticbeanstalk/travis.yml
+++ b/.travis/providers/aws-elasticbeanstalk/travis.yml
@@ -20,6 +20,7 @@ deploy:
     app: dpl-test
     env: DplTest-env
     bucket_name: travis-dpl-test-elasticbeanstalk
+    debug: true
 
 after_deploy:
   - cd ../..

--- a/lib/dpl/providers/elasticbeanstalk.rb
+++ b/lib/dpl/providers/elasticbeanstalk.rb
@@ -30,7 +30,8 @@ module Dpl
       opt '--wait_until_deployed', 'Wait until the deployment has finished'
       opt '--debug', internal: true
 
-      msgs login: 'Using Access Key: %{access_key_id}'
+      msgs login:   'Using Access Key: %{access_key_id}',
+           zip_add: 'Adding %s'
 
       attr_reader :started, :object, :version
 

--- a/lib/dpl/providers/elasticbeanstalk.rb
+++ b/lib/dpl/providers/elasticbeanstalk.rb
@@ -11,7 +11,7 @@ module Dpl
 
       gem 'aws-sdk', '~> 2.0'
       gem 'rubyzip', '~> 1.2.2', require: 'zip'
-      gem 'pathspec', require: 'pathspec'
+      gem 'pathspec', '~> 0.2.1', require: 'pathspec'
 
       env :aws, :elastic_beanstalk
       config '~/.aws/credentials', '~/.aws/config', prefix: 'aws'

--- a/lib/dpl/providers/elasticbeanstalk.rb
+++ b/lib/dpl/providers/elasticbeanstalk.rb
@@ -28,6 +28,7 @@ module Dpl
       opt '--zip_file PATH', 'The zip file that you want to deploy'
       opt '--only_create_app_version', 'Only create the app version, do not actually deploy it'
       opt '--wait_until_deployed', 'Wait until the deployment has finished'
+      opt '--debug', internal: true
 
       msgs login: 'Using Access Key: %{access_key_id}'
 
@@ -81,7 +82,10 @@ module Dpl
 
       def create_zip
         ::Zip::File.open(zip_file, ::Zip::File::CREATE) do |zip|
-          files.each { |path| zip.add(path.sub(cwd, ''), path) }
+          files.each do |path|
+            debug :zip_add, path
+            zip.add(path.sub(cwd, ''), path)
+          end
         end
       end
 
@@ -166,6 +170,10 @@ module Dpl
 
       def eb
         @eb ||= Aws::ElasticBeanstalk::Client.new(retry_limit: 10)
+      end
+
+      def debug(*args)
+        info *args if debug?
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,7 @@ RSpec.configure do |c|
   c.include Support::Fixtures
   c.include Support::Matchers
   c.include Support::Matchers::RecordCmds, record: true
+  c.include Support::Now
   c.include Support::Require
 
   c.before { rm_rf '/tmp/dpl' }

--- a/spec/support.rb
+++ b/spec/support.rb
@@ -5,6 +5,7 @@ require 'support/file'
 require 'support/fixtures'
 require 'support/gemfile'
 require 'support/matchers'
+require 'support/now'
 require 'support/require'
 
 def stringify(obj)

--- a/spec/support/now.rb
+++ b/spec/support/now.rb
@@ -1,0 +1,17 @@
+require 'time'
+
+module Support
+  module Now
+    def self.included(base)
+      base.let(:now) { Time.now }
+      base.before { allow(Time).to receive(:now).and_return(now) }
+    end
+  end
+end
+
+# https://stackoverflow.com/questions/44259104/rubyzip-undefined-method-to-binary-dos-time-for
+require 'zip'
+
+Zip::DOSTime.instance_eval do
+  def now; Zip::DOSTime.new(); end # ugh.
+end


### PR DESCRIPTION
This should address https://github.com/travis-ci/dpl/issues/411, and supersedes https://github.com/travis-ci/dpl/pull/885

It uses a Rubygem that ports Python's `PathSpec` (which is what the EB CLI uses) https://github.com/highb/pathspec-ruby.

FWIW the Python implementation in the EB CLI currently is:

```python
def get_ebignore_list():
    location = get_ebignore_location()

    if not os.path.isfile(location):
        return None

    with codecs.open(location, 'r', encoding='utf-8') as f:
        spec = PathSpec.from_lines('gitwildmatch', f)

    ignore_list = [f for f in spec.match_tree(get_project_root())]
    ignore_list.append('.ebignore')

    return ignore_list
```
