### PR TITLE
Convox prepare option

### DIFF
--- a/lib/dpl/providers/convox.rb
+++ b/lib/dpl/providers/convox.rb
@@ -58,6 +58,13 @@ module Dpl
         shell :create
       end
 
+      def prepare
+        cmds = super || []
+        Array(cmds).each do |cmd|
+          cmd.casecmp('restart').zero? ? restart : run_cmd(cmd)
+        end
+      end
+
       def deploy
         shell :set_env, echo: false unless env.empty?
         shell promote? ? :deploy : :build, echo: false

--- a/lib/dpl/providers/convox.rb
+++ b/lib/dpl/providers/convox.rb
@@ -61,7 +61,7 @@ module Dpl
 
       def prepare
         Array(opts[:prepare]).each do |cmd|
-          cmd.casecmp('restart').zero? ? restart : run_cmd(cmd)
+          cmd.downcase == 'restart' ? restart : run_cmd(cmd)
         end
       end
 

--- a/lib/dpl/providers/convox.rb
+++ b/lib/dpl/providers/convox.rb
@@ -59,8 +59,7 @@ module Dpl
       end
 
       def prepare
-        cmds = super || []
-        Array(cmds).each do |cmd|
+        Array(opts[:prepare]).each do |cmd|
           cmd.casecmp('restart').zero? ? restart : run_cmd(cmd)
         end
       end

--- a/lib/dpl/providers/convox.rb
+++ b/lib/dpl/providers/convox.rb
@@ -24,6 +24,7 @@ module Dpl
       opt '--env_file FILE'
       opt '--description STR'
       opt '--generation NUM', type: :int, default: '2'
+      opt '--prepare'
 
       # if app and rack are exported to the env, do they need to be passed to these commands?
       cmds login:    'convox version --rack %{rack}',

--- a/lib/dpl/providers/convox.rb
+++ b/lib/dpl/providers/convox.rb
@@ -20,11 +20,11 @@ module Dpl
       opt '--update_cli'
       opt '--create'
       opt '--promote', default: true
-      opt '--env VARS', type: :array, sep: ','
+      opt '--env VARS', type: :array
       opt '--env_file FILE'
       opt '--description STR'
       opt '--generation NUM', type: :int, default: '2'
-      opt '--prepare'
+      opt '--prepare CMDS', 'Run commands with convox cli available just before deployment', type: :array
 
       # if app and rack are exported to the env, do they need to be passed to these commands?
       cmds login:    'convox version --rack %{rack}',
@@ -60,8 +60,8 @@ module Dpl
       end
 
       def prepare
-        Array(opts[:prepare]).each do |cmd|
-          cmd.downcase == 'restart' ? restart : run_cmd(cmd)
+        Array(super).each do |cmd|
+          cmd.casecmp('restart').zero? ? restart : run_cmd(cmd)
         end
       end
 

--- a/spec/dpl/providers/convox_spec.rb
+++ b/spec/dpl/providers/convox_spec.rb
@@ -85,11 +85,11 @@ describe Dpl::Providers::Convox do
     it { should have_run 'convox deploy --rack rack --app app --wait --id --description other' }
   end
 
-  describe 'given --env "ONE=$one,TWO=two"' do
+  describe 'given --env ONE=$one --env TWO=two' do
     it { should have_run 'convox env set ONE\=\$one TWO\=two --rack rack --app app --replace' }
   end
 
-  describe 'given --env "ONE=$one,TWO=two,THREE=three four five"' do
+  describe 'given --env ONE=$one --env TWO=two --env "THREE=three four five"' do
     it { should have_run 'convox env set ONE\=\$one TWO\=two THREE\=three\ four\ five --rack rack --app app --replace' }
   end
 


### PR DESCRIPTION
In case of convox apps we found that it's good to have before/after deployment methods that are run with context of provider. Thanks to that user can have access to `convox` binary so just before deployment some `admin processes` can be run (https://12factor.net/admin-processes).

For post deployment tasks `run` can be used.