### PR TITLE
Convox names

### DIFF
--- a/lib/dpl/providers/convox.rb
+++ b/lib/dpl/providers/convox.rb
@@ -97,10 +97,10 @@ module Dpl
       end
 
       def export
-        sh_env_vars.each { |key, value| ENV[key.to_s] = value.to_s }
+        env_vars.each { |key, value| ENV[key.to_s] = value.to_s }
       end
 
-      def sh_env_vars
+      def env_vars
         {
           CONVOX_HOST: host,
           CONVOX_PASSWORD: password,

--- a/lib/dpl/providers/convox.rb
+++ b/lib/dpl/providers/convox.rb
@@ -20,8 +20,8 @@ module Dpl
       opt '--update_cli'
       opt '--create'
       opt '--promote', default: true
-      opt '--env_vars_names VAR_NAMES', type: :array, sep: ','
-      opt '--env_vars VARS', type: :array, sep: ','
+      opt '--env_names VAR_NAMES', type: :array, sep: ','
+      opt '--env VARS', type: :array, sep: ','
       opt '--env_file FILE'
       opt '--description STR'
       opt '--generation NUM', type: :int, default: '2'
@@ -64,14 +64,14 @@ module Dpl
         shell promote? ? :deploy : :build, echo: false
       end
 
-      def env_vars_names
+      def env_names
         env = super || []
         env = env.map { |str| "#{str}=#{ENV[str]}" }
         env_file.concat(env)
       end
 
-      def env_vars
-        env = env_vars_names.concat(super || [])
+      def env
+        env = env_names.concat(super || [])
         env.map { |str| escape(str) }.join(' ')
       end
 

--- a/spec/dpl/providers/convox_spec.rb
+++ b/spec/dpl/providers/convox_spec.rb
@@ -86,13 +86,17 @@ describe Dpl::Providers::Convox do
   end
 
   describe 'given --env "ONE=$one,TWO=two"' do
-    it { should have_run 'convox env set ONE="$one" TWO="two" --rack rack --app app --replace' }
+    it { should have_run 'convox env set ONE\=\$one TWO\=two --rack rack --app app --replace' }
+  end
+
+  describe 'given --env "ONE=$one,TWO=two,THREE=three four five"' do
+    it { should have_run 'convox env set ONE\=\$one TWO\=two THREE\=three\ four\ five --rack rack --app app --replace' }
   end
 
   describe 'given --env_file .env --env TWO=two', run: false do
     file '.env', 'ONE=$one'
     before { subject.run }
-    it { should have_run 'convox env set ONE="$one" TWO="two" --rack rack --app app --replace' }
+    it { should have_run 'convox env set ONE\=\$one TWO\=two --rack rack --app app --replace' }
   end
 
   describe 'missing env file, given --env_file .env', run: false do


### PR DESCRIPTION
This PR solves issue with: 
- `$` sign in environment variables.
- adds new `env_names` method to allow defining variables names to be passed from the build (apart of using `VAR_NAME_FOO=${VAR_NAME_FOO}` which with longer names make a lot of deduplications.
