### PR TITLE
npm: Fix EACCES in Windows

### DIFF
--- a/lib/dpl/provider/npm.rb
+++ b/lib/dpl/provider/npm.rb
@@ -18,6 +18,7 @@ module DPL
         file = File.open(File.expand_path(NPMRC_FILE), 'w')
         file.puts(npmrc_file_content)
         file.flush
+        file.close
       end
 
       def check_auth

--- a/spec/provider/heroku_spec.rb
+++ b/spec/provider/heroku_spec.rb
@@ -226,14 +226,26 @@ describe DPL::Provider::Heroku, :api do
       provider.trigger_build
     end
 
-    example do
-      expect(provider).to receive(:log).with('triggering new deployment')
-      expect(provider).to receive(:faraday).at_least(:once).and_return(faraday)
-      expect(provider).to receive(:get_url).and_return 'http://example.com/source.tgz'
-      expect(provider).to receive(:version).and_return 'v1.3.0'
-      expect(provider.context).to receive(:shell).with("curl -sS https://build-output.heroku.com/streams/01234567-89ab-cdef-0123-456789abcdef -H 'Accept: application/vnd.heroku+json; version=3' -H 'User-Agent: dpl/#{DPL::VERSION}'")
-      provider.trigger_build
-      expect(provider.build_id).to eq('01234567-89ab-cdef-0123-456789abcdef')
+    context 'when $stdout is a TTY' do
+      before do
+        @old_stdout = $stdout
+        $stdout = StringIO.new
+        allow($stdout).to receive(:isatty).and_return(true)
+      end
+
+      after do
+        $stdout = @old_stdout
+      end
+      
+      example do
+        expect(provider).to receive(:log).with('triggering new deployment')
+        expect(provider).to receive(:faraday).at_least(:once).and_return(faraday)
+        expect(provider).to receive(:get_url).and_return 'http://example.com/source.tgz'
+        expect(provider).to receive(:version).and_return 'v1.3.0'
+        expect(provider.context).to receive(:shell).with("curl https://build-output.heroku.com/streams/01234567-89ab-cdef-0123-456789abcdef -H 'Accept: application/vnd.heroku+json; version=3' -H 'User-Agent: dpl/#{DPL::VERSION}'")
+        provider.trigger_build
+        expect(provider.build_id).to eq('01234567-89ab-cdef-0123-456789abcdef')
+      end
     end
 
     context 'when $stdout is not a TTY' do

--- a/spec/provider/npm_spec.rb
+++ b/spec/provider/npm_spec.rb
@@ -91,5 +91,6 @@ def test_setup_auth(registry = DPL::Provider::NPM::DEFAULT_NPM_REGISTRY, content
   expect(File).to receive(:open).with(File.expand_path(DPL::Provider::NPM::NPMRC_FILE), 'w').and_return(f)
   expect(f).to receive(:puts).with(content)
   allow(f).to receive(:flush)
+  allow(f).to receive(:close)
   provider.setup_auth
 end


### PR DESCRIPTION
https://travis-ci.community/t/permission-denied-apply2files-when-unlinking-c-users-travis-npmrc-in-windows/6682

Includes a cherry-picked unrelated fix from https://github.com/travis-ci/dpl/pull/1145, otherwise tests fail.