### PR TITLE
Constrain faraday to 1.x for the Heroku provider

### DIFF
--- a/lib/dpl/providers/heroku.rb
+++ b/lib/dpl/providers/heroku.rb
@@ -5,7 +5,7 @@ module Dpl
 
       abstract
 
-      gem 'faraday', '~> 0.9.2'
+      gem 'faraday', ['~> 0.9.2','< 2.0.0']
       gem 'json'
       gem 'netrc', '~> 0.11.0'
       gem 'rendezvous', '~> 0.1.3'


### PR DESCRIPTION
Fixes #1247

Although this may not be necessary anymore because Faraday 2.0.1 reverted the change that made Faraday 2.0.0 not work:

https://github.com/lostisland/faraday/issues/1362#issuecomment-1006958547