### PR TITLE
Fix "NameError: uninitialized constant DPL" on rake --tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -23,7 +23,7 @@ def top
 end
 
 def gem_version
-  ENV['DPL_VERSION'] || DPL::VERSION
+  ENV['DPL_VERSION'] || Dpl::VERSION
 end
 
 def confirm(verb = "release")


### PR DESCRIPTION
(the below command is what RubyMine runs on "reload rake tasks list")
```
C:\Users\Sasha\Documents\travis-dpl>"C:\Ruby24-x64\bin\ruby.exe"  "C:\Ruby24-x64\bin\bundle" exec C:\Ruby24-x64\bin\ruby
.exe C:\Ruby24-x64\bin\rake --tasks --trace
rake aborted!
NameError: uninitialized constant DPL
Did you mean?  Dpl
C:/Users/Sasha/Documents/travis-dpl/Rakefile:26:in `gem_version'
C:/Users/Sasha/Documents/travis-dpl/Rakefile:49:in `<top (required)>'
C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/rake-12.3.3/lib/rake/rake_module.rb:29:in `load'
C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/rake-12.3.3/lib/rake/rake_module.rb:29:in `load_rakefile'
C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/rake-12.3.3/lib/rake/application.rb:703:in `raw_load_rakefile'
C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/rake-12.3.3/lib/rake/application.rb:104:in `block in load_rakefile'
C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/rake-12.3.3/lib/rake/application.rb:186:in `standard_exception_handling'
C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/rake-12.3.3/lib/rake/application.rb:103:in `load_rakefile'
C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/rake-12.3.3/lib/rake/application.rb:82:in `block in run'
C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/rake-12.3.3/lib/rake/application.rb:186:in `standard_exception_handling'
C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/rake-12.3.3/lib/rake/application.rb:80:in `run'
C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/rake-12.3.3/exe/rake:27:in `<top (required)>'
C:/Ruby24-x64/bin/rake:23:in `load'
C:/Ruby24-x64/bin/rake:23:in `<main>'
```