### PR TITLE
update gleis gem dependency to 0.7.0

### DIFF
--- a/lib/dpl/providers/gleis.rb
+++ b/lib/dpl/providers/gleis.rb
@@ -9,7 +9,7 @@ module Dpl
         tbd
       str
 
-      gem 'gleis', '~> 0.7.0'
+      gem 'gleis', '~> 0.8.0'
 
       env :gleis
 

--- a/lib/dpl/providers/gleis.rb
+++ b/lib/dpl/providers/gleis.rb
@@ -9,7 +9,7 @@ module Dpl
         tbd
       str
 
-      gem 'gleis', '~> 0.6.0'
+      gem 'gleis', '~> 0.7.0'
 
       env :gleis
 


### PR DESCRIPTION
This PR updates the gleis gem dependency from version 0.6 to 0.7 for the Gleis provider as version 0.7.0 has been released yesterday (https://rubygems.org/gems/gleis).