### PR TITLE
Clean provider, always unshallow git repository and add new deploy method by archive

### DIFF
--- a/README.md
+++ b/README.md
@@ -2098,11 +2098,10 @@ Options:
                          api_token))
   --username NAME        Scalingo username (type: string)
   --password PASS        Scalingo password (type: string)
-  --region REGION        Scalingo region (type: string, default: agora-fr1, known values: agora-fr1,
-                         osc-fr1)
+  --region REGION        Scalingo region (type: string, default: osc-fr1, known values: osc-fr1, osc-secnum-fr1)
   --remote REMOTE        Git remote name (type: string, default: scalingo-dpl)
-  --branch BRANCH        Git branch (type: string, default: master)
   --timeout SEC          Timeout for Scalingo CLI commands (type: integer, default: 60)
+  --deploy-method METHOD Method of deployment, git or archive (type: string, default: 'git')
 
 Common Options:
 
@@ -2115,7 +2114,7 @@ Examples:
 
   dpl scalingo --api_token token
   dpl scalingo --username name --password pass
-  dpl scalingo --api_token token --app app --region agora-fr1 --remote remote --branch branch
+  dpl scalingo --api_token token --app app --region agora-fr1 --remote remote
 ```
 
 Options can be given via env vars if prefixed with `SCALINGO_`. E.g. the option `--password` can be

--- a/lib/dpl/providers/scalingo.rb
+++ b/lib/dpl/providers/scalingo.rb
@@ -66,6 +66,12 @@ module Dpl
 
       def deploy
         if deploy_method == 'git'
+          # pushing code from a shallow repository is not possible with git,
+          # the :fetch action aims at transforming a shallow clone of the
+          # repository usually used by CIs to a complete git repository
+          #
+          # If the repository is already full, the command will return an error
+          # we will ignore (assert: false)
           shell :fetch, assert: false
           shell :push
         elsif deploy_method == 'archive'

--- a/lib/dpl/providers/scalingo.rb
+++ b/lib/dpl/providers/scalingo.rb
@@ -17,26 +17,31 @@ module Dpl
       opt '--api_token TOKEN', 'Scalingo API token', alias: :api_key, deprecated: :api_key
       opt '--username NAME', 'Scalingo username'
       opt '--password PASS', 'Scalingo password', secret: true
-      opt '--region REGION', 'Scalingo region', default: 'agora-fr1', enum: %w(agora-fr1 osc-fr1)
+      opt '--region REGION', 'Scalingo region', default: 'osc-fr1'
       opt '--remote REMOTE', 'Git remote name', default: 'scalingo-dpl'
-      opt '--branch BRANCH', 'Git branch', default: 'master'
       opt '--timeout SEC', 'Timeout for Scalingo CLI commands', default: 60, type: :integer
+      opt '--deploy-method METHOD', 'Method of deployment, git or archive', default: 'git'
 
       needs :git, :ssh_key
 
-      cmds login_key:   'timeout %{timeout} ./scalingo login --api-token %{api_token} > /dev/null',
-           login_creds: 'echo -e \"%{username}\n%{password}\" | timeout %{timeout} ./scalingo login > /dev/null',
-           add_key:     'timeout %{timeout} ./scalingo keys-add dpl_tmp_key %{key}',
-           remove_key:  'timeout %{timeout} ./scalingo keys-remove dpl_tmp_key',
-           git_setup:   './scalingo --app %{app} git-setup --remote %{remote}',
-           push:        'git push %{remote} HEAD:%{branch} -f'
+      cmds login_key:      'timeout %{timeout} ./scalingo login --api-token %{api_token} > /dev/null',
+           login_creds:    'echo -e \"%{username}\n%{password}\" | timeout %{timeout} ./scalingo login > /dev/null',
+           add_key:        'timeout %{timeout} ./scalingo keys-add dpl_tmp_key %{key}',
+           remove_key:     'timeout %{timeout} ./scalingo keys-remove dpl_tmp_key',
+           git_setup:      './scalingo --app %{app} git-setup --remote %{remote}',
+           fetch:          'git fetch origin --unshallow',
+           push:           'git push %{remote} HEAD:refs/heads/master -f',
+           archive:        'git archive --prefix dpl-scalingo-deploy/ HEAD | gzip - > dpl-scalingo-deploy.tar.gz',
+           archive_deploy: './scalingo --app %{app} deploy "dpl-scalingo-deploy.tar.gz" "%{ref}"'
 
-      errs install:    'Failed to install the Scalingo CLI.',
-           login:      'Failed to authenticate with the Scalingo API.',
-           add_key:    'Failed to add the ssh key.',
-           remove_key: 'Failed to remove the ssh key.',
-           git_setup:  'Failed to add the git remote.',
-           push:       'Failed to push the app.'
+      errs install:        'Failed to install the Scalingo CLI.',
+           login:          'Failed to authenticate with the Scalingo API.',
+           add_key:        'Failed to add the ssh key.',
+           remove_key:     'Failed to remove the ssh key.',
+           git_setup:      'Failed to add the git remote.',
+           push:           'Failed to push the app.',
+           archive:        'Failed to create code archive',
+           archive_deploy: 'Failed to deploy the code archive'
 
       def install
         script :install
@@ -48,19 +53,38 @@ module Dpl
       end
 
       def add_key(key, type = nil)
+        return if deploy_method == 'archive'
+
         shell :add_key, key: key
       end
 
       def setup
+        return if deploy_method == 'archive'
+
         shell :git_setup
       end
 
       def deploy
-        shell :push
+        if deploy_method == 'git'
+          shell :fetch, assert: false
+          shell :push
+        elsif deploy_method == 'archive'
+          shell :archive
+          shell :archive_deploy, ref: archive_ref
+        end
       end
 
       def remove_key
+        return if deploy_method == 'archive'
+
         shell :remove_key
+      end
+
+      private
+
+      def archive_ref
+        # Compatibility with Gitlab CI and Travis CI
+        ENV['CI_COMMIT_SHA'] || ENV['TRAVIS_COMMIT'] || "dpl-#{Time.now.to_i.to_s}"
       end
     end
   end

--- a/spec/dpl/providers/scalingo_spec.rb
+++ b/spec/dpl/providers/scalingo_spec.rb
@@ -7,7 +7,8 @@ describe Dpl::Providers::Scalingo do
     it { should have_run %r(curl --remote-name --location https://cli-dl.scalingo.io/release/scalingo_latest_linux_amd64.tar.gz) }
     it { should have_run %r(timeout 60 ./scalingo login --api-token token) }
     it { should have_run 'timeout 60 ./scalingo keys-add dpl_tmp_key ~/.dpl/id_rsa.pub' }
-    it { should have_run 'git push scalingo-dpl HEAD:master -f' }
+    it { should have_run 'git fetch origin --unshallow' }
+    it { should have_run 'git push scalingo-dpl HEAD:refs/heads/master -f' }
     it { should have_run 'timeout 60 ./scalingo keys-remove dpl_tmp_key' }
     it { should have_run_in_order }
   end
@@ -20,16 +21,17 @@ describe Dpl::Providers::Scalingo do
     it { should have_run %r(echo -e "user\npass" | timeout 60 ./scalingo login) }
   end
 
-  describe 'given --api_token key --branch branch' do
-    it { should have_run 'git push scalingo-dpl HEAD:branch -f' }
-  end
-
   describe 'given --api_token key --app app' do
     it { should have_run %r(./scalingo --app app git-setup --remote scalingo-dpl) }
   end
 
   describe 'given --api_token key --app app --remote remote' do
     it { should have_run %r(./scalingo --app app git-setup --remote remote) }
+  end
+
+  describe 'given --api_token key --app app --deploy-method archive' do
+    it { should have_run %r(git archive --prefix dpl-scalingo-deploy/ HEAD | gzip - > dpl-scalingo-deploy.tar.gz) }
+    it { should have_run %r(./scalingo --app app deploy "dpl-scalingo-deploy.tar.gz" ".+") }
   end
 
   describe 'invalid credentials', run: false do


### PR DESCRIPTION
For the `scalingo` provider:

* Remove flag `--branch` unused and unusable by users
* Add flag `--deploy-method` allowing the ability to deploy through `git` or `archive` quite similar to provider `heroku:api` vs `heroku:git` but gathered together.
* With `git` method, always unshallow git repository to allow `git push` without any warning/error