### PR TITLE
Fix parsing of metadata.rb for chef_supermarket provider

### DIFF
--- a/lib/dpl/providers/chef_supermarket.rb
+++ b/lib/dpl/providers/chef_supermarket.rb
@@ -80,7 +80,11 @@ module Dpl
         end
 
         def name_from_rb
-          Chef::Cookbook::Metadata.new.from_file('metadata.rb') if file?('metadata.rb')
+          if file?('metadata.rb')
+            metadata = Chef::Cookbook::Metadata.new
+            metadata.from_file('metadata.rb')
+            metadata.name
+          end
         end
 
         def cookbook

--- a/spec/dpl/providers/chef_supermarket_spec.rb
+++ b/spec/dpl/providers/chef_supermarket_spec.rb
@@ -8,7 +8,7 @@ describe Dpl::Providers::ChefSupermarket do
   file 'chef.pem'
   file 'metadata.json', '{"name":"dpl"}'
   # metadata must be more than one property, see #1199
-  file 'metadata.rb', <<~METADATA
+  file 'metadata.rb', <<-METADATA
     name "dpl"
     description "something"
   METADATA

--- a/spec/dpl/providers/chef_supermarket_spec.rb
+++ b/spec/dpl/providers/chef_supermarket_spec.rb
@@ -7,7 +7,11 @@ describe Dpl::Providers::ChefSupermarket do
 
   file 'chef.pem'
   file 'metadata.json', '{"name":"dpl"}'
-  file 'metadata.rb', 'name "dpl"'
+  # metadata must be more than one property, see #1199
+  file 'metadata.rb', <<~METADATA
+    name "dpl"
+    description "something"
+  METADATA
 
   before do |c|
     # all this stubbing business makes the tests rather ineffective


### PR DESCRIPTION
Apparently Chef::Cookbook::Metadata.new.from_file('metadata.rb') only returns the last token of the metadata. Since the name is most likely not the last token the deployment failed since the name was something else, usually a version from a depends

This was changed so the metadata is an instance that is populated by from_file() and then the name property is returned.

This fixes #1199 

As a side note: The unit test passed because the metadata.rb in the test was only the name property.