### PR TITLE
Elastic Beanstalk provider improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,9 @@ Options:
   --bucket_path PATH                     Location within Bucket to upload app to (type: string)
   --description DESC                     Description for the application version (type: string)
   --label LABEL                          Label for the application version (type: string)
-  --zip_file PATH                        The zip file that you want to deploy (type: string)
+  --zip_file PATH                        The zip file that you want to deploy. You probably also should set cleanup to
+                                         false if you set this. If unset, a zipfile will be created from the current
+                                         directory, honoring .ebignore and .gitignore. (type: string)
   --[no-]wait_until_deployed             Wait until the deployment has finished
   --wait_until_deployed_timeout SEC      How many seconds to wait for Elastic Beanstalk deployment update. (type:
                                          integer, default: 600)

--- a/README.md
+++ b/README.md
@@ -332,9 +332,8 @@ Options:
   --bucket_path PATH                     Location within Bucket to upload app to (type: string)
   --description DESC                     Description for the application version (type: string)
   --label LABEL                          Label for the application version (type: string)
-  --zip_file PATH                        The zip file that you want to deploy. You probably also should set cleanup to
-                                         false if you set this. If unset, a zipfile will be created from the current
-                                         directory, honoring .ebignore and .gitignore. (type: string)
+  --zip_file PATH                        The zip file that you want to deploy. If unset, a zipfile will be created
+                                         from the current directory, honoring .ebignore and .gitignore. (type: string)
   --[no-]wait_until_deployed             Wait until the deployment has finished
   --wait_until_deployed_timeout SEC      How many seconds to wait for Elastic Beanstalk deployment update. (type:
                                          integer, default: 600)
@@ -787,7 +786,7 @@ Examples:
   dpl chef_supermarket --user_id id --category cat --name name --client_key key --dir dir
 ```
 
-Options can be given via env vars if prefixed with `CHEF_`. 
+Options can be given via env vars if prefixed with `CHEF_`.
 
 ### Cloud Files
 
@@ -955,7 +954,7 @@ Examples:
   dpl convox --app app --rack rack --password pass --host host --install_url url
 ```
 
-Options can be given via env vars if prefixed with `CONVOX_`. 
+Options can be given via env vars if prefixed with `CONVOX_`.
 
 ### Datica
 
