### PR TITLE
Fixing Python installation, Google Cloud SDK

### DIFF
--- a/lib/dpl/providers/gcs.rb
+++ b/lib/dpl/providers/gcs.rb
@@ -33,7 +33,7 @@ module Dpl
       opt '--cache_control HEADER', 'HTTP header Cache-Control to suggest that the browser cache the file.', see: 'https://cloud.google.com/storage/docs/xml-api/reference-headers#cachecontrol'
       opt '--glob GLOB', default: '**/*'
 
-      cmds install:   'curl -L %{URL} | tar xz -C ~ && ~/google-cloud-sdk/install.sh --path-update false --usage-reporting false --command-completion false',
+      cmds install:   'curl -L %{URL} | tar xz -C ~ && ~/google-cloud-sdk/install.sh --quiet --path-update false --usage-reporting false --command-completion false',
            login_key: 'gcloud auth activate-service-account --key-file=%{key_file}',
            rsync:     'gsutil %{gs_opts} rsync %{rsync_opts} %{glob} %{target}',
            copy:      'gsutil %{gs_opts} cp %{copy_opts} -r %{source} %{target}'

--- a/spec/dpl/providers/gcs_spec.rb
+++ b/spec/dpl/providers/gcs_spec.rb
@@ -12,8 +12,8 @@ describe Dpl::Providers::Gcs do
     describe 'by default', record: true do
       it { should have_run 'mv /etc/boto.cfg /tmp/boto.cfg' }
       it { should have_run '[validate:runtime] python (>= 2.7.9)' }
-      it { should have_run '[info] $ curl -L https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz | tar xz -C ~ && ~/google-cloud-sdk/install.sh --path-update false --usage-reporting false --command-completion false' }
-      it { should have_run 'curl -L https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz | tar xz -C ~ && ~/google-cloud-sdk/install.sh --path-update false --usage-reporting false --command-completion false' }
+      it { should have_run '[info] $ curl -L https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz | tar xz -C ~ && ~/google-cloud-sdk/install.sh --quiet --path-update false --usage-reporting false --command-completion false' }
+      it { should have_run 'curl -L https://dl.google.com/dl/cloudsdk/channels/rapid/google-cloud-sdk.tar.gz | tar xz -C ~ && ~/google-cloud-sdk/install.sh --quiet --path-update false --usage-reporting false --command-completion false' }
       it { should have_run '[info] Authenticating with service account key file key.json' }
       it { should have_run '[info] $ gcloud auth activate-service-account --key-file=key.json' }
       it { should have_run 'gsutil cp -a "private" -r one gs://bucket/one' }


### PR DESCRIPTION
Google Cloud SDK installation hangs on macOS at the Python installation step, waiting for user input. 