### PR TITLE
Add netlify --json flag option

### DIFF
--- a/lib/dpl/providers/netlify.rb
+++ b/lib/dpl/providers/netlify.rb
@@ -24,7 +24,9 @@ module Dpl
       def deploy
         output = shell "netlify deploy #{deploy_opts}", echo: false, capture:true
         info output
-        json && (shell "export NETLIFY_DEPLOY_JSON_ID_#{site.gsub(/-/, '_')}=\"#{output.gsub(/\n/,'').gsub(/"/, '\"')}\"")
+        if json
+          write_file "./NETLIFY_DEPLOY_JSON_ID_#{site}.json", output
+        end
       end
 
       private

--- a/lib/dpl/providers/netlify.rb
+++ b/lib/dpl/providers/netlify.rb
@@ -19,15 +19,17 @@ module Dpl
       opt '--functions FUNCS', 'Specify a functions folder to deploy'
       opt '--message MSG',     'A message to include in the deploy log'
       opt '--prod',            'Deploy to production'
+      opt '--json',            'Output json data'
 
       def deploy
-        shell "netlify deploy #{deploy_opts}"
+        output = shell "netlify deploy #{deploy_opts}"
+        json && (shell "export NETLIFY_DEPLOY_JSON_ID_#{site.gsub(/-/, '_')}=#{output}")
       end
 
       private
 
         def deploy_opts
-          opts_for(%i(site auth dir functions message prod))
+          opts_for(%i(site auth dir functions message prod json))
         end
     end
   end

--- a/lib/dpl/providers/netlify.rb
+++ b/lib/dpl/providers/netlify.rb
@@ -22,8 +22,9 @@ module Dpl
       opt '--json',            'Output json data'
 
       def deploy
-        output = shell "netlify deploy #{deploy_opts}"
-        json && (shell "export NETLIFY_DEPLOY_JSON_ID_#{site.gsub(/-/, '_')}=#{output}")
+        output = shell "netlify deploy #{deploy_opts}", echo: false, capture:true
+        info output
+        json && (shell "export NETLIFY_DEPLOY_JSON_ID_#{site.gsub(/-/, '_')}=\"#{output.gsub(/\n/,'').gsub(/"/, '\"')}\"")
       end
 
       private

--- a/lib/dpl/providers/netlify.rb
+++ b/lib/dpl/providers/netlify.rb
@@ -25,7 +25,7 @@ module Dpl
         output = shell "netlify deploy #{deploy_opts}", echo: false, capture:true
         info output
         if json
-          write_file "./NETLIFY_DEPLOY_JSON_ID_#{site}.json", output
+          shell "echo \"#{output.gsub(/\n/, '').gsub(/"/, '\"')}\" > ./NETLIFY_DEPLOY_JSON_ID_#{site}.json"
         end
       end
 

--- a/spec/dpl/providers/netlify_spec.rb
+++ b/spec/dpl/providers/netlify_spec.rb
@@ -26,7 +26,6 @@ describe Dpl::Providers::Netlify do
 
   describe 'given --json' do
     it { should have_run 'netlify deploy --site="id" --auth="token" --json' }
-    it { should have_env NETLIFY_DEPLOY_JSON_ID_id }
   end
 
   describe 'with credentials in env vars', run: false do

--- a/spec/dpl/providers/netlify_spec.rb
+++ b/spec/dpl/providers/netlify_spec.rb
@@ -24,6 +24,11 @@ describe Dpl::Providers::Netlify do
     it { should have_run 'netlify deploy --site="id" --auth="token" --prod' }
   end
 
+  describe 'given --json' do
+    it { should have_run 'netlify deploy --site="id" --auth="token" --json' }
+    it { should have_env NETLIFY_DEPLOY_JSON_ID_id }
+  end
+
   describe 'with credentials in env vars', run: false do
     let(:args) { %w(--site id) }
     env NETLIFY_AUTH: 'token'


### PR DESCRIPTION
My attempt at #1206. I don't know Ruby much or the codebase. This works for me at the moment, but is probably somehow broken. I wouldn't be offended if someone wanted to do this differently.

I couldn't get Ruby, bundle, rspec to work locally so I tested it by running it on my deployment :hand_over_mouth:. Although it turned out Travis automatically runs tests for forks of `dpl` (?) so I used that as well.

Initially the idea was to export an environment variable, but it was not accessible in the `after_deploy` script. The current solution is to write a `./NETLIFY_DEPLOY_JSON_ID_<SITE_ID>.json` file. If someone deploys the whole repo I guess this could be a problem, I guess home directory would be better?

Turns out it's not being saved in `$TRAVIS_BUILD_DIR` as I expected but somewhere else? Does anyone know where I can find that file 🥺 ? Ok it turns out it is being saved to wherever you `cd` inside `before_deploy` which makes sense.