### PR TITLE
Specify time to wait for deploy on AWS Elastic Beanstalk

### DIFF
--- a/lib/dpl/providers/elasticbeanstalk.rb
+++ b/lib/dpl/providers/elasticbeanstalk.rb
@@ -123,12 +123,12 @@ module Dpl
 
       def wait_until_deployed
         msgs = []
-        1.upto(20) { return if check_deployment(msgs) }
+        1.upto(wait_until_deployed_timeout / 5) { return if check_deployment(msgs) }
         error 'Deploy status unknown due to timeout. Increase the wait_until_deployed_timeout option'
       end
 
       def check_deployment(msgs)
-        sleep wait_until_deployed_timeout / 20
+        sleep 5
         events.each do |event|
           msg = "#{event.event_date} [#{event.severity}] #{event.message}"
           error "Deployment failed: #{msg}" if event.severity == 'ERROR'

--- a/lib/dpl/providers/elasticbeanstalk.rb
+++ b/lib/dpl/providers/elasticbeanstalk.rb
@@ -29,6 +29,7 @@ module Dpl
       opt '--zip_file PATH', 'The zip file that you want to deploy'
       opt '--only_create_app_version', 'Only create the app version, do not actually deploy it'
       opt '--wait_until_deployed', 'Wait until the deployment has finished'
+      opt '--wait_until_deployed_timeout SEC', 'How many seconds to wait for Elastic Beanstalk deployment update.', type: :integer, default: 600
       opt '--debug', internal: true
 
       msgs login:   'Using Access Key: %{access_key_id}',
@@ -123,11 +124,11 @@ module Dpl
       def wait_until_deployed
         msgs = []
         1.upto(20) { return if check_deployment(msgs) }
-        error 'Too many failures'
+        error 'Deploy status unknown due to timeout. Increase the wait_until_deployed_timeout option'
       end
 
       def check_deployment(msgs)
-        sleep 5
+        sleep wait_until_deployed_timeout / 20
         events.each do |event|
           msg = "#{event.event_date} [#{event.severity}] #{event.message}"
           error "Deployment failed: #{msg}" if event.severity == 'ERROR'


### PR DESCRIPTION
Currently, when deploying to Elastic Beanstalk with the `wait_until_deployed` flag set, `dpl` will only wait for up to 100 seconds before declaring the build has failed with a "Too many failures" error. However, this is not indicative of what the actual deploy status is. 

I raised this to @svenfuchs in https://github.com/travis-ci/dpl/issues/985. EB deploys generally take much more than 100 seconds when you choose rolling or immutable deploys. Mine take about 10 mins. In line with that, this PR:

- allows user to specify a time period to wait with a new `wait_until_deployed_timeout` flag
- use a default timeout of 600 seconds to allow for more complex deployments to succeed before terminating build
- prompt the user to use the new `wait_until_deployed_timeout` flag when the build terminates before application is in Ready state

Tests:
- Failing case of a timeout that is too short for the deploy to complete here: https://travis-ci.com/cloudhary/test-travis-eb-deploy/builds/134615440
- Success case of a deploy that takes about 300 seconds here: https://travis-ci.com/cloudhary/test-travis-eb-deploy/builds/134608445