### PR TITLE
Fix `[ -z $var` clauses without quotes

### DIFF
--- a/lib/dpl/assets/atlas/install
+++ b/lib/dpl/assets/atlas/install
@@ -7,7 +7,7 @@ if ! command -v atlas-upload &>/dev/null ; then
     chmod +x $HOME/bin/gimme
   fi
 
-  if [ -z $GOPATH ]; then
+  if [ -z "$GOPATH" ]; then
     export GOPATH="$HOME/gopath"
   else
     export GOPATH="$HOME/gopath:$GOPATH"

--- a/lib/dpl/assets/pypi/install
+++ b/lib/dpl/assets/pypi/install
@@ -1,4 +1,4 @@
 #!/bin/bash
-if [ -z ${VIRTUAL_ENV+x} ]; then export PIP_USER=yes; fi &&
+if [ -z "${VIRTUAL_ENV}" ]; then export PIP_USER=yes; fi &&
 wget -nv -O - https://bootstrap.pypa.io/get-pip.py | python - --no-setuptools --no-wheel &&
 pip install --upgrade --ignore-installed %{setuptools_arg} %{twine_arg} %{wheel_arg}


### PR DESCRIPTION
https://travis-ci.community/t/pypi-deploy-failing-on-windows-couldnt-install-pip-setuptools-twine-or-wheel/6338/5