### PR TITLE
Update CloudFoundry CLI to v7

### DIFF
--- a/lib/dpl/providers/cloudfoundry.rb
+++ b/lib/dpl/providers/cloudfoundry.rb
@@ -22,7 +22,7 @@ module Dpl
       opt '--buildpack PACK',      'Buildpack name or Git URL'
       opt '--manifest FILE',       'Path to the manifest'
       opt '--skip_ssl_validation', 'Skip SSL validation'
-      opt '--strategy STRATEGY',   'Deployment strategy, either rolling or null'
+      opt '--deployment_strategy STRATEGY', 'Deployment strategy, either rolling or null'
       opt '--v3',                  'Use the v3 API version to push the application'
       opt '--logout', default: true, internal: true
 
@@ -71,7 +71,7 @@ module Dpl
           args = []
           args << quote(app_name)  if app_name?
           args << "-f #{manifest}" if manifest?
-          args << "--strategy #{strategy}" if strategy?
+          args << "--deployment_strategy #{deployment_strategy}" if deployment_strategy?
           args.join(' ')
         end
 

--- a/lib/dpl/providers/cloudfoundry.rb
+++ b/lib/dpl/providers/cloudfoundry.rb
@@ -25,7 +25,7 @@ module Dpl
       opt '--v3',                  'Use the v3 API version to push the application'
       opt '--logout', default: true, internal: true
 
-      cmds install: 'test $(uname) = "Linux" && rel="linux64-binary" || rel="macosx64"; wget "https://cli.run.pivotal.io/stable?release=${rel}&source=github" -qO cf.tgz && tar -zxvf cf.tgz && rm cf.tgz',
+      cmds install: 'test $(uname) = "Linux" && rel="linux64-binary" || rel="macosx64"; wget "https://cli.run.pivotal.io/stable?release=${rel}&version=v7&source=github" -qO cf.tgz && tar -zxvf cf.tgz && rm cf.tgz',
            api:     './cf api %{api} %{skip_ssl_validation_opt}',
            login:   './cf login -u %{username} -p %{password} -o %{organization} -s %{space}',
            push:    './cf %{push_cmd} %{push_args}',

--- a/lib/dpl/providers/cloudfoundry.rb
+++ b/lib/dpl/providers/cloudfoundry.rb
@@ -71,7 +71,7 @@ module Dpl
           args = []
           args << quote(app_name)  if app_name?
           args << "-f #{manifest}" if manifest?
-          args << "--deployment_strategy #{deployment_strategy}" if deployment_strategy?
+          args << "--strategy #{deployment_strategy}" if deployment_strategy?
           args.join(' ')
         end
 

--- a/lib/dpl/providers/cloudfoundry.rb
+++ b/lib/dpl/providers/cloudfoundry.rb
@@ -22,6 +22,7 @@ module Dpl
       opt '--buildpack PACK',      'Buildpack name or Git URL'
       opt '--manifest FILE',       'Path to the manifest'
       opt '--skip_ssl_validation', 'Skip SSL validation'
+      opt '--strategy STRATEGY',   'Deployment strategy, either rolling or null'
       opt '--v3',                  'Use the v3 API version to push the application'
       opt '--logout', default: true, internal: true
 
@@ -70,6 +71,7 @@ module Dpl
           args = []
           args << quote(app_name)  if app_name?
           args << "-f #{manifest}" if manifest?
+          args << "--strategy #{strategy}" if strategy?
           args.join(' ')
         end
 

--- a/spec/dpl/providers/cloudfoundry_spec.rb
+++ b/spec/dpl/providers/cloudfoundry_spec.rb
@@ -28,7 +28,7 @@ describe Dpl::Providers::Cloudfoundry do
   end
 
   describe 'given --deployment_strategy rolling' do
-    it { should have_run './cf push --deployment_strategy rolling' }
+    it { should have_run './cf push --strategy rolling' }
   end
 
   describe 'given --v3' do

--- a/spec/dpl/providers/cloudfoundry_spec.rb
+++ b/spec/dpl/providers/cloudfoundry_spec.rb
@@ -27,8 +27,8 @@ describe Dpl::Providers::Cloudfoundry do
     it { should have_run './cf push -f other.yml' }
   end
 
-  describe 'given --strategy rolling' do
-    it { should have_run './cf push --strategy rolling' }
+  describe 'given --deployment_strategy rolling' do
+    it { should have_run './cf push --deployment_strategy rolling' }
   end
 
   describe 'given --v3' do

--- a/spec/dpl/providers/cloudfoundry_spec.rb
+++ b/spec/dpl/providers/cloudfoundry_spec.rb
@@ -27,6 +27,10 @@ describe Dpl::Providers::Cloudfoundry do
     it { should have_run './cf push -f other.yml' }
   end
 
+  describe 'given --strategy rolling' do
+    it { should have_run './cf push --strategy rolling' }
+  end
+
   describe 'given --v3' do
     it { should have_run './cf v3-push' }
   end


### PR DESCRIPTION
Official instructions:

https://github.com/cloudfoundry/cli/blob/master/doc/installation-instructions/installation-instructions-v7.md#installers-and-compressed-binaries

Also adding support to the new CLI v7 has a new strategy option for rolling deploy:
https://docs.cloudfoundry.org/devguide/deploy-apps/rolling-deploy.html

Fix #910