### PR TITLE
Fix pages on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@
 
 * Add `--key_file` to allow using a service account key file
 
+### pages
+
+* Fix to allow being run on a Windows Git bash
+
 ### Releases
 
 * Make --file glob files by default, and default to `*`

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,8 @@ gems.each do |name, version, opts|
   gem name, version, opts
 end
 
+gem 'os'
+
 group :test do
   gem 'coveralls'
   gem 'rspec'

--- a/lib/dpl/providers/pages/git.rb
+++ b/lib/dpl/providers/pages/git.rb
@@ -96,7 +96,7 @@ module Dpl
           info :committer_from_gh if committer_from_gh?
           info :git_config
           copy_files
-          return info :stop unless git_dirty?
+          return info :stop unless !(git_clone?) || git_dirty?
           git_config
           git_commit
           git_push

--- a/lib/dpl/providers/pages/git.rb
+++ b/lib/dpl/providers/pages/git.rb
@@ -82,8 +82,6 @@ module Dpl
 
         def setup
           info :setup_dir, src_dir
-          info :committer_from_gh if committer_from_gh?
-          info :git_config
         end
 
         def prepare
@@ -95,6 +93,8 @@ module Dpl
 
         def deploy
           git_clone? ? git_clone : git_init
+          info :committer_from_gh if committer_from_gh?
+          info :git_config
           copy_files
           return info :stop unless git_dirty?
           git_config

--- a/spec/dpl/providers/pages/git_spec.rb
+++ b/spec/dpl/providers/pages/git_spec.rb
@@ -16,10 +16,10 @@ describe Dpl::Providers::Pages::Git do
 
   describe 'by default', record: true do
     it { should have_run '[info] Authenticated as login' }
-    it { should have_run '[info] Configuring git committer to be author name (via Travis CI) <author email>' }
     it { should have_run '[info] Deploying branch gh-pages to github.com/travis-ci/dpl.git' }
     it { should have_run '[info] Cloning the branch gh-pages from the remote repo' }
     it { should have_run 'git clone --quiet --branch="gh-pages" --depth=1 "https://token@github.com/travis-ci/dpl.git" . > /dev/null 2>&1' }
+    it { should have_run '[info] Configuring git committer to be author name (via Travis CI) <author email>' }
     it { should have_run %(rsync -rl --exclude .git --delete "#{cwd}/" .) }
     it { should have_run 'git config user.name "author name (via Travis CI)"' }
     it { should have_run 'git config user.email "author email"' }


### PR DESCRIPTION
This fixes #1105.

On "Git Bash" on Windows, the `dpl` executable runs `cmd.exe`, which does not play well with the `bash` syntax. Thus, I added a check to be on Windows and then execute `bash.exe`. 

This required 

- new dependency on `os` to check for Windows
- reroute calls from `Kernel.system` to `shell`

I also fixed the `setup` phase. The `git config` command was called inside the source directory (which typically is not a `.git` directory) and not in the target directory (which is the git repository being pushed).

Tested on Windows with a GitHub repository.

Minor fix: typo