### PR TITLE
Upgrade firebase-tools to ^7.11

### DIFF
--- a/lib/dpl/providers/firebase.rb
+++ b/lib/dpl/providers/firebase.rb
@@ -9,7 +9,7 @@ module Dpl
 
       node_js '>= 8.0.0'
 
-      npm 'firebase-tools@^6.3', 'firebase'
+      npm 'firebase-tools@^7.11', 'firebase'
 
       path 'node_modules/.bin'
 

--- a/lib/dpl/providers/heroku.rb
+++ b/lib/dpl/providers/heroku.rb
@@ -3,7 +3,7 @@ module Dpl
     class Heroku < Provider
       abstract
 
-      gem 'faraday', '~> 0.9.2'
+      gem 'faraday', '~> 0.17.3'
       gem 'json'
       gem 'netrc', '~> 0.11.0'
       gem 'rendezvous', '~> 0.1.3'

--- a/spec/dpl/providers/firebase_spec.rb
+++ b/spec/dpl/providers/firebase_spec.rb
@@ -6,7 +6,7 @@ describe Dpl::Providers::Firebase do
   before { |c| subject.run if run?(c) }
 
   describe 'by default' do
-    it { should have_run '[npm:install] firebase-tools@^6.3 (firebase)' }
+    it { should have_run '[npm:install] firebase-tools@^7.11 (firebase)' }
     it { should have_run 'firebase deploy --non-interactive --token="token"' }
   end
 


### PR DESCRIPTION
Upgrading firebase-tools version to [^7.11](https://github.com/firebase/firebase-tools/releases).

This should solve the "Unexpected error has occurred" issues.