### PR TITLE
fix: github pages token deployment

### DIFF
--- a/lib/dpl/providers/pages/git.rb
+++ b/lib/dpl/providers/pages/git.rb
@@ -155,7 +155,6 @@ module Dpl
         end
 
         def git_push
-          shell 'ssh-keygen -lv -f /home/travis/.dpl/deploy_key'
           shell :git_push
         end
 


### PR DESCRIPTION
Recent changes caused our builds to fail. The reason for that is removed line in this PR. This line was executed despite we were using token authentication instead of deploy keys. In our case this deploy key did not exist and caused this command to fail which was crashing the whole build.

If output of this command is needed then it should be guarded by some "if deploy_key is set/used" flag. A quick fix is just to remove this, actually a debug, line.