### PR TITLE
lambda: more runtime dependent separators

### DIFF
--- a/lib/dpl/providers/lambda.rb
+++ b/lib/dpl/providers/lambda.rb
@@ -129,11 +129,7 @@ module Dpl
         end
 
         def handler
-          [module_name, java? ? '::' : '.', handler_name].join if handler_name?
-        end
-
-        def java?
-          runtime =~ /java/
+          Handler.new(runtime, module_name, handler_name).to_s if handler_name?
         end
 
         def function_zip
@@ -178,6 +174,28 @@ module Dpl
 
         def tmp_filename
           @tmp_filename ||= "#{tmp_dir}/#{repo_name}.zip"
+        end
+
+        class Handler < Struct.new(:runtime, :module_name, :handler_name)
+          SEP = {
+            default: '.',
+            java:    '::',
+            dotnet:  '::',
+            go:      ''
+          }
+
+          def to_s
+            [go? ? nil : module_name, sep, handler_name].compact.join
+          end
+
+          def sep
+            key = SEP.keys.detect { |key| runtime.start_with?(key.to_s) }
+            SEP[key || :default]
+          end
+
+          def go?
+            runtime.start_with?('go')
+          end
         end
     end
   end

--- a/spec/dpl/providers/lambda_spec.rb
+++ b/spec/dpl/providers/lambda_spec.rb
@@ -68,6 +68,14 @@ describe Dpl::Providers::Lambda do
       it { should create_function Handler: 'index::handler' }
     end
 
+    describe 'given --runtime dotnetcore2.1' do
+      it { should create_function Handler: 'index::handler' }
+    end
+
+    describe 'given --runtime go1.x' do
+      it { should create_function Handler: 'handler' }
+    end
+
     describe 'given --subnet_ids one --subnet_ids two' do
       it { should create_function VpcConfig: { SubnetIds: ['one', 'two'] } }
     end


### PR DESCRIPTION
This ports the remaining runtime dependent separators and logic from https://github.com/travis-ci/dpl/pull/1018

The Java separator `::` was already ported in another PR (https://github.com/travis-ci/dpl/pull/1027).