### PR TITLE
Allow embedded newlines in arguments

### DIFF
--- a/dpl-chef_supermarket.gemspec
+++ b/dpl-chef_supermarket.gemspec
@@ -12,7 +12,7 @@ if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.3.0")
 elsif Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.4.0")
   gemspec_for 'chef_supermarket', (deps << ['chef', '~> 13.0'])
 elsif Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.5.0")
-  gemspec_for 'chef_supermarket', (deps << ['chef', '~> 14.0'])
+  gemspec_for 'chef_supermarket', (deps << ['chef', '~> 14.0'] << ['chef-utils', '<= 16.6.14'])
 elsif Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.6.0")
   gemspec_for 'chef_supermarket', (deps << ['chef', '~> 15.0'] << ['chef-zero', '<= 14.0.17'])
 else

--- a/lib/dpl/cli.rb
+++ b/lib/dpl/cli.rb
@@ -7,7 +7,7 @@ module DPL
       new(args).run
     end
 
-    OPTION_PATTERN = /\A--([a-z][a-z_\-]*)(?:=(.+))?\z/
+    OPTION_PATTERN = /\A--([a-z][a-z_\-]*)(?:=(.+))?\z/m
     attr_accessor :options, :fold_count
 
     def initialize(*args)

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -5,7 +5,7 @@ describe DPL::CLI do
   describe "#options" do
     example { expect(described_class.new.options[:app])                           .to eq(File.basename(Dir.pwd)) }
     example { expect(described_class.new(:app => 'foo')            .options[:app]).to eq('foo')                  }
-    example { expect(described_class.new("--app=foo")              .options[:app]).to eq('foo')                  }
+    example { expect(described_class.new("--app=foo\nbar")         .options[:app]).to eq("foo\nbar")             }
     example { expect(described_class.new("--app")                  .options[:app]).to eq(true)                   }
     example { expect(described_class.new("--app=foo", "--app=bar") .options[:app]).to eq(['foo', 'bar'])         }
 


### PR DESCRIPTION
https://travis-ci.community/t/deploy-scripts-not-supporting-multiline-strings/8297

The arg is now passed correctly but DPL rejects it due to it not matching `OPTION_PATTERN`.