### PR TITLE
initial snap support

### DIFF
--- a/.travis/providers/snap/prepare
+++ b/.travis/providers/snap/prepare
@@ -4,23 +4,36 @@ require 'fileutils'
 
 include FileUtils
 
-mkdir_p 'tmp/dpl-test/snap'
-chdir 'tmp/dpl-test'
+mkdir_p 'tmp/dee-pee-ell-test/snap'
+mkdir_p 'tmp/dee-pee-ell-test/bin'
+chdir 'tmp/dee-pee-ell-test'
 
-File.write 'snap/snapcraft.yaml', <<~str
-  name: dpl-test
-  version: "0.0.0-test.#{ENV['ID'][0..5]}"
-  summary: Travis CI dpl canary test snap
-  description: Travis CI dpl canary test snap.
-  apps:
-    dpl-test:
-      command: dpl-test
-  parts:
-    dpl-test:
-      plugin: ruby
-      source: https://github.com/travis-ci/dpl.git
+File.write 'bin/dee-pee-ell-test', <<~str
+  #!/bin/bash
+  echo -n "This is just a test: #{ENV['ID']}"
 str
 
-cmd = 'snapcraft build'
+FileUtils.chmod 0755, "bin/dee-pee-ell-test"
+
+File.write 'snap/snapcraft.yaml', <<~str
+  name: dee-pee-ell-test
+  version: "#{ENV['ID']}"
+  summary: Travis CI dpl canary test snap
+  description: Travis CI dpl canary test snap.
+  base: core18
+  confinement: strict
+  grade: stable
+
+  apps:
+    dee-pee-ell-test:
+      command: bin/dee-pee-ell-test
+
+  parts:
+    dee-pee-ell-test:
+      plugin: dump
+      source: .
+str
+
+cmd = 'sudo snapcraft snap --use-lxd'
 puts cmd
 system cmd

--- a/.travis/providers/snap/test
+++ b/.travis/providers/snap/test
@@ -5,6 +5,9 @@ require 'json'
 
 $stdout.sync = true
 
-expected = ENV['ID']
-url = ''
+expected = "This is just a test: #{ENV['ID']}"
+actual = %x[dee-pee-ell-test]
 
+exit 0 if actual == expected
+
+abort 'failed'

--- a/.travis/providers/snap/travis.yml
+++ b/.travis/providers/snap/travis.yml
@@ -1,19 +1,28 @@
 dist: xenial
-language: python
-python: 3.6
+language: shell
 
 script:
   - true
 
+addons:
+  snaps:
+  - name: snapcraft
+    channel: stable
+    confinement: classic
+  - name: lxd
+    channel: stable
+
 before_deploy:
-  - sudo snap install snapcraft --classic
+  - sudo /snap/bin/lxd.migrate -yes
+  - sudo /snap/bin/lxd waitready
+  - sudo /snap/bin/lxd init --auto
   - .travis/providers/snap/prepare
-  - cd tmp/dpl-test
 
 deploy:
   - provider: snap
-    snap: '**/*.snap'
+    snap: '**/dee-pee-ell-test_*.snap'
+    channel: edge
 
 after_deploy:
-  - cd ../..
-  - .travis/providers/pypi/test || TRAVIS_TEST_RESULT=$?
+  - sudo snap install dee-pee-ell-test --edge
+  - .travis/providers/snap/test || TRAVIS_TEST_RESULT=$?

--- a/.travis/trigger
+++ b/.travis/trigger
@@ -52,8 +52,7 @@ SKIP = [
   'gae',            # suddenly started failing with "api not enabled" https://travis-ci.com/travis-ci/dpl/jobs/241090908#L412
   'hephy',          # keeps failing
   'npm-github',     # not fully implemented, yet
-  'openshift',      # trial account expired
-  'snap'            # unfinished
+  'openshift'      # trial account expired
 ]
 
 def skip?(path)

--- a/lib/dpl/providers/snap.rb
+++ b/lib/dpl/providers/snap.rb
@@ -16,7 +16,7 @@ module Dpl
       apt 'snapd', 'snap'
 
       cmds install:        'sudo snap install snapcraft --classic',
-           login:          'snapcraft login --with %{token}',
+           login:          'echo "%{token}" | snapcraft login --with -',
            deploy:         'snapcraft push %{snap_path} --release=%{channel}'
 
       msgs login:          'Attemping to login ...',

--- a/spec/dpl/providers/snap_spec.rb
+++ b/spec/dpl/providers/snap_spec.rb
@@ -8,7 +8,7 @@ describe Dpl::Providers::Snap do
   describe 'given --snap ./snap', record: true do
     it { should have_run '[apt:get] snapd (snap)' }
     it { should have_run 'sudo snap install snapcraft --classic' }
-    it { should have_run 'snapcraft login --with token' }
+    it { should have_run 'echo "token" | snapcraft login --with -' }
     it { should have_run 'snapcraft push ./snap --release=edge' }
     it { should have_run_in_order }
   end
@@ -27,7 +27,7 @@ describe Dpl::Providers::Snap do
     env SNAP_TOKEN: 'token'
 
     before { subject.run }
-    it { should have_run 'snapcraft login --with token' }
+    it { should have_run 'echo "token" | snapcraft login --with -' }
   end
 
   describe 'given --snap ./snap', run: false do


### PR DESCRIPTION
Updates to fix and test snap deployment.

Before merging, this will require a handoff or collaborative access for:
(1) `dee-pee-ell-test` snap
(2) or `sed -i 's|dee-pee-ell-test|dpl-test|g'` to use `dpl-test` snap which I believe is owned by @svenfuchs.

SNAP_TOKEN may be generated using snapcraft with:
`snapcraft export-login --acls package_upload --snaps <snap-name> --channels edge -`