### PR TITLE
NPM: add --dry-run option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1623,6 +1623,7 @@ Options:
   --registry URL            npm registry url (type: string)
   --src SRC                 directory or tarball to publish (type: string, default: .)
   --tag TAGS                distribution tags to add (type: string)
+  --[no-]dry_run            performs test run without uploading to registry
   --auth_method METHOD      Authentication method (type: string, known values: auth)
 
 Common Options:

--- a/lib/dpl/providers/npm.rb
+++ b/lib/dpl/providers/npm.rb
@@ -19,6 +19,7 @@ module Dpl
       opt '--registry URL', 'npm registry url'
       opt '--src SRC', 'directory or tarball to publish', default: '.'
       opt '--tag TAGS', 'distribution tags to add'
+      opt '--dry_run', 'performs test run without uploading to registry'
       opt '--auth_method METHOD', 'Authentication method', enum: %w(auth)
 
       REGISTRY = 'https://registry.npmjs.org'
@@ -51,7 +52,7 @@ module Dpl
       private
 
         def publish_opts
-          opts_for(%i(access tag))
+          opts_for(%i(access tag dry_run), dashed: true)
         end
 
         def write_npmrc

--- a/spec/dpl/providers/npm_spec.rb
+++ b/spec/dpl/providers/npm_spec.rb
@@ -25,6 +25,11 @@ describe Dpl::Providers::Npm do
     it { should have_run 'npm publish . --tag="tag"' }
   end
 
+  describe 'npm_version 6, given --dry-run' do
+    let(:npm_version) { '6' }
+    it { should have_run 'npm publish . --dry-run' }
+  end
+
   let(:npmrc_1) { "_auth = 12345\nemail = email" }
   let(:npmrc_2) { '//registry.npmjs.org/:_authToken=12345' }
 


### PR DESCRIPTION
This PR introduces the `--dry-run` CLI parameter as described in the [npm CLI documentation](https://docs.npmjs.com/cli/publish.html#description).

The reason for this addition is, that there is currently no possibility of testing the `npm publish` option without actually uploading the package to the registry.

Due to the fact, that a version number cannot be re-used on npm once a package has been uploaded and released on the registry, it could cause issues in terms of the transparency between tagged versions vs. the actually released packages.