### PR TITLE
Remove python requirement for dpl-v2 google cloud storage

### DIFF
--- a/lib/dpl/providers/gcs.rb
+++ b/lib/dpl/providers/gcs.rb
@@ -15,8 +15,6 @@ module Dpl
 
       gem 'mime-types', '~> 3.2.2'
 
-      python '>= 2.7.9'
-
       env :gcs
 
       required :key_file, [:access_key_id, :secret_access_key]


### PR DESCRIPTION
I don't know if this is right, but it helped with my project