### PR TITLE
convox: changed convox CLI url

### DIFF
--- a/lib/dpl/providers/convox.rb
+++ b/lib/dpl/providers/convox.rb
@@ -18,7 +18,7 @@ module Dpl
       opt '--app APP', required: true
       opt '--rack RACK', required: true
       opt '--password PASS', required: true
-      opt '--install_url URL', default: 'https://convox.com/cli/linux/convox'
+      opt '--install_url URL', default: 'https://convox.s3.amazonaws.com/cli/linux/convox'
       opt '--update_cli'
       opt '--create'
       opt '--promote', default: true

--- a/spec/dpl/providers/convox_spec.rb
+++ b/spec/dpl/providers/convox_spec.rb
@@ -33,7 +33,7 @@ describe Dpl::Providers::Convox do
     it { should have_env CONVOX_RACK: 'rack' }
     it { should have_env CONVOX_CLI: 'convox' }
 
-    it { should have_run %r(curl -sL -o \$HOME/bin/convox https://convox.com/cli/linux/convox) }
+    it { should have_run %r(curl -sL -o \$HOME/bin/convox https://convox.s3.amazonaws.com/cli/linux/convox) }
     it { should have_run '[info] $ convox version --rack rack' }
     it { should have_run 'convox version --rack rack' }
     it { should have_run '[info] Setting the build environment up for the deployment' }


### PR DESCRIPTION
Convox has changed it's official URL for CLI downloads.

Official url is: http://download.convox.com/cli/linux/convox - though it lacks SSL yet, thus the best way is to use S3 hosting for now. 

This commit is required for convox dpl to start working again.