### PR TITLE
allow safelisting interpolation vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Options can be given via env vars if prefixed with `[AWS_|CLOUDFORMATION_]`. E.g
 
 ### AWS Code Deploy
 
-Support for deployments to AWS Code Deploy is in **alpha**. Please see [Maturity Levels](https://github.com/travis-ci/dpl/#maturity-levels) for details.
+Support for deployments to AWS Code Deploy is in **beta**. Please see [Maturity Levels](https://github.com/travis-ci/dpl/#maturity-levels) for details.
 
 ```
 Usage: dpl codedeploy [options]
@@ -291,6 +291,11 @@ Examples:
 Options can be given via env vars if prefixed with `[AWS_|CODEDEPLOY_]`. E.g. the option
 `--access_key_id` can be given as `AWS_ACCESS_KEY_ID=<access_key_id>` or
 `CODEDEPLOY_ACCESS_KEY_ID=<access_key_id>`.
+
+The following variable are availabe for interpolation on `description`:
+
+  `application`, `bucket`, `bundle_type`, `commit_id`, `deployment_group`, `endpoint`, `file_exists_behavior`, `git_author_email`, `git_author_name`, `git_branch`, `git_commit_author`, `git_commit_msg`, `git_sha`, `git_tag`, `key`, `region`, `repository`, `revision_type`, `build_number`
+
 
 ### AWS Elastic Beanstalk
 
@@ -416,6 +421,11 @@ Options can be given via env vars if prefixed with `[AWS_|LAMBDA_]`. E.g. the op
 `--access_key_id` can be given as `AWS_ACCESS_KEY_ID=<access_key_id>` or
 `LAMBDA_ACCESS_KEY_ID=<access_key_id>`.
 
+The following variable are availabe for interpolation on `description`:
+
+  `dead_letter_arn`, `function_name`, `git_author_email`, `git_author_name`, `git_branch`, `git_commit_author`, `git_commit_msg`, `git_sha`, `git_tag`, `handler_name`, `kms_key_arn`, `memory_size`, `module_name`, `region`, `role`, `runtime`, `timeout`, `tracing_mode`, `zip`
+
+
 ### AWS OpsWorks
 
 
@@ -488,6 +498,7 @@ Options:
   --upload_dir DIR                    S3 directory to upload to (type: string)
   --local_dir DIR                     Local directory to upload from (type: string, default: ., e.g.: ~/travis/build
                                       (absolute path) or ./build (relative path))
+  --glob GLOB                         Files to upload (type: string, default: **/*)
   --[no-]dot_match                    Upload hidden files starting with a dot
   --acl ACL                           Access control for the uploaded objects (type: string, default: private, known
                                       values: private, public_read, public_read_write, authenticated_read,
@@ -608,7 +619,7 @@ as `BINTRAY_KEY=<key>`.
 
 ### Bluemix Cloud Foundry
 
-Support for deployments to Bluemix Cloud Foundry is in **alpha**. Please see [Maturity Levels](https://github.com/travis-ci/dpl/#maturity-levels) for details.
+Support for deployments to Bluemix Cloud Foundry is in **beta**. Please see [Maturity Levels](https://github.com/travis-ci/dpl/#maturity-levels) for details.
 
 ```
 Usage: dpl bluemixcloudfoundry [options]
@@ -695,7 +706,7 @@ given as `BOXFUSE_SECRET=<secret>`.
 
 ### Cargo
 
-Support for deployments to Cargo is in **beta**. Please see [Maturity Levels](https://github.com/travis-ci/dpl/#maturity-levels) for details.
+
 
 ```
 Usage: dpl cargo [options]
@@ -1063,21 +1074,37 @@ given as `FIREBASE_TOKEN=<token>`.
 
 ### Flynn
 
+Support for deployments to Flynn is in **development**. Please see [Maturity Levels](https://github.com/travis-ci/dpl/#maturity-levels) for details.
+
 ```
 Usage: dpl flynn [options]
 
+Summary:
+
+  Flynn deployment provider
+
 Description:
 
-  Flynn dpl provider
- 
+  Flynn provider for Dpl
+
 Options:
 
-  --git remote (type: string, required: true)
+  --git URL      Flynn Git remote URL (type: string, required)
+
+Common Options:
+
+  --cleanup      Clean up build artifacts from the Git working directory before the deployment
+  --run CMD      Commands to execute after the deployment finished successfully (type: array
+                 (string, can be given multiple times))
+  --help         Get help on this command
 
 Examples:
 
-  dpl flynn --git https://git.<flynn_base_url>/myapp.git
+  dpl flynn --git url
+  dpl flynn --git url --cleanup --run cmd
 ```
+
+
 
 ### GitHub Pages
 
@@ -1138,6 +1165,11 @@ Examples:
 
 Options can be given via env vars if prefixed with `[GITHUB_|PAGES_]`. E.g. the option `--token` can
 be given as `GITHUB_TOKEN=<token>` or `PAGES_TOKEN=<token>`.
+
+The following variable are availabe for interpolation on `commit_message`:
+
+  `deploy_key`, `email`, `fqdn`, `git_author_email`, `git_author_name`, `git_branch`, `git_commit_author`, `git_commit_msg`, `git_sha`, `git_tag`, `local_dir`, `name`, `project_name`, `repo`, `target_branch`, `url`
+
 
 ### GitHub Pages (API)
 
@@ -1972,7 +2004,7 @@ Examples:
 
 ### Snap
 
-Support for deployments to Snap is in **development**. Please see [Maturity Levels](https://github.com/travis-ci/dpl/#maturity-levels) for details.
+Support for deployments to Snap is in **beta**. Please see [Maturity Levels](https://github.com/travis-ci/dpl/#maturity-levels) for details.
 
 ```
 Usage: dpl snap [options]
@@ -2547,4 +2579,4 @@ This tool would not exist without your help.
 
 A huge thank you goes out to all of our current and past [contributors](https://github.com/travis-ci/dpl/graphs/contributors):
 
-5c077yP, A.J. May, A92hm, Aakriti Gupta, Aaron Hill, Aaron1011, Abdón Rodríguez Davila, Adam King, Adam Mcgrath, adinata, Adrian Moreno, Ahmad Nassri, Ahmed Refaey, Ainun Nazieb, Albertin Loic, Alexander Springer, Alexey Kotlyarov, Ali Hajimirza, Amos Wenger, Anders Olsen Sandvik, Andrey Lushchick, Andy Vanbutsele, Angelo Livanos, Anne-Julia Seitz, Antoine Savignac, Anton Babenko, Anton Ilin, Arnold Daniels, Ashen Gunaratne, awesomescot, Axel Fontaine, Baptiste Courtois, Ben Hale, Benjamin Guttmann, Bob, Bob Zoller, Brad Gignac, Brandon Burton, Brandon LeBlanc, Brian Hou, Cameron White, capotej, Carla, carlad, Chad Engler, Chathan Driehuys, Chris Patterson, Christian Elsen, Christian Rackerseder, Clay Reimann, cleem, Cryptophobia, Damien Mathieu, Dan Buch, Dan Powell, Daniel X Moore, David F. Severski, Denis Cornehl, Dennis Koot, dependabot[bot], Devin J. Pohly, Dominic Jodoin, Dwayne Forde, emdantrim, Eric Peterson, Erik Dalén, Esteban Santiesteban, Étienne Michon, eyalbe4, Fabio Napoleoni, Felix Rieseberg, fgogolli, Filip Š, Flamur Gogolli, Gabriel Saldana, George Brighton, Gil, Gil Megidish, Gil Tselenchuk, Hao Luo, Hauke Stange, Henrik Hodne, Hiro Asari, IMANAKA, Kouta, Ivan Evtuhovich, Ivan Kusalic, Ivan Pozdeev, Jacob Burkhart, Jake Hewitt, Jakub Holy, James Adam, James Awesome, James Parker, Janderson, Jannis Leidel, Jeffrey Yasskin, Jeremy Frasier, Joe Damato, Joep van Delft, Johannes Würbach, johanneswuerbach, Johnny Dobbins, Jon Benson, Jon Rowe, Jon-Erik Schneiderhan, Jonatan Männchen, Jonathan Stites, Jonathan Sundqvist, jorgecasar, Josh Kalderimis, joshua-anderson, Jouni Kaplas, Julia S.Simon, Julio Capote, jung_b@localhost, Karim Fateem, Ke Zhu, konrad-c, Konstantin Haase, Kouta Imanaka, Kristofer Svardstal, Kyle Fazzari, Kyle VanderBeek, Loïc Mahieu, Lorenz Leutgeb, Lorne Currie, Louis Lagrange, Louis St-Amour, Luke Yeager, Maciej Skierkowski, Marc, María de Antón, mariadeanton, Mariana Lenetis and Zachary Gershman, Marius Gripsgard, Mark Pundsack, marscher, Marwan Rabbâa, Mathias Meyer, Mathias Rangel Wulff, Mathias San Miguel, Matt Hernandez, Matt Knox, Matt Travi, Matthew Knox, Maxime Brugidou, mayeut, Meir Gottlieb, Michael Bleigh, Michael Dunn, Michael Friis, Michel Boudreau, Mike Bryant, Nat Welch, Nicholas Bruning, Nick Mohoric, Nico Lindemann, Nigel Ramsay, Nikhil, Ole Michaelis, Olle Jonsson, Omer Katz, Patrique Legault, Paul Beaudoin, Paul Nikitochkin, Peter, Peter Georgantas, Peter Newman, Philipp Hansch, Piotr Sarnacki, Radek Lisowski, Radosław Lisowski, Rail Aliiev, Randall A. Gordon, Robert Gogolok, Rokas Brazdžionis, Romuald Bulyshko, root, ryanj, Ryn Daniels, Samir Talwar, Samuel Wright, Sandor Zeestraten, Sascha Zarhuber, SAULEAU Sven, Scot Spinner, Sebastien Estienne, Sergei Chertkov, shunyi, Simon, Solly, Sorin Sbarnea, Soulou, Stefan Kolb, Steffen Kötte, step76, Steven Berlanga, Sven Fuchs, Sviatoslav Sydorenko, testfairy, Tim Ysewyn, Troels Thomsen, Tyler Cross, Uriah Levy, Vincent Jacques, Vojtech Vondra, Vojtěch Vondra, Wael M. Nasreddine, Wen Kokke, Wim Looman, Xavier Krantz, yeonhoyoon, Zane Williamson
+5c077yP, A.J. May, A92hm, Aakriti Gupta, Aaron Hill, Aaron1011, Abdón Rodríguez Davila, Adam King, Adam Mcgrath, adinata, Adrian Moreno, Ahmad Nassri, Ahmed Refaey, Ainun Nazieb, Albertin Loic, Alexander Springer, Alexey Kotlyarov, Ali Hajimirza, Amos Wenger, Anders Olsen Sandvik, Andrey Lushchick, Andy Vanbutsele, Angelo Livanos, Anne-Julia Seitz, Antoine Savignac, Anton Babenko, Anton Ilin, Arnold Daniels, Ashen Gunaratne, awesomescot, Axel Fontaine, Baptiste Courtois, Ben Hale, Benjamin Guttmann, Bob, Bob Zoller, Brad Gignac, Brandon Burton, Brandon LeBlanc, Brian Hou, Cameron White, capotej, Carla, carlad, Chad Engler, Chathan Driehuys, Chris Patterson, Christian Elsen, Christian Rackerseder, Clay Reimann, cleem, Cryptophobia, Damien Mathieu, Dan Buch, Dan Powell, Daniel X Moore, David F. Severski, Denis Cornehl, Dennis Koot, dependabot[bot], Devin J. Pohly, Dominic Jodoin, Dwayne Forde, emdantrim, Eric Peterson, Erik Dalén, Esteban Santiesteban, Étienne Michon, eyalbe4, Fabio Napoleoni, Felix Rieseberg, fgogolli, Filip Š, Flamur Gogolli, Gabriel Saldana, George Brighton, Gil, Gil Megidish, Gil Tselenchuk, Hao Luo, Hauke Stange, Henrik Hodne, Hiro Asari, IMANAKA, Kouta, Ivan Evtuhovich, Ivan Kusalic, Ivan Pozdeev, Jacob Burkhart, Jake Hewitt, Jakub Holy, James Adam, James Awesome, James Parker, Janderson, Jannis Leidel, Jeffrey Yasskin, Jeremy Frasier, JMSwag, Joe Damato, Joep van Delft, Johannes Würbach, johanneswuerbach, Johnny Dobbins, Jon Benson, Jon Rowe, Jon-Erik Schneiderhan, Jonatan Männchen, Jonathan Stites, Jonathan Sundqvist, jorgecasar, Josh Kalderimis, joshua-anderson, Jouni Kaplas, Julia S.Simon, Julio Capote, jung_b@localhost, Karim Fateem, Ke Zhu, konrad-c, Konstantin Haase, Kouta Imanaka, Kristofer Svardstal, Kyle Fazzari, Kyle VanderBeek, Loïc Mahieu, Lorenz Leutgeb, Lorne Currie, Louis Lagrange, Louis St-Amour, Luke Yeager, Maciej Skierkowski, Marc, María de Antón, mariadeanton, Mariana Lenetis and Zachary Gershman, Marius Gripsgard, Mark Pundsack, marscher, Marwan Rabbâa, Mathias Meyer, Mathias Rangel Wulff, Mathias San Miguel, Matt Hernandez, Matt Knox, Matt Travi, Matthew Knox, Maxime Brugidou, mayeut, Meir Gottlieb, Michael Bleigh, Michael Dunn, Michael Friis, Michel Boudreau, Mike Bryant, Nat Welch, Nicholas Bruning, Nick Mohoric, Nico Lindemann, Nigel Ramsay, Nikhil, Ole Michaelis, Olle Jonsson, Omer Katz, Patrique Legault, Paul Beaudoin, Paul Nikitochkin, Peter, Peter Georgantas, Peter Newman, Philipp Hansch, Piotr Sarnacki, Radek Lisowski, Radosław Lisowski, Rail Aliiev, Randall A. Gordon, Robert Gogolok, Rokas Brazdžionis, Romuald Bulyshko, root, ryanj, Ryn Daniels, Samir Talwar, Samuel Wright, Sandor Zeestraten, Sascha Zarhuber, SAULEAU Sven, Scot Spinner, Sebastien Estienne, Sergei Chertkov, shunyi, Simon, Solly, Sorin Sbarnea, Soulou, Stefan Kolb, Steffen Kötte, step76, Steven Berlanga, Sven Fuchs, Sviatoslav Sydorenko, testfairy, Tim Ysewyn, Troels Thomsen, Tyler Cross, Uriah Levy, Vincent Jacques, Vojtech Vondra, Vojtěch Vondra, Wael M. Nasreddine, Wen Kokke, Wim Looman, Xavier Krantz, yeonhoyoon, Zane Williamson

--- a/bin/readme
+++ b/bin/readme
@@ -4,6 +4,7 @@ $: << File.expand_path('../../lib', __FILE__)
 require 'ffi-icu'
 require 'erb'
 require 'dpl'
+require 'dpl/helper/squiggle'
 require 'dpl/helper/wrap'
 
 SKIP = %i(help heroku pages)
@@ -19,13 +20,31 @@ class Header < Struct.new(:cmd)
 end
 
 class Footer < Struct.new(:cmd)
+  extend Squiggle
   include Wrap
 
   def to_s
-    # TODO
-    return unless env = cmd.instance_variable_get(:@env) || cmd.superclass.instance_variable_get(:@env)
+    [env, vars].compact.join("\n\n")
+  end
+
+  def env
+    return unless env = cmd.instance_variable_get(:@env) || cmd.superclass.instance_variable_get(:@env) # TODO
     str = env.description(cmd)
     wrap(str, 100)
+  end
+
+  VARS = sq(<<-str)
+    The following variable are availabe for interpolation on %s:
+
+      %s
+  str
+
+  def vars
+    opts = cmd.opts.select(&:interpolate?)
+    return unless opts.any?
+    opts = opts.map(&:name).map { |name| "`#{name}`" }.join(', ')
+    vars = cmd.vars.map { |var| "`#{var}`" }.join(', ')
+    VARS % [opts, vars]
   end
 end
 

--- a/lib/dpl/provider.rb
+++ b/lib/dpl/provider.rb
@@ -152,6 +152,16 @@ module Dpl
     opt '--fold',         'Wrap log output in folds', internal: true
     opt '--edge',         internal: true
 
+    vars *%i(
+      git_author_email
+      git_author_name
+      git_branch
+      git_commit_author
+      git_commit_msg
+      git_sha
+      git_tag
+    )
+
     msgs before_install:  'Installing deployment dependencies',
          before_setup:    'Setting the build environment up for the deployment',
          setup_git_ssh:   'Setting up git-ssh',

--- a/lib/dpl/providers/codedeploy.rb
+++ b/lib/dpl/providers/codedeploy.rb
@@ -30,7 +30,7 @@ module Dpl
       opt '--wait_until_deployed', 'Wait until the deployment has finished'
       opt '--bundle_type TYPE', 'Bundle type of the revision'
       opt '--key KEY', 'S3 bucket key of the revision'
-      opt '--description DESCR', 'Description of the revision'
+      opt '--description DESCR', 'Description of the revision', interpolate: true
       opt '--endpoint ENDPOINT', 'S3 endpoint url'
 
       msgs login:                 'Using Access Key: %{access_key_id}',
@@ -43,6 +43,8 @@ module Dpl
            missing_key:           'Missing required key for S3 deployment',
            unknown_revision_type: 'Unknown revision type %p',
            unknown_bundle_type:   'Unknown bundle type'
+
+      vars :build_number
 
       def login
         info :login
@@ -152,7 +154,7 @@ module Dpl
       end
 
       def description
-        super || interpolate(msg(:description))
+        interpolate(super || msg(:description), vars: vars)
       end
 
       def build_number

--- a/lib/dpl/providers/lambda.rb
+++ b/lib/dpl/providers/lambda.rb
@@ -24,7 +24,7 @@ module Dpl
       opt '--role ROLE',              'ARN of the IAM role to assign to the Lambda function', note: 'required when creating a new function'
       opt '--handler_name NAME',      'Function the Lambda calls to begin execution.', note: 'required when creating a new function'
       opt '--module_name NAME',       'Name of the module that exports the handler', default: 'index', requires: :handler_name
-      opt '--description DESCR',      'Description of the Lambda being created or updated'
+      opt '--description DESCR',      'Description of the Lambda being created or updated', interpolate: true
       opt '--timeout SECS',           'Function execution time (in seconds) at which Lambda should terminate the function', default: 3
       opt '--memory_size MB',         'Amount of memory in MB to allocate to this Lambda', default: 128
       opt '--subnet_ids IDS',         'List of subnet IDs to be added to the function', type: :array, note: 'Needs the ec2:DescribeSubnets and ec2:DescribeVpcs permission for the user of the access/secret key to work'
@@ -157,7 +157,7 @@ module Dpl
         end
 
         def description
-          super || interpolate(msg(:description))
+          interpolate(super || msg(:description), vars: vars)
         end
 
         def client

--- a/lib/dpl/providers/pages/git.rb
+++ b/lib/dpl/providers/pages/git.rb
@@ -22,7 +22,7 @@ module Dpl
         opt '--deploy_key PATH', 'Path to a file containing a private deploy key with write access to the repository', see: 'https://developer.github.com/v3/guides/managing-deploy-keys/#deploy-keys'
         opt '--target_branch BRANCH', 'Branch to push force to', default: 'gh-pages'
         opt '--keep_history', 'Create incremental commit instead of doing push force', default: true
-        opt '--commit_message MSG', default: 'Deploy %{project_name} to %{url}:%{target_branch}'
+        opt '--commit_message MSG', default: 'Deploy %{project_name} to %{url}:%{target_branch}', interpolate: true
         opt '--allow_empty_commit', 'Allow an empty commit to be created', requires: :keep_history
         opt '--verbose', 'Be verbose about the deploy process'
         opt '--local_dir DIR', 'Directory to push to GitHub Pages', default: '.'
@@ -171,7 +171,7 @@ module Dpl
         end
 
         def git_commit_msg_opts
-          msg = interpolate(commit_message)
+          msg = interpolate(commit_message, vars: vars)
           msg.split("\n").reject(&:empty?).map { |msg| %(-m #{quote(msg)}) }
         end
 

--- a/spec/dpl/helper/interpolate_spec.rb
+++ b/spec/dpl/helper/interpolate_spec.rb
@@ -1,6 +1,11 @@
 describe Dpl::Interpolate do
-  let(:provider) { Class.new(Dpl::Provider, &body).new(ctx, %w(--password secret)) }
-  let(:body) { ->(*) { opt '--password PASS', secret: true } }
+  let(:provider) { Class.new(Dpl::Provider, &body).new(ctx, %w(--name a-name --password secret)) }
+  let(:body) do
+    ->(*) do
+      opt '--name NAME'
+      opt '--password PASS', secret: true
+    end
+  end
   let(:args) { [] }
   let(:opts) { {} }
 
@@ -38,5 +43,19 @@ describe Dpl::Interpolate do
   describe 'interpolating an undefined const' do
     let(:str) { 'string containing %{CONST}' }
     it { expect { subject }.to raise_error KeyError, 'CONST' }
+  end
+
+  describe 'safelisting vars' do
+    let(:opts) { { vars: [:name] } }
+
+    describe 'known var' do
+      let(:str) { 'string containing %{name}' }
+      it { should eq 'string containing a-name' }
+    end
+
+    describe 'unknown var' do
+      let(:str) { 'string containing %{unknown}' }
+      it { should eq 'string containing [unknown variable: unknown]' }
+    end
   end
 end


### PR DESCRIPTION
Allow safelisting interpolation vars on providers that expose interpolated strings, such as `commit_message` on `pages:git`, and add these to the generated documentation.