### PR TITLE
Add --strategy option to the CloudFoundry provider

### DIFF
--- a/lib/dpl/providers/cloudfoundry.rb
+++ b/lib/dpl/providers/cloudfoundry.rb
@@ -22,6 +22,7 @@ module Dpl
       opt '--buildpack PACK',      'Buildpack name or Git URL'
       opt '--manifest FILE',       'Path to the manifest'
       opt '--skip_ssl_validation', 'Skip SSL validation'
+      opt '--strategy STRATEGY',   'Deployment strategy, either rolling or null'
       opt '--v3',                  'Use the v3 API version to push the application'
       opt '--logout', default: true, internal: true
 
@@ -70,6 +71,7 @@ module Dpl
           args = []
           args << quote(app_name)  if app_name?
           args << "-f #{manifest}" if manifest?
+          args << "--strategy #{strategy}" if strategy?
           args.join(' ')
         end
 


### PR DESCRIPTION
The new CLI v7 has a new strategy option for rolling deploy:
https://docs.cloudfoundry.org/devguide/deploy-apps/rolling-deploy.html

Fix #910 
Depends on #1211