### PR TITLE
Fail CodeDeploy when wait_until_deployed fails

### DIFF
--- a/lib/dpl/providers/codedeploy.rb
+++ b/lib/dpl/providers/codedeploy.rb
@@ -84,8 +84,12 @@ module Dpl
       def wait_until_deployed(id)
         print :waiting_for_deploy
         status = poll(id) until %w(Succeeded Failed Stopped).include?(status)
-        error "Waiting terminated with status: #{status}" if status != 'Succeeded'
-        info :finished_deploy, status
+        case status
+        when 'Succeeded'
+          info :finished_deploy, status
+        else
+          error :finished_deploy, status
+        end
       end
 
       def poll(id)

--- a/lib/dpl/providers/codedeploy.rb
+++ b/lib/dpl/providers/codedeploy.rb
@@ -84,6 +84,7 @@ module Dpl
       def wait_until_deployed(id)
         print :waiting_for_deploy
         status = poll(id) until %w(Succeeded Failed Stopped).include?(status)
+        error "Waiting terminated with status: #{status}" if status != 'Succeeded'
         info :finished_deploy, status
       end
 

--- a/spec/dpl/providers/codedeploy_spec.rb
+++ b/spec/dpl/providers/codedeploy_spec.rb
@@ -97,7 +97,7 @@ describe Dpl::Providers::Codedeploy do
       }
     end
 
-    it { expect { subject.run }.to raise_error 'Waiting terminated with status: Failed' }
+    it { expect { subject.run }.to raise_error(/Failed/)}
   end
 
   describe 'with ~/.aws/credentials', run: false do

--- a/spec/dpl/providers/codedeploy_spec.rb
+++ b/spec/dpl/providers/codedeploy_spec.rb
@@ -86,6 +86,20 @@ describe Dpl::Providers::Codedeploy do
     it { should get_deployment }
   end
 
+  describe 'given --wait_until_deployed', run: false do
+    let(:responses) do
+      {
+        eb: {
+          get_deployment: {
+            deployment_info: { status: 'Failed' }
+          }
+        }
+      }
+    end
+
+    it { expect { subject.run }.to raise_error 'Waiting terminated with status: Failed' }
+  end
+
   describe 'with ~/.aws/credentials', run: false do
     let(:args) { |e| %w(--application app) }
 


### PR DESCRIPTION
Specifically, if the eventually returned status is not 'Succeeded', then
the deploy fails with a message indicating that waiting was terminated
and the returned status.

This change includes a test that asserts that the failure is correctly
raised in this case.

With some additional effort I could set up a script that should provoke
a non-'Succeeded' status code and prove out the integration itself,
please let me know if that's desired.

I'm definitely also open to feedback on the style of the returned
error message.

Closes: #1186