### PR TITLE
Fix issues on sf_port_950 branch

### DIFF
--- a/lib/dpl/providers/bintray.rb
+++ b/lib/dpl/providers/bintray.rb
@@ -99,8 +99,8 @@ module Dpl
       end
 
       def upload_files
-        files.select(&:download).each do |file|
-          info :list_download, path: file.target
+        files.each do |file|
+          info :upload_file, source: file.source, target: file.target
           put(path(:version_file, target: file.target), file.read, file.params)
         end
       end
@@ -117,8 +117,8 @@ module Dpl
       end
 
       def update_files
-        files.each do |file|
-          info :upload_file, source: file.source, target: file.target
+        files.select(&:download).each do |file|
+          info :list_download, path: file.target
           update_file(file)
         end
       end

--- a/lib/dpl/providers/bintray.rb
+++ b/lib/dpl/providers/bintray.rb
@@ -133,6 +133,7 @@ module Dpl
           code = yield
           break if code < 400
           info :retrying, opts.merge(count: count, code: code)
+          sleep opts[:pause]
         end
       end
 

--- a/lib/dpl/providers/bintray.rb
+++ b/lib/dpl/providers/bintray.rb
@@ -32,7 +32,7 @@ module Dpl
            missing_path:    'Path: %{path} does not exist.',
            list_download:   'Listing %{path} in downloads',
            retrying:        '%{code} response from Bintray. It may take some time for a version to be published, retrying in %{pause} sec ... (%{count}/%{max})',
-           giveup_retries:  '%{code} response from Bintray. Giving up, something went wrong.',
+           giveup_retries:  'Too many retries failed, giving up, something went wrong.',
            unexpected_code: 'Unexpected HTTP response code %s while checking if the %s exists' ,
            request_failed:  '%s %s returned unexpected HTTP response code %s',
            request_success: 'Bintray response: %s %s. %s'
@@ -136,7 +136,7 @@ module Dpl
           info :retrying, opts.merge(count: count, code: code)
           sleep opts[:pause]
         end
-        error :giveup_retries, code
+        error :giveup_retries
       end
 
       def files

--- a/lib/dpl/providers/bintray.rb
+++ b/lib/dpl/providers/bintray.rb
@@ -124,7 +124,7 @@ module Dpl
 
       def update_file(file)
         retrying(max: 10, pause: 5) do
-          put(path(:file_metadata, target: file.target), list_in_downloads: true)
+	put(path(:file_metadata, target: file.target), {list_in_downloads: file.download}.to_json)
         end
       end
 

--- a/lib/dpl/providers/bintray.rb
+++ b/lib/dpl/providers/bintray.rb
@@ -124,7 +124,7 @@ module Dpl
 
       def update_file(file)
         retrying(max: 10, pause: 5) do
-	put(path(:file_metadata, target: file.target), {list_in_downloads: file.download}.to_json)
+          put(path(:file_metadata, target: file.target), {list_in_downloads: file.download}.to_json, {}, 'application/json')
         end
       end
 
@@ -192,8 +192,9 @@ module Dpl
         request(req)
       end
 
-      def put(path, body, params = {})
+      def put(path, body, params = {}, contentType = '')
         req = Net::HTTP::Put.new(append_params(path, params))
+        req.add_field('Content-Type', contentType) if contentType != ''
         req.basic_auth(user, key)
         req.body = body
         request(req)

--- a/lib/dpl/providers/bintray.rb
+++ b/lib/dpl/providers/bintray.rb
@@ -32,6 +32,7 @@ module Dpl
            missing_path:    'Path: %{path} does not exist.',
            list_download:   'Listing %{path} in downloads',
            retrying:        '%{code} response from Bintray. It may take some time for a version to be published, retrying in %{pause} sec ... (%{count}/%{max})',
+           giveup_retries:  '%{code} response from Bintray. Giving up, something went wrong.',
            unexpected_code: 'Unexpected HTTP response code %s while checking if the %s exists' ,
            request_failed:  '%s %s returned unexpected HTTP response code %s',
            request_success: 'Bintray response: %s %s. %s'
@@ -131,10 +132,11 @@ module Dpl
       def retrying(opts, &block)
         1.upto(opts[:max]) do |count|
           code = yield
-          break if code < 400
+          return if code < 400
           info :retrying, opts.merge(count: count, code: code)
           sleep opts[:pause]
         end
+        error :giveup_retries, code
       end
 
       def files


### PR DESCRIPTION
Fixed several issues with the original branch:

* When updating file metadata the request body should be json-encoded
* When updating file metadata the request should contain a `Content-Type` set to `application/json`
* When retrying there was no delay
* Failing retries was ignored silently
* There was a mistake that lead to upload only artifacts with the `listInDownloads` attribute but try to actually list all artifacts resulting in a `404` error for artifacts without `listInDownloads` 

Tested on https://github.com/loicalbertin/travis-dpl-bintray-test
See https://travis-ci.org/loicalbertin/travis-dpl-bintray-test/builds/573880501