### PR TITLE
Fix #1146: update octokit version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Add npm `--run_script`, allowing one or many scripts from package.json to be run
+* Fix pages: update octokit version to 4.15.0
 
 ## dpl v2.0.0-alpha.11 (2019-10-14)
 

--- a/lib/dpl/providers/pages/api.rb
+++ b/lib/dpl/providers/pages/api.rb
@@ -18,7 +18,7 @@ module Dpl
           open_timeout: 180
         }
 
-        gem 'octokit', '~> 4.14.0'
+        gem 'octokit', '~> 4.15.0'
 
         full_name 'GitHub Pages (API)'
 

--- a/lib/dpl/providers/pages/git.rb
+++ b/lib/dpl/providers/pages/git.rb
@@ -12,7 +12,7 @@ module Dpl
           tbd
         str
 
-        gem 'octokit', '~> 4.14.0'
+        gem 'octokit', '~> 4.15.0'
         gem 'public_suffix', '~> 3.0.3'
 
         required :token, :deploy_key

--- a/lib/dpl/providers/releases.rb
+++ b/lib/dpl/providers/releases.rb
@@ -13,7 +13,7 @@ module Dpl
         tbd
       str
 
-      gem 'octokit', '~> 4.14.0'
+      gem 'octokit', '~> 4.15.0'
       gem 'mime-types', '~> 3.2.2'
       gem 'public_suffix', '~> 3.0.3'
 


### PR DESCRIPTION
The octokit 4.14.0 gem is broken due to the new faraday release.
See: [https://github.com/octokit/octokit.rb/issues/1177](https://github.com/octokit/octokit.rb/issues/1177)

This patch updates the octokit version used by dpl to 4.15.0.