### PR TITLE
snap: `push` is replaced with `upload`

### DIFF
--- a/lib/dpl/providers/snap.rb
+++ b/lib/dpl/providers/snap.rb
@@ -21,7 +21,7 @@ module Dpl
            update_snapd:   'sudo apt-get install snapd',
            install:        'sudo snap install snapcraft --classic',
            login:          'echo "%{token}" | snapcraft login --with -',
-           deploy:         'snapcraft push %{snap_path} --release=%{channel}'
+           deploy:         'snapcraft upload %{snap_path} --release=%{channel}'
 
       msgs login:          'Attemping to login ...',
            no_snaps:       'No snap found matching %{snap}',

--- a/spec/dpl/providers/snap_spec.rb
+++ b/spec/dpl/providers/snap_spec.rb
@@ -9,16 +9,16 @@ describe Dpl::Providers::Snap do
     it { should have_run '[apt:get] snapd (snap)' }
     it { should have_run 'sudo snap install snapcraft --classic' }
     it { should have_run 'echo "token" | snapcraft login --with -' }
-    it { should have_run 'snapcraft push ./snap --release=edge' }
+    it { should have_run 'snapcraft upload ./snap --release=edge' }
     it { should have_run_in_order }
   end
 
   describe 'given --snap ./sn*' do
-    it { should have_run 'snapcraft push ./snap --release=edge' }
+    it { should have_run 'snapcraft upload ./snap --release=edge' }
   end
 
   describe 'given --snap ./snap --channel channel' do
-    it { should have_run 'snapcraft push ./snap --release=channel' }
+    it { should have_run 'snapcraft upload ./snap --release=channel' }
   end
 
   describe 'given --snap ./snap', run: false do


### PR DESCRIPTION
Fixes deprecation warning

    DEPRECATED: The 'push' set of commands have been replaced with 'upload'.
    See http://snapcraft.io/docs/deprecation-notices/dn11 for more information.

https://travis-ci.org/github/yakshaveinc/linux/jobs/714166058#L397-L398