@@ -991,7 +990,7 @@ Examples:
   dpl datica --target target --path path --cleanup --run cmd
 ```
 
-Options can be given via env vars if prefixed with `[CATALYZE_|DATICA_]`. 
+Options can be given via env vars if prefixed with `[CATALYZE_|DATICA_]`.
 
 ### Engineyard
 

--- a/README.md
+++ b/README.md
@@ -320,14 +320,13 @@ Options:
   --region REGION                        AWS Region the Elastic Beanstalk app is running in (type: string, default:
                                          us-east-1)
   --app NAME                             Elastic Beanstalk application name (type: string, default: repo name)
-  --env NAME                             Elastic Beanstalk environment name which will be updated (type: string,
-                                         required)
+  --env NAME                             Elastic Beanstalk environment name which will be updated. If unset, no
+                                         environment will be updated. (type: string)
   --bucket NAME                          Bucket name to upload app to (type: string, required, alias: bucket_name)
   --bucket_path PATH                     Location within Bucket to upload app to (type: string)
   --description DESC                     Description for the application version (type: string)
   --label LABEL                          Label for the application version (type: string)
   --zip_file PATH                        The zip file that you want to deploy (type: string)
-  --[no-]only_create_app_version         Only create the app version, do not actually deploy it
   --[no-]wait_until_deployed             Wait until the deployment has finished
   --wait_until_deployed_timeout SEC      How many seconds to wait for Elastic Beanstalk deployment update. (type:
                                          integer, default: 600)

--- a/README.md
+++ b/README.md
@@ -311,8 +311,14 @@ Summary:
 
 Description:
 
-  tbd
+  Deploy to AWS Elastic Beanstalk: https://aws.amazon.com/elasticbeanstalk/
 
+  This provider:
+
+  1. Creates a zip file (or uses one you provide)
+  2. Uploads it to your EB application
+  3. (Optionally) deploys to a specific EB environment
+      a. (Optionally) waits until the deployment finishes
 Options:
 
   --access_key_id ID                     AWS Access Key ID (type: string, required)

--- a/lib/dpl/providers/elasticbeanstalk.rb
+++ b/lib/dpl/providers/elasticbeanstalk.rb
@@ -62,7 +62,7 @@ module Dpl
         create_zip unless zip_exists?
         upload
         create_version
-        update_app unless env
+        update_app unless env?
       end
 
       def zip_file

--- a/lib/dpl/providers/elasticbeanstalk.rb
+++ b/lib/dpl/providers/elasticbeanstalk.rb
@@ -23,13 +23,12 @@ module Dpl
       opt '--secret_access_key KEY', 'AWS Secret Key', required: true, secret: true
       opt '--region REGION', 'AWS Region the Elastic Beanstalk app is running in', default: 'us-east-1'
       opt '--app NAME', 'Elastic Beanstalk application name', default: :repo_name
-      opt '--env NAME', 'Elastic Beanstalk environment name which will be updated', required: true
+      opt '--env NAME', 'Elastic Beanstalk environment name which will be updated. If unset, no environment will be updated.'
       opt '--bucket NAME', 'Bucket name to upload app to', required: true, alias: :bucket_name
       opt '--bucket_path PATH', 'Location within Bucket to upload app to'
       opt '--description DESC', 'Description for the application version'
       opt '--label LABEL', 'Label for the application version'
       opt '--zip_file PATH', 'The zip file that you want to deploy'
-      opt '--only_create_app_version', 'Only create the app version, do not actually deploy it'
       opt '--wait_until_deployed', 'Wait until the deployment has finished'
       opt '--wait_until_deployed_timeout SEC', 'How many seconds to wait for Elastic Beanstalk deployment update.', type: :integer, default: 600
       opt '--debug', internal: true
@@ -56,7 +55,7 @@ module Dpl
         create_zip unless zip_exists?
         upload
         create_version
-        update_app unless only_create_app_version?
+        update_app unless env.empty?
       end
 
       def zip_file

--- a/lib/dpl/providers/elasticbeanstalk.rb
+++ b/lib/dpl/providers/elasticbeanstalk.rb
@@ -28,7 +28,7 @@ module Dpl
       opt '--bucket_path PATH', 'Location within Bucket to upload app to'
       opt '--description DESC', 'Description for the application version'
       opt '--label LABEL', 'Label for the application version'
-      opt '--zip_file PATH', 'The zip file that you want to deploy'
+      opt '--zip_file PATH', 'The zip file that you want to deploy. You probably also should set cleanup to false if you set this. If unset, a zipfile will be created from the current directory, honoring .ebignore and .gitignore.'
       opt '--wait_until_deployed', 'Wait until the deployment has finished'
       opt '--wait_until_deployed_timeout SEC', 'How many seconds to wait for Elastic Beanstalk deployment update.', type: :integer, default: 600
       opt '--debug', internal: true

--- a/lib/dpl/providers/elasticbeanstalk.rb
+++ b/lib/dpl/providers/elasticbeanstalk.rb
@@ -8,7 +8,14 @@ module Dpl
       full_name 'AWS Elastic Beanstalk'
 
       description sq(<<-str)
-        tbd
+        Deploy to AWS Elastic Beanstalk: https://aws.amazon.com/elasticbeanstalk/
+
+        This provider:
+
+        1. Creates a zip file (or uses one you provide)
+        2. Uploads it to your EB application
+        3. (Optionally) deploys to a specific EB environment
+            a. (Optionally) waits until the deployment finishes
       str
 
       gem 'aws-sdk-elasticbeanstalk', '~> 1.0'

--- a/lib/dpl/providers/elasticbeanstalk.rb
+++ b/lib/dpl/providers/elasticbeanstalk.rb
@@ -35,7 +35,7 @@ module Dpl
       opt '--bucket_path PATH', 'Location within Bucket to upload app to'
       opt '--description DESC', 'Description for the application version'
       opt '--label LABEL', 'Label for the application version'
-      opt '--zip_file PATH', 'The zip file that you want to deploy. You probably also should set cleanup to false if you set this. If unset, a zipfile will be created from the current directory, honoring .ebignore and .gitignore.'
+      opt '--zip_file PATH', 'The zip file that you want to deploy. If unset, a zipfile will be created from the current directory, honoring .ebignore and .gitignore.'
       opt '--wait_until_deployed', 'Wait until the deployment has finished'
       opt '--wait_until_deployed_timeout SEC', 'How many seconds to wait for Elastic Beanstalk deployment update.', type: :integer, default: 600
       opt '--debug', internal: true

--- a/lib/dpl/providers/elasticbeanstalk.rb
+++ b/lib/dpl/providers/elasticbeanstalk.rb
@@ -62,7 +62,7 @@ module Dpl
         create_zip unless zip_exists?
         upload
         create_version
-        update_app unless env.empty?
+        update_app unless env
       end
 
       def zip_file

--- a/spec/dpl/providers/elasticbeanstalk_spec.rb
+++ b/spec/dpl/providers/elasticbeanstalk_spec.rb
@@ -53,12 +53,6 @@ describe Dpl::Providers::Elasticbeanstalk do
     it { should create_app_version /S3Key=one%2Ftwo%2Ftravis-sha-.*.zip/ }
   end
 
-  describe 'given --only_create_app_version' do
-    before { subject.run }
-    it { should create_app_version }
-    it { should_not update_environment }
-  end
-
   describe 'given --description description' do
     before { subject.run }
     it { should create_app_version 'Description=description' }

--- a/spec/dpl/providers/elasticbeanstalk_spec.rb
+++ b/spec/dpl/providers/elasticbeanstalk_spec.rb
@@ -2,7 +2,7 @@ describe Dpl::Providers::Elasticbeanstalk do
   include Support::Matchers::Aws
 
   let(:args) { |e| required + args_from_description(e) }
-  let(:required) { %w(--access_key_id id --secret_access_key key --env env --bucket bucket) }
+  let(:required) { %w(--access_key_id id --secret_access_key key --bucket bucket) }
   let(:events) { [] }
 
   let(:client)   { Aws::ElasticBeanstalk::Client.new(stub_responses: responses) }
@@ -45,8 +45,14 @@ describe Dpl::Providers::Elasticbeanstalk do
     it { should create_app_version 'S3Bucket=bucket' }
     it { should create_app_version /S3Key=travis-sha-.*.zip/ }
     it { should create_app_version /VersionLabel=travis-sha.*/ }
-    it { should update_environment }
+    it { should_not update_environment }
   end
+
+    describe 'given --env env' do
+      before { subject.run }
+      it { should create_app_version }
+      it { should update_environment }
+    end
 
   describe 'given --bucket_path one/two' do
     before { subject.run }


### PR DESCRIPTION
Note that edf8c70a breaks backwards compatibility by removing an option. I'm thinking this is OK because dpl v2 is still not the default choice. We could keep the old option around as an (undocumented?) compatibility shim if you prefer.