### PR TITLE
Fixes for cloudformation provider

### DIFF
--- a/lib/dpl/providers/cloudformation.rb
+++ b/lib/dpl/providers/cloudformation.rb
@@ -143,14 +143,14 @@ module Dpl
         end
 
         def common_params
-          @common_params ||= compact(
+          params = {
             stack_name: stack_name,
             role_arn: role_arn,
             capabilities: capabilities,
-            parameters: parameters,
-            # template: template
-            # template: 'https://s3.amazonaws.com/templates/myTemplate.template?versionId=123ab1cdeKdOW5IH4GAcYbEngcpTJTDW'
-          )
+            parameters: parameters
+          }
+
+          @common_params ||= compact(params.merge(template))
         end
 
         def parameters
@@ -175,8 +175,8 @@ module Dpl
 
         def template
           str = super
-          return str if url?(str)
-          return read(str) if file?(str)
+          return { template_url: str } if url?(str)
+          return { template_body: read(str) } if file?(str)
           error(:missing_template)
         end
 

--- a/lib/dpl/providers/cloudformation.rb
+++ b/lib/dpl/providers/cloudformation.rb
@@ -235,12 +235,12 @@ module Dpl
 
             # source: https://github.com/rvedotrc/cfn-events/blob/master/lib/cfn-events/runner.rb
             def events_since(event)
-              events = stack_events
-              return [event, []] if events.first.event_id == event.event_id
+              stack_events = describe_stack_events
+              return [event, []] if events.stack_events.first.event_id == event.event_id
 
               events = []
-              events.each_page do |page|
-                if oldest_new = page.stack_events.index { |e| e.event_id == event.event_id }
+              stack_events.each_page do |page|
+                if (oldest_new = page.stack_events.index { |e| e.event_id == event.event_id })
                   events.concat(page.stack_events[0..oldest_new - 1])
                   return [events.first, events.reverse]
                 end
@@ -251,8 +251,8 @@ module Dpl
               [events.first, events.reverse]
             end
 
-            def stack_events
-              client.describe_stack_events(stack_name: stack_name).stack_events
+            def describe_stack_events
+              client.describe_stack_events(stack_name: stack_name)
             end
 
             def mutex


### PR DESCRIPTION
Changes:
- Removed requirement for AWS credentials - it will try the default chain if not provided as parameters (allows to use global env variables and saves some repetitions in .travis.yml later on)
- Fixed events printing
- added/fixed template definition (changed method of `template` -> `template_param` because of infinite loop in messages)
- moved error messages from `errs` to `msgs` - `Cl?` doesn't handle `errs` section (yet?)
- Syntax errors fix for EVENT_KEYS