### PR TITLE
convox: added manifest parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -987,6 +987,7 @@ Options:
   --generation NUM       type: integer, default: 2
   --prepare CMDS         Run commands with convox cli available just before deployment (type: array
                          (string, can be given multiple times))
+  --manifest STR         Manifest file to be used during deployment (type: string, default: convox.yml)
 
 Common Options:
 

--- a/lib/dpl/providers/convox.rb
+++ b/lib/dpl/providers/convox.rb
@@ -28,6 +28,7 @@ module Dpl
       opt '--description STR'
       opt '--generation NUM', type: :int, default: '2'
       opt '--prepare CMDS', 'Run commands with convox cli available just before deployment', type: :array
+      opt '--manifest STR', 'Manifest file to be used during deployment', default: 'convox.yml'
 
       # if app and rack are exported to the env, do they need to be passed to these commands?
       cmds login:    'convox version --rack %{rack}',
@@ -35,8 +36,8 @@ module Dpl
            create:   'convox apps create %{app} --generation %{generation} --rack %{rack} --wait',
            update:   'convox update',
            set_env:  'convox env set %{env} --rack %{rack} --app %{app} --replace',
-           build:    'convox build --rack %{rack} --app %{app} --id --description %{escaped_description}',
-           deploy:   'convox deploy --rack %{rack} --app %{app} --wait --id --description %{escaped_description}'
+           build:    'convox build --rack %{rack} --app %{app} --id --manifest %{manifest} --description %{escaped_description}',
+           deploy:   'convox deploy --rack %{rack} --app %{app} --wait --id --manifest %{manifest} --description %{escaped_description}'
 
       msgs create:   'Application %{app} does not exist on rack %{rack}. Creating it ...',
            missing:  'Application %{app} does not exist on rack %{rack}.',

--- a/spec/dpl/providers/convox_spec.rb
+++ b/spec/dpl/providers/convox_spec.rb
@@ -1,6 +1,7 @@
 describe Dpl::Providers::Convox do
   let(:args)   { |e| %w(--app app --rack rack --password pass) + args_from_description(e) }
   let(:exists) { true }
+  let(:manifest) { 'convox.yml' }
 
   let(:desc) do
     Shellwords.escape JSON.dump(
@@ -40,7 +41,7 @@ describe Dpl::Providers::Convox do
     it { should have_run '[info] $ convox apps info --rack rack --app app' }
     it { should have_run 'convox apps info --rack rack --app app' }
     it { should have_run '[info] Building and promoting application ...' }
-    it { should have_run "convox deploy --rack rack --app app --wait --id --description #{desc}" }
+    it { should have_run "convox deploy --rack rack --app app --wait --id --manifest #{manifest} --description #{desc}" }
     it { should have_run_in_order }
   end
 
@@ -62,7 +63,7 @@ describe Dpl::Providers::Convox do
   end
 
   describe 'given --no-promote' do
-    it { should have_run "convox build --rack rack --app app --id --description #{desc}" }
+    it { should have_run "convox build --rack rack --app app --id --manifest #{manifest} --description #{desc}" }
     it { should_not have_run /convox deploy/ }
   end
 
@@ -79,7 +80,7 @@ describe Dpl::Providers::Convox do
   end
 
   describe 'given --description other' do
-    it { should have_run 'convox deploy --rack rack --app app --wait --id --description other' }
+    it { should have_run "convox deploy --rack rack --app app --wait --id --manifest #{manifest} --description other" }
   end
 
   describe 'given --env ONE=$one --env TWO=two' do
@@ -106,6 +107,10 @@ describe Dpl::Providers::Convox do
 
   describe 'missing env file, given --env_file .env', run: false do
     it { expect { subject.run }.to raise_error 'The given env_file does not exist.' }
+  end
+
+  describe 'given --manifest custom-convox.yml' do
+    it { should have_run "convox deploy --rack rack --app app --wait --id --manifest custom-convox.yml --description #{desc}" }
   end
 
   describe 'with credentials in env vars', run: false do


### PR DESCRIPTION
Manifest parameter allows to change the default manifest file from `convox.yml` to any other.