### PR TITLE
Install prerelease versions of `dpl-*`

### DIFF
--- a/lib/dpl/provider.rb
+++ b/lib/dpl/provider.rb
@@ -81,7 +81,7 @@ module DPL
             # don't know what to do with this error
             raise e
           end
-          install_cmd = "gem install dpl-#{provider_gem_name || opt} -v #{ENV['DPL_VERSION'] || DPL::VERSION}"
+          install_cmd = "gem install --pre dpl-#{provider_gem_name || opt} -v #{ENV['DPL_VERSION'] || DPL::VERSION}"
 
           if File.exist?(local_gem = File.join(Dir.pwd, "dpl-#{GEM_NAME_OF[provider_gem_name] || opt_lower}-#{ENV['DPL_VERSION'] || DPL::VERSION}.gem"))
             install_cmd = "gem install #{local_gem}"

--- a/spec/provider_spec.rb
+++ b/spec/provider_spec.rb
@@ -23,7 +23,7 @@ describe DPL::Provider do
     end
 
     it "installs correct gem when provider name does not match" do
-      expect(context).to receive(:shell).with("gem install dpl-cloud_foundry -v #{ENV['DPL_VERSION'] || DPL::VERSION}")
+      expect(context).to receive(:shell).with("gem install --pre dpl-cloud_foundry -v #{ENV['DPL_VERSION'] || DPL::VERSION}")
       expect(described_class).to receive(:require).with("dpl/provider/cloud_foundry").and_raise LoadError.new("cannot load such file -- dpl/provider/cloud_foundry")
       expect(described_class).to receive(:require).with("dpl/provider/cloud_foundry").and_call_original
       described_class.new(context, :provider => 'cloudfoundry')


### PR DESCRIPTION
Versions automatically uploaded on commits into `travis-ci/dpl/v1` are considered prereleases and as such, are not installed by `gem install` without `--pre`.

Supplemental to https://github.com/travis-ci/travis-build/pull/1972