### PR TITLE
GCS Provider Parallel uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -1343,7 +1343,6 @@ Options:
   --cache_control HEADER       HTTP header Cache-Control to suggest that the browser cache the file. (type:
                                string, see:
                                https://cloud.google.com/storage/docs/xml-api/reference-headers#cachecontrol)
-  --glob GLOB                  type: string, default: **/*
 
 Common Options:
 
@@ -1357,7 +1356,7 @@ Examples:
   dpl gcs --bucket bucket --key_file file
   dpl gcs --bucket bucket --access_key_id id --secret_access_key key
   dpl gcs --bucket bucket
-  dpl gcs --bucket bucket --key_file file --local_dir dir --upload_dir dir
+  dpl gcs --bucket bucket --key_file file --local_dir dir/*.txt --upload_dir dir
 ```
 
 Options can be given via env vars if prefixed with `GCS_`. E.g. the option `--access_key_id` can be

--- a/README.md
+++ b/README.md
@@ -1309,7 +1309,7 @@ Examples:
 Options can be given via env vars if prefixed with
 `[CLOUDSDK_CORE|CLOUDSDK_CORE_|GAE|GAE_|GOOGLECLOUD|GOOGLECLOUD_]`.
 
-### Google Cloud Store
+### Google Cloud Storage
 
 
 
@@ -1318,7 +1318,7 @@ Usage: dpl gcs [options]
 
 Summary:
 
-  Google Cloud Store deployment provider
+  Google Cloud Storage deployment provider
 
 Description:
 
@@ -1334,13 +1334,12 @@ Options:
   --bucket BUCKET              GCS Bucket (type: string, required: true)
   --local_dir DIR              Local directory to upload from (type: string, default: .)
   --upload_dir DIR             GCS directory to upload to (type: string)
-  --[no-]dot_match             Upload hidden files starting with a dot
   --acl ACL                    Access control to set for uploaded objects (type: string, default: private,
                                known values: private, public-read, public-read-write, authenticated-read,
                                bucket-owner-read, bucket-owner-full-control, see:
                                https://cloud.google.com/storage/docs/reference-headers#xgoogacl)
-  --[no-]detect_encoding       HTTP header Content-Encoding to set for files compressed with gzip and compress
-                               utilities.
+  --gzip STR                   Calls gsutil with -z to gzip files with matching extensions. (type: array (string, can be given multiple
+                               times))
   --cache_control HEADER       HTTP header Cache-Control to suggest that the browser cache the file. (type:
                                string, see:
                                https://cloud.google.com/storage/docs/xml-api/reference-headers#cachecontrol)
@@ -1358,7 +1357,7 @@ Examples:
   dpl gcs --bucket bucket --key_file file
   dpl gcs --bucket bucket --access_key_id id --secret_access_key key
   dpl gcs --bucket bucket
-  dpl gcs --bucket bucket --key_file file --local_dir dir --upload_dir dir --dot_match
+  dpl gcs --bucket bucket --key_file file --local_dir dir --upload_dir dir
 ```
 
 Options can be given via env vars if prefixed with `GCS_`. E.g. the option `--access_key_id` can be

--- a/lib/dpl/providers/gcs.rb
+++ b/lib/dpl/providers/gcs.rb
@@ -98,7 +98,7 @@ module Dpl
           path = []
           path << local_dir
           path << glob if glob?
-          File::join(path)
+          "'#{File::join(path)}'"
         end
 
     end

--- a/lib/dpl/providers/gcs.rb
+++ b/lib/dpl/providers/gcs.rb
@@ -26,11 +26,9 @@ module Dpl
       opt '--acl ACL', 'Access control to set for uploaded objects', default: 'private', enum: %w(private public-read public-read-write authenticated-read bucket-owner-read bucket-owner-full-control), see: 'https://cloud.google.com/storage/docs/reference-headers#xgoogacl'
       opt '--cache_control HEADER', 'HTTP header Cache-Control to suggest that the browser cache the file.', see: 'https://cloud.google.com/storage/docs/xml-api/reference-headers#cachecontrol'
       opt '--gzip STR', 'Calls gsutil with -z to gzip files with matching extensions.', type: :array, default: ['html', 'js', 'css', 'png', 'jpg'], see: 'https://cloud.google.com/storage/docs/gsutil/commands/cp'
-      opt '--glob GLOB', default: '**/*'
 
       cmds install:   'curl -L %{URL} | tar xz -C ~ && ~/google-cloud-sdk/install.sh --path-update false --usage-reporting false --command-completion false',
            login_key: 'gcloud auth activate-service-account --key-file=%{key_file}',
-           rsync:     'gsutil %{gs_opts} rsync %{rsync_opts} %{glob} %{target}',
            copy:      'gsutil %{gs_opts} cp %{copy_opts} -r %{source} %{target}'
 
       msgs login_key:   'Authenticating with service account key file %{key_file}',
@@ -97,7 +95,6 @@ module Dpl
         def source
           path = []
           path << local_dir
-          path << glob if glob?
           "'#{File::join(path)}'"
         end
 


### PR DESCRIPTION
This is a possible solution to speed up the GCS provider (closes #1142) by passing the local_dir and `-m` to gsutil instead of copying each file individually. I don't expect this to get merged given the breaking changes, but I wanted to share this solution.

#### Breaking Changes
This introduces the following **breaking** changes for the user but makes the provider usable for users wanting to upload more than a handful of files.

`--dot_match` 
Not available with gsutil by wildcards...

> Per standard Unix behavior, the wildcard "*" only matches files that don't start with a "." character (to avoid confusion with the "." and ".." directories present in all Unix directories). gsutil provides this same behavior when using wildcards over a file system URI https://cloud.google.com/storage/docs/gsutil/addlhelp/WildcardNames

`--detect_encoding` -> `--compress_extensions` This allows using the `-z <ext, >`.
>-z  Applies gzip content-encoding to any file upload whose extension matches the -z extension list. https://cloud.google.com/storage/docs/gsutil/commands/cp#options

`--glob` was removed since the user can pass wildcard into local_dir which unfortunately is unable to match current functionality since gsutil [flattens wildcard directory structure](https://github.com/GoogleCloudPlatform/gsutil/issues/465)

#### Timing and Logs
The following timing results are run over 1.2k objects and 2.2 MiB.

Current - 1039.00s - [Build](https://travis-ci.org/googlemaps/js-samples/builds/623838218)
This PR - 34.00s - [Build](https://travis-ci.org/googlemaps/js-samples/builds/623911094)
