### PR TITLE
pages: Fix deploy keys

### DIFF
--- a/lib/dpl/assets/dpl/git_ssh
+++ b/lib/dpl/assets/dpl/git_ssh
@@ -1,2 +1,8 @@
 #!/bin/sh
-exec ssh -o StrictHostKeychecking=no -o CheckHostIP=no -o UserKnownHostsFile=/dev/null -i %s $@
+exec ssh \
+	-o CheckHostIP=no \
+	-o IdentitiesOnly=yes \
+	-o StrictHostKeychecking=no \
+	-o UserKnownHostsFile=/dev/null \
+	-i %s \
+	$@

--- a/lib/dpl/providers/pages/git.rb
+++ b/lib/dpl/providers/pages/git.rb
@@ -58,7 +58,7 @@ module Dpl
         cmds git_clone:           'git clone --quiet --branch="%{target_branch}" --depth=1 "%{remote_url}" . > /dev/null 2>&1',
              git_init:            'git init .',
              git_checkout:        'git checkout --orphan "%{target_branch}"',
-             check_deploy_key:    'ssh -i %{key} -T git@github.com 2>&1 | grep successful > /dev/null',
+             check_deploy_key:    'ssh -i %{key} -T git@%{url} 2>&1 | grep successful > /dev/null',
              copy_files:          'rsync -rl --exclude .git --delete "%{src_dir}/" .',
              git_config_email:    'git config user.email %{quoted_email}',
              git_config_name:     'git config user.name %{quoted_name}',
@@ -119,7 +119,7 @@ module Dpl
           mv deploy_key, path
           chmod 0600, path
           setup_git_ssh path
-          shell :check_deploy_key, key: path
+          shell :check_deploy_key, key: path, url: opts[:url]
         end
 
         def git_clone?

--- a/lib/dpl/providers/pages/git.rb
+++ b/lib/dpl/providers/pages/git.rb
@@ -68,7 +68,7 @@ module Dpl
              git_commit_hook:     'cp %{path} .git/hooks/pre-commit',
              git_commit:          'git commit %{git_commit_opts} -q %{git_commit_msg_opts}',
              git_show:            'git show --stat-count=10 HEAD',
-             git_push:            'git push%{git_push_opts} --quiet "%{remote_url}" "%{target_branch}":"%{target_branch}" > /dev/null 2>&1'
+             git_push:            'git push%{git_push_opts} --quiet "%{remote_url}" "%{target_branch}":"%{target_branch}"'
 
         errs copy_files:          'Failed to copy %{src_dir}.',
              check_deploy_key:    'Failed to authenticate using the deploy key',
@@ -155,7 +155,8 @@ module Dpl
         end
 
         def git_push
-          shell :git_push, echo: false
+          shell 'ssh-keygen -lv -f /home/travis/.dpl/deploy_key'
+          shell :git_push
         end
 
         def git_status

--- a/spec/dpl/providers/pages/git_spec.rb
+++ b/spec/dpl/providers/pages/git_spec.rb
@@ -27,7 +27,7 @@ describe Dpl::Providers::Pages do
     it { should have_run 'git commit -q -m "Deploy travis-ci/dpl to github.com/travis-ci/dpl.git:gh-pages"' }
     it { should have_run 'git show --stat-count=10 HEAD' }
     it { should have_run '[info] Pushing to github.com/travis-ci/dpl.git' }
-    it { should have_run 'git push --quiet "https://token@github.com/travis-ci/dpl.git" "gh-pages":"gh-pages" > /dev/null 2>&1' }
+    it { should have_run 'git push --quiet "https://token@github.com/travis-ci/dpl.git" "gh-pages":"gh-pages"' }
     it { should have_run_in_order }
   end
 
@@ -45,12 +45,12 @@ describe Dpl::Providers::Pages do
   describe 'given --repo other/name' do
     it { should have_run 'git commit -q -m "Deploy travis-ci/dpl to github.com/other/name.git:gh-pages"' }
     it { should have_run '[info] Pushing to github.com/other/name.git' }
-    it { should have_run 'git push --quiet "https://token@github.com/other/name.git" "gh-pages":"gh-pages" > /dev/null 2>&1' }
+    it { should have_run 'git push --quiet "https://token@github.com/other/name.git" "gh-pages":"gh-pages"' }
   end
 
   describe 'given --target_branch other' do
     it { should have_run 'git commit -q -m "Deploy travis-ci/dpl to github.com/travis-ci/dpl.git:other"' }
-    it { should have_run 'git push --quiet "https://token@github.com/travis-ci/dpl.git" "other":"other" > /dev/null 2>&1' }
+    it { should have_run 'git push --quiet "https://token@github.com/travis-ci/dpl.git" "other":"other"' }
   end
 
   describe 'given --no_keep_history' do
@@ -61,7 +61,7 @@ describe Dpl::Providers::Pages do
     it { should have_run 'git add -A .' }
     it { should have_run 'git commit -q -m "Deploy travis-ci/dpl to github.com/travis-ci/dpl.git:gh-pages"' }
     it { should have_run 'git show --stat-count=10 HEAD' }
-    it { should have_run 'git push --force --quiet "https://token@github.com/travis-ci/dpl.git" "gh-pages":"gh-pages" > /dev/null 2>&1' }
+    it { should have_run 'git push --force --quiet "https://token@github.com/travis-ci/dpl.git" "gh-pages":"gh-pages"' }
   end
 
   describe 'given --no_keep_history --allow_empty' do
@@ -111,7 +111,7 @@ describe Dpl::Providers::Pages do
     it { should have_run '[info] $ ssh -i ~/.dpl/deploy_key -T git@github.com 2>&1 | grep successful > /dev/null' }
     it { should have_run 'ssh -i ~/.dpl/deploy_key -T git@github.com 2>&1 | grep successful > /dev/null' }
     it { should have_run %r(cp .*lib/dpl/assets/git/detect_private_key .git/hooks/pre-commit) }
-    it { should have_run 'git push --quiet "git@github.com:travis-ci/dpl.git" "gh-pages":"gh-pages" > /dev/null 2>&1' }
+    it { should have_run 'git push --quiet "git@github.com:travis-ci/dpl.git" "gh-pages":"gh-pages"' }
     it { should have_run_in_order }
   end
 


### PR DESCRIPTION
### pages: Fix deploy key check on GHE

Remove a hardcoded github.com in the pages provider's deploy key validation check, which breaks deployment pipelines running against GitHub Enterprise.

### Force usage of selected identity when using SSH for git

This fixes usage of read-write deploy keys with the pages deploy_key option when the Travis default private key is only authorized for read-only access.

### pages: Show more information when pushing

This makes debugging broken deployments slightly easier, as error messages are no longer suppressed.

---

Signed-off-by: afzhou <afzhou@ibm.com>