### PR TITLE
Update octokit dependency to ~> 4.15.0

### DIFF
--- a/lib/dpl/providers/pages/api.rb
+++ b/lib/dpl/providers/pages/api.rb
@@ -18,7 +18,7 @@ module Dpl
           open_timeout: 180
         }
 
-        gem 'octokit', '~> 4.14.0'
+        gem 'octokit', '~> 4.15.0'
 
         full_name 'GitHub Pages (API)'
 

--- a/lib/dpl/providers/pages/git.rb
+++ b/lib/dpl/providers/pages/git.rb
@@ -12,7 +12,7 @@ module Dpl
           tbd
         str
 
-        gem 'octokit', '~> 4.14.0'
+        gem 'octokit', '~> 4.15.0'
         gem 'public_suffix', '~> 3.0.3'
 
         required :token, :deploy_key

--- a/lib/dpl/providers/releases.rb
+++ b/lib/dpl/providers/releases.rb
@@ -13,7 +13,7 @@ module Dpl
         tbd
       str
 
-      gem 'octokit', '~> 4.14.0'
+      gem 'octokit', '~> 4.15.0'
       gem 'mime-types', '~> 3.2.2'
       gem 'public_suffix', '~> 3.0.3'
 


### PR DESCRIPTION
Resolves https://travis-ci.community/t/there-was-an-error-while-trying-to-load-the-gem-octokit/6708
by using the new octokit release, which fixes dependency issue (See
https://github.com/octokit/octokit.rb/issues/1155